### PR TITLE
Verify Supabase auth tokens and add security headers

### DIFF
--- a/FroggyHub/_headers
+++ b/FroggyHub/_headers
@@ -1,0 +1,7 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+  Content-Security-Policy: default-src 'self' https:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https:; script-src 'self' 'unsafe-inline' https:
+

--- a/api/event-by-code.js
+++ b/api/event-by-code.js
@@ -5,11 +5,28 @@ const pool = new Pool({
   ssl: { rejectUnauthorized: false }
 });
 
+async function getUserFromAuth(event) {
+  const auth = event.headers.authorization || "";
+  const token = auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  if (!token) throw new Error("Missing Authorization");
+
+  const res = await fetch(`${process.env.SUPABASE_URL}/auth/v1/user`, {
+    headers: {
+      apikey: process.env.SUPABASE_SERVICE_KEY,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) throw new Error("Auth validation failed");
+  const user = await res.json();
+  return user;
+}
+
 export async function handler(event) {
   try {
     if (event.httpMethod !== 'GET') {
       return { statusCode: 405, body: 'Method Not Allowed' };
     }
+    await getUserFromAuth(event);
     const code = (event.queryStringParameters?.code || '').trim();
     if (!/^\d{6}$/.test(code)) return { statusCode: 400, body: 'Invalid code' };
 

--- a/api/join-by-code.js
+++ b/api/join-by-code.js
@@ -5,15 +5,33 @@ const pool = new Pool({
   ssl: { rejectUnauthorized: false }
 });
 
+async function getUserFromAuth(event) {
+  const auth = event.headers.authorization || "";
+  const token = auth.startsWith("Bearer ") ? auth.slice(7) : null;
+  if (!token) throw new Error("Missing Authorization");
+
+  const res = await fetch(`${process.env.SUPABASE_URL}/auth/v1/user`, {
+    headers: {
+      apikey: process.env.SUPABASE_SERVICE_KEY,
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) throw new Error("Auth validation failed");
+  const user = await res.json();
+  return user;
+}
+
 export async function handler(event) {
   try {
     if (event.httpMethod !== 'POST') {
       return { statusCode: 405, body: 'Method Not Allowed' };
     }
-    const { code, name, user_id } = JSON.parse(event.body || '{}');
-    if (!code || !name || !user_id) {
-      return { statusCode: 400, body: 'code, name, user_id are required' };
+    const { code, name } = JSON.parse(event.body || '{}');
+    if (!code || !name) {
+      return { statusCode: 400, body: 'code and name are required' };
     }
+
+    const user = await getUserFromAuth(event);
 
     const client = await pool.connect();
     try {
@@ -26,7 +44,7 @@ export async function handler(event) {
          values ($1, $2, $3)
          on conflict (event_id, name)
          do update set user_id = excluded.user_id`,
-        [event_id, user_id, name]
+        [event_id, user.id, name]
       );
 
       return { statusCode: 200, body: JSON.stringify({ event_id }) };


### PR DESCRIPTION
## Summary
- validate Supabase JWTs in Netlify functions and use verified user IDs
- require auth when fetching events by code
- set basic security headers for static assets

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689eb2147f948332861e3f7fdd6d5515