### PR TITLE
Add smoke test script and early API validation

### DIFF
--- a/api/event-by-code.js
+++ b/api/event-by-code.js
@@ -6,7 +6,7 @@ const pool = new Pool({
 });
 
 async function getUserFromAuth(event) {
-  const auth = event.headers.authorization || "";
+  const auth = event.headers?.authorization || "";
   const token = auth.startsWith("Bearer ") ? auth.slice(7) : null;
   if (!token) throw new Error("Missing Authorization");
 
@@ -26,9 +26,9 @@ export async function handler(event) {
     if (event.httpMethod !== 'GET') {
       return { statusCode: 405, body: 'Method Not Allowed' };
     }
-    await getUserFromAuth(event);
     const code = (event.queryStringParameters?.code || '').trim();
     if (!/^\d{6}$/.test(code)) return { statusCode: 400, body: 'Invalid code' };
+    await getUserFromAuth(event);
 
     const { rows } = await pool.query(
       `select id, title, date, time, address, dress, bring, notes, code

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "scripts": {
     "dev": "netlify dev",
-    "serve:functions": "netlify functions:serve"
+    "serve:functions": "netlify functions:serve",
+    "test": "npm run test:syntax && node tools/smoke.mjs",
+    "test:syntax": "node --check FroggyHub/app.js && node --check api/join-by-code.js && node --check api/event-by-code.js"
   },
   "dependencies": {
     "pg": "^8.11.3"

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -1,0 +1,67 @@
+// Lightweight CI smoke tests (no DB needed)
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const PUBLISH_DIR = 'FroggyHub';
+let fails = 0;
+const log = (ok, msg) => console[ok ? 'log' : 'error']((ok ? '✅' : '❌') + ' ' + msg);
+const ok  = (m) => log(true, m);
+const fail= (m) => { log(false, m); fails++; };
+
+// 1) Files exist
+[
+  path.join(PUBLISH_DIR, 'index.html'),
+  path.join(PUBLISH_DIR, '_redirects'),
+  'api/event-by-code.js',
+  'api/join-by-code.js',
+  'netlify.toml'
+].forEach(p => fs.existsSync(p) ? ok(`found ${p}`) : fail(`missing ${p}`));
+
+// 2) No DSN secrets in client files
+const clientFiles = [
+  path.join(PUBLISH_DIR, 'index.html'),
+  path.join(PUBLISH_DIR, 'app.js'),
+  path.join(PUBLISH_DIR, 'style.css')
+].filter(f => fs.existsSync(f));
+
+const badPatterns = [/postgresql:\/\//i, /SUPABASE_DB_URL/i, /service_role/i];
+for (const f of clientFiles) {
+  const txt = fs.readFileSync(f, 'utf8');
+  const hit = badPatterns.find(rx => rx.test(txt));
+  hit ? fail(`secret-like pattern in ${f}: ${hit}`) : ok(`no secrets in ${f}`);
+}
+
+// 3) Import functions and test early guards (no DB call)
+const imp = async (p) => (await import(pathToFileURL(path.resolve(p)).href));
+
+const testEventByCode = async () => {
+  const { handler } = await imp('api/event-by-code.js');
+  if (typeof handler !== 'function') return fail('event-by-code: no handler export');
+
+  const r1 = await handler({ httpMethod: 'POST', queryStringParameters: {} });
+  (r1.statusCode === 405) ? ok('event-by-code: 405 on POST') : fail('event-by-code: expected 405 on POST');
+
+  const r2 = await handler({ httpMethod: 'GET', queryStringParameters: { code: 'abc' } });
+  (r2.statusCode === 400) ? ok('event-by-code: 400 on bad code') : fail('event-by-code: expected 400 on bad code');
+};
+
+const testJoinByCode = async () => {
+  const { handler } = await imp('api/join-by-code.js');
+  if (typeof handler !== 'function') return fail('join-by-code: no handler export');
+
+  const r1 = await handler({ httpMethod: 'GET' });
+  (r1.statusCode === 405) ? ok('join-by-code: 405 on GET') : fail('join-by-code: expected 405 on GET');
+
+  const r2 = await handler({ httpMethod: 'POST', body: JSON.stringify({}) });
+  (r2.statusCode === 400) ? ok('join-by-code: 400 on missing body') : fail('join-by-code: expected 400 on missing body');
+};
+
+await testEventByCode();
+await testJoinByCode();
+
+if (fails) {
+  console.error(`\n${fails} check(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll smoke checks passed');


### PR DESCRIPTION
## Summary
- add npm test script with syntax checks and smoke tests
- ensure event-by-code handler validates code before auth check
- include lightweight CI smoke tests for required files and secrets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689eb3de57348332ac03ccb87d38f890