### PR TITLE
Implement frog final position, responsive layout, auth tabs, Supabase and API

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -35,7 +35,7 @@
           <input id="loginPass" type="password" placeholder="••••••••" minlength="4" required>
         </label>
         <button type="submit" class="btn primary">Войти</button>
-        <div id="loginError" class="error" role="status" aria-live="polite"></div>
+        <p id="loginError" class="error" role="status" aria-live="polite"></p>
         <p class="hint">Нет аккаунта? Перейдите на вкладку «Регистрация».</p>
       </form>
 
@@ -54,7 +54,7 @@
           <input id="regPass2" type="password" placeholder="повторите пароль" minlength="4" required>
         </label>
         <button type="submit" class="btn primary">Зарегистрироваться</button>
-        <div id="regError" class="error" role="status" aria-live="polite"></div>
+        <p id="regError" class="error" role="status" aria-live="polite"></p>
       </form>
     </div>
   </div>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -133,11 +133,14 @@ body.scene-intro .wrap, body.scene-final .wrap{grid-template-rows:100vh 0}
 /* ФИНАЛ: две колонки */
 .final-layout{
   position:absolute; inset:0;
-  display:flex; align-items:center; gap:26px;
+  display:none;
+  align-items:center;
+  gap:26px;
   padding:0 6vw;
   pointer-events:none;
   z-index:5;
 }
+body.scene-final .final-layout{display:flex;}
 .final-left{flex:1; min-height:64vh; min-width:0}
 .final-right{width:min(780px, 48vw); display:flex; justify-content:flex-end; min-width:0}
 .final-card{
@@ -224,6 +227,7 @@ body.scene-pond .speech, body.scene-final .speech{display:none}
 body.scene-intro .speech{display:block}
 
 @media (max-width:960px){
+  .final-layout{flex-direction:column}
   .final-left{display:none}
   .final-right{width:100%}
   body.scene-final .big-clock{left:50%; top:14%}
@@ -232,13 +236,6 @@ body.scene-intro .speech{display:block}
   .final-main .meta{grid-template-columns:1fr}
 }
 @media (max-width:760px){ .row2{grid-template-columns:1fr} }
-/* Финальная карточка показывается только на сцене final */
-.final-layout{ display:none; }                 /* по умолчанию скрыта */
-body.scene-final .final-layout{ display:flex; }/* в финале — видна как flex-контейнер */
-
-/* На всякий случай: на интро/пруду принудительно скрыть */
-body.scene-intro .final-layout,
-body.scene-pond  .final-layout{ display:none !important; }
 
 @media (max-width:640px){
   body{font-size:clamp(14px,4vw,16px)}

--- a/api/event-by-code.js
+++ b/api/event-by-code.js
@@ -1,0 +1,27 @@
+const { Pool } = require('pg');
+const pool = new Pool({
+  connectionString: process.env.SUPABASE_DB_URL,
+  ssl: { rejectUnauthorized: false }
+});
+
+module.exports = async (req, res) => {
+  try {
+    if (req.method !== 'GET') return send(res, 405, { error: 'method_not_allowed' });
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const code = url.searchParams.get('code');
+    const ev = await pool.query(
+      'SELECT id,title,date,time,address,dress,bring,notes,code FROM events WHERE code=$1',
+      [code]
+    );
+    if (ev.rowCount === 0) return send(res, 404, { error: 'not_found' });
+    send(res, 200, ev.rows[0]);
+  } catch (err) {
+    send(res, 500, { error: err.message });
+  }
+};
+
+function send(res, status, body){
+  res.statusCode = status;
+  res.setHeader('Content-Type','application/json');
+  res.end(JSON.stringify(body));
+}

--- a/api/join-by-code.js
+++ b/api/join-by-code.js
@@ -1,0 +1,40 @@
+const { Pool } = require('pg');
+const pool = new Pool({
+  connectionString: process.env.SUPABASE_DB_URL,
+  ssl: { rejectUnauthorized: false }
+});
+
+module.exports = async (req, res) => {
+  try {
+    if (req.method !== 'POST') return send(res, 405, { error: 'method_not_allowed' });
+    const body = await readBody(req);
+    const { code, name, user_id } = body || {};
+    if (!code || !name || !user_id) return send(res, 400, { error: 'bad_request' });
+    const ev = await pool.query('SELECT id FROM events WHERE code = $1', [code]);
+    if (ev.rowCount === 0) return send(res, 404, { error: 'not_found' });
+    const eventId = ev.rows[0].id;
+    await pool.query(
+      'INSERT INTO guests(event_id,user_id,name) VALUES($1,$2,$3) ON CONFLICT (event_id,name) DO UPDATE SET user_id=EXCLUDED.user_id',
+      [eventId, user_id, name]
+    );
+    send(res, 200, { event_id: eventId });
+  } catch (err) {
+    send(res, 500, { error: err.message });
+  }
+};
+
+function send(res, status, body){
+  res.statusCode = status;
+  res.setHeader('Content-Type','application/json');
+  res.end(JSON.stringify(body));
+}
+
+function readBody(req){
+  return new Promise((resolve, reject)=>{
+    let data='';
+    req.on('data', c => (data += c));
+    req.on('end', ()=>{
+      try{ resolve(JSON.parse(data || '{}')); }catch(e){ reject(e); }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- keep frog centered on stump during final scene and on resize
- overhaul final scene layout for responsive two-column design
- add tabbed login/registration with Supabase-based auth
- introduce serverless join-by-code and event-by-code endpoints and integrate client

## Testing
- `node --check FroggyHub/app.js`
- `node --check api/join-by-code.js`
- `node --check api/event-by-code.js`
- `curl -X POST http://localhost:8888/api/join-by-code -H "content-type: application/json" -d '{"code":"123456","name":"Alex","user_id":"00000000-0000-0000-0000-000000000000"}'` *(fails: Couldn't connect to server)*
- `curl "http://localhost:8888/api/event-by-code?code=123456"` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_689ea7d052748332a848c9a39e748268