### PR TITLE
Fix mobile breakpoints and wishlist layout

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -258,6 +258,28 @@ const bigClock = $('#bigClock'), bigClockHM = $('#bigClockHM'), bigClockDays = $
 const finalLayout = $('#finalLayout');
 const slidesEl = $('#slides');
 const stumpImg = document.getElementById('stumpImg');
+
+// Фикс для мобильных: держим мобильную раскладку при открытой клавиатуре
+function installMobileLock(){
+  const vv = window.visualViewport;
+  const isCoarse = matchMedia('(pointer: coarse)').matches;
+
+  const update = () => {
+    let kbOpen = false;
+    if (vv) {
+      // если высота визуального вьюпорта сильно меньше window.innerHeight → открыта клавиатура
+      kbOpen = (window.innerHeight - vv.height) > 120;
+    }
+    document.body.classList.toggle('force-mobile', kbOpen || isCoarse);
+  };
+
+  update();
+  window.addEventListener('resize', update);
+  vv?.addEventListener('resize', update);
+  document.addEventListener('focusin', update);
+  document.addEventListener('focusout', update);
+}
+installMobileLock();
 stumpImg?.addEventListener('load',()=>{
   if(document.body.classList.contains('scene-final')) placeFrogOnStump();
 });
@@ -279,15 +301,20 @@ function setScene(scene){
 window.addEventListener('resize', () => {
   if (document.body.classList.contains('scene-final')) placeFrogOnStump();
 });
+window.visualViewport?.addEventListener('resize', () => {
+  if (document.body.classList.contains('scene-final')) placeFrogOnStump();
+});
 
 /* Лягушка на пне */
 function placeFrogOnStump(){
-  const stump = $('#stumpImg'); const frog = $('#frog');
+  const stump = document.querySelector('#stumpImg');
+  const frog  = document.querySelector('#frog');
   if(!stump || !frog) return;
   const r = stump.getBoundingClientRect();
-  const top  = r.top  + window.scrollY + r.height * 0.58; // чуть ниже центра текстуры
+  const top  = r.top  + window.scrollY + r.height * 0.58;
   const left = r.left + window.scrollX + r.width  * 0.50;
-  frog.style.top = `${top}px`; frog.style.left = `${left}px`;
+  frog.style.top = `${top}px`;
+  frog.style.left = `${left}px`;
 }
 
 const stepToPad = {

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -2,7 +2,8 @@
 <html lang="ru">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <title>FroggyHub — события и вишлисты</title>
   <link rel="stylesheet" href="style.css">
 </head>
@@ -246,7 +247,7 @@
         <!-- ПРИСОЕДИНИТЬСЯ: вишлист гостя -->
         <section id="slide-join-wishlist" hidden>
           <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Выберите один пункт.</div></div>
-          <div id="guestGifts" class="grid" style="gap:10px"></div>
+          <div id="guestGifts" class="wishlist-grid"></div>
           <div class="bar-actions">
             <button class="btn ghost" id="skipWishlist">Пропустить</button>
             <button class="btn" id="toGuestFinal">Готово</button>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -43,12 +43,14 @@ body{
 
 .grid{display:grid;gap:14px}
 .row2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
-label{display:grid;gap:6px}
-input,textarea{
-  padding:12px 14px;border-radius:14px;
-  border:1px solid var(--input-border);
-  background:var(--input-bg); color:var(--text);
-}
+  label{display:grid;gap:6px}
+  input,textarea{
+    padding:12px 14px;border-radius:14px;
+    border:1px solid var(--input-border);
+    background:var(--input-bg); color:var(--text);
+  }
+/* Всегда 16px+ на инпутах, чтобы мобильный браузер не зумил */
+input, textarea, select { font-size: 16px; }
 
 .btn{
   display:inline-flex;align-items:center;justify-content:center;
@@ -70,7 +72,8 @@ input,textarea{
 }
 
 .hint{color:var(--muted);font-size:.92rem}
-.hero{display:flex;gap:16px;align-items:center;margin-bottom:10px}
+ .hero{display:flex;gap:16px;align-items:center;margin-bottom:10px}
+ .hero, .header-pond { position: relative; overflow: hidden; }
 .avatar{width:64px;height:64px;border-radius:50%;display:grid;place-items:center;font-size:28px;background:var(--accent)}
 .hero-text h1{margin:0 0 6px}
 .chips{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
@@ -111,6 +114,9 @@ body.scene-intro .wrap, body.scene-final .wrap{grid-template-rows:100vh 0}
 #stumpImg{display:none;position:relative;width:min(420px,70vw);height:auto;margin:0 auto;}
 #frog{position:absolute;left:50%;top:42%;transform:translate(-50%,-50%);transition:left .45s ease,top .45s ease,transform .2s ease;z-index:3}
 #frog img{width:100%;height:auto;display:block}
+/* Шапка с иллюстрациями: не даём им вылезать и менять ширину контейнера */
+.frog-hero, #frog { max-width: clamp(140px, 45vw, 360px); height: auto; }
+.lilypads img { max-width: 22vw; height: auto; }
 #frog.jump{animation:jump .55s ease}
 @keyframes jump{0%{transform:translate(-50%,-50%)}35%{transform:translate(-50%,-85%)}100%{transform:translate(-50%,-50%)} }
 body.scene-final #stumpImg{display:block}
@@ -127,6 +133,10 @@ body.scene-final #frog{width:min(140px,20vw);transform:translate(-50%,-78%);will
 #finalLayout{ display:flex; align-items:flex-start; gap:32px; }
 #finalLeft{ flex:1 1 50%; min-width:320px; position:relative; }
 #finalRight{ flex:1 1 50%; min-width:320px; }
+/* Лок для layout, когда открыта клавиатура или устройство с coarse pointer */
+body.force-mobile #finalLayout { flex-direction: column; align-items: stretch; gap: 18px; }
+body.force-mobile #finalLeft { order: 0; text-align: center; }
+body.force-mobile #finalRight { order: 1; width: 100%; }
 
 /* правая карточка поверх фона */
 .final-card{
@@ -138,8 +148,11 @@ body.scene-final #frog{width:min(140px,20vw);transform:translate(-50%,-78%);will
   border-radius:22px;
   box-shadow:0 20px 60px rgba(0,0,0,.45);
   padding:18px 18px 22px;
-  backdrop-filter:blur(4px) saturate(120%);
-}
+    backdrop-filter:blur(4px) saturate(120%);
+  }
+/* Итоговый экран: уже были стили – добавь страховку при принудительной мобиле */
+body.force-mobile #bigClock { margin-bottom: 12px; }
+body.force-mobile .final-card { padding: 14px; border-radius: 14px; }
 .final-card *, .form-row *{ min-width:0; }
 
 .final-header{display:grid; gap:8px; margin-bottom:10px}
@@ -155,9 +168,9 @@ body.scene-final #frog{width:min(140px,20vw);transform:translate(-50%,-78%);will
 .final-main .meta{display:grid; grid-template-columns:1fr 1fr; gap:12px}
 .meta-item{background:#113424;border:1px solid #2a7c56;border-radius:12px;padding:10px}
 
-.wl-block{display:grid; gap:10px}
-.wl-head{display:flex; align-items:center; justify-content:space-between}
-.wl-scroll{display:grid; grid-auto-flow:column; grid-auto-columns:minmax(140px,1fr); gap:12px; overflow:auto; padding-bottom:4px}
+  .wl-block{display:grid; gap:10px}
+  .wl-head{display:flex; align-items:center; justify-content:space-between}
+  .wl-scroll{display:grid; grid-auto-flow:column; grid-auto-columns:minmax(140px,1fr); gap:12px; overflow:auto; padding-bottom:4px}
 .wl-tile{
   background:#143d2a; border:1px solid #2a7c56; border-radius:16px;
   padding:10px; display:grid; gap:8px
@@ -167,8 +180,8 @@ body.scene-final #frog{width:min(140px,20vw);transform:translate(-50%,-78%);will
 .wl-tile.taken{filter:saturate(.85) brightness(.95)}
 .wl-tile.taken .tag{opacity:1}
 
-.dashboard{display:grid; grid-template-columns:1fr 1fr; gap:12px}
-.db-card{
+  .dashboard{display:grid; grid-template-columns:1fr 1fr; gap:12px}
+  .db-card{
   background:#113424;border:1px solid #2a7c56;border-radius:14px;
   padding:12px
 }
@@ -194,9 +207,21 @@ body.scene-final #frog{width:min(140px,20vw);transform:translate(-50%,-78%);will
 .cell .action{position:absolute;bottom:8px;left:8px;right:8px;display:flex;justify-content:center}
 .cell a{display:inline-block;padding:6px 10px;border-radius:12px;background:#113424;border:1px solid #2a7c56;color:#c7f5d8;text-decoration:none;font-weight:700;font-size:.82rem}
 
-.list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-.list li{background:#113424;border:1px solid #2a7c56;border-radius:12px;padding:10px 12px}
-.code-box{font-size:2rem;font-weight:900;background:#143d2a;border:1px solid #2a7c56;display:inline-block;padding:10px 18px;border-radius:12px;margin-top:8px}
+  .list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+  .list li{background:#113424;border:1px solid #2a7c56;border-radius:12px;padding:10px 12px}
+  .code-box{font-size:2rem;font-weight:900;background:#143d2a;border:1px solid #2a7c56;display:inline-block;padding:10px 18px;border-radius:12px;margin-top:8px}
+/* Грид вишлиста — резиновый без перепрыгиваний */
+.wishlist-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+@media (max-width: 480px){
+  .wishlist-grid { grid-template-columns: repeat(2, 1fr); gap: 10px; }
+}
+
+/* На время фокуса поля не меняют метрики карточек (боремся с reflow) */
+.form-row, .final-card { contain: layout paint; }
 
 .btn-group{display:flex;gap:10px;flex-wrap:wrap}
 .bar-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:10px}


### PR DESCRIPTION
## Summary
- prevent mobile auto-zoom and stabilize layout
- clamp frog and lilypad assets and add responsive wishlist grid
- lock mobile layout while keyboard open and reposition frog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed5ceab088332a82ac697a3d8eb48