### PR TITLE
feat: add event analytics screen

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Аналитика события</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="container" role="main">
+    <div class="card" id="eventHead">
+      <div class="hero">
+        <div class="hero-text">
+          <h1 id="eventTitle">Событие</h1>
+          <div class="chips">
+            <span class="chip" id="eventDate">—</span>
+            <span class="chip" id="eventTime">—</span>
+            <span class="chip" id="eventAddr">—</span>
+          </div>
+        </div>
+      </div>
+      <div class="bar-actions">
+        <button class="btn ghost small" id="backBtn" aria-label="Назад в меню">Назад</button>
+        <button class="btn small" id="editEventBtn" aria-label="Редактировать событие">Редактировать событие</button>
+      </div>
+    </div>
+
+    <section class="card" id="visitorsBlock" aria-labelledby="visitorsTitle">
+      <h2 id="visitorsTitle">Посетители</h2>
+      <ul id="visitorsList" class="ea-list" role="list" aria-describedby="visitorsHint"></ul>
+      <p id="visitorsHint" class="hint">Сортировка по статусу участия</p>
+    </section>
+
+    <section class="card" id="wishlistBlock" aria-labelledby="wishlistTitle">
+      <h2 id="wishlistTitle">Wishlist</h2>
+      <ul id="wishlistList" class="wl-list" role="list"></ul>
+    </section>
+
+    <p id="error" class="error" role="status" aria-live="polite"></p>
+  </main>
+  <script type="module" src="event-analytics.js"></script>
+</body>
+</html>

--- a/FroggyHub/event-analytics.js
+++ b/FroggyHub/event-analytics.js
@@ -1,0 +1,75 @@
+const backBtn = document.getElementById('backBtn');
+const editBtn = document.getElementById('editEventBtn');
+const titleEl = document.getElementById('eventTitle');
+const dateEl = document.getElementById('eventDate');
+const timeEl = document.getElementById('eventTime');
+const addrEl = document.getElementById('eventAddr');
+const visitorsList = document.getElementById('visitorsList');
+const wishlistList = document.getElementById('wishlistList');
+const errorEl = document.getElementById('error');
+
+const params = new URLSearchParams(location.search);
+const eventId = params.get('id');
+
+backBtn?.addEventListener('click', () => {
+  window.location.href = 'index.html';
+});
+
+editBtn?.addEventListener('click', () => {
+  if (eventId) window.location.href = `event-edit.html?id=${eventId}`;
+});
+
+function statusText(s){
+  switch(s){
+    case 'yes': return 'Иду';
+    case 'maybe': return 'Возможно';
+    case 'no':
+    default: return 'Не иду';
+  }
+}
+
+function renderVisitors(list){
+  const order = { yes:0, maybe:1, no:2 };
+  list.sort((a,b)=> (order[a.status]??3) - (order[b.status]??3));
+  visitorsList.innerHTML = list.map(v => `
+    <li class="ea-item" role="listitem">
+      <img class="ea-avatar" src="${v.avatar||'assets/stump.png'}" alt="Аватар ${v.nickname}">
+      <div class="ea-name">${v.nickname}</div>
+      <div class="ea-status">${statusText(v.status)}</div>
+    </li>`).join('');
+}
+
+function renderWishlist(items){
+  wishlistList.innerHTML = items.map(i => {
+    let claimed = '🟢 свободно';
+    if(i.claimedBy){
+      claimed = `<span class="claimed"><img class="wl-ava" src="${i.claimedBy.avatar}" alt="Аватар ${i.claimedBy.nickname}"><span>${i.claimedBy.nickname}</span></span>`;
+    }
+    return `<li class="wl-item" role="listitem">
+      <div class="wl-title">${i.title}</div>
+      <div class="wl-claimed">${claimed}</div>
+    </li>`;
+  }).join('');
+}
+
+async function load(){
+  if(!eventId){ errorEl.textContent = 'Не указан id события'; return; }
+  try{
+    const res = await fetch(`/.netlify/functions/get-event-analytics?id=${encodeURIComponent(eventId)}`, {
+      credentials: 'include'
+    });
+    if(!res.ok) throw new Error('Ошибка загрузки');
+    const data = await res.json();
+    const evt = data.event||{};
+    titleEl.textContent = evt.title || 'Событие';
+    dateEl.textContent = evt.date || '—';
+    timeEl.textContent = evt.time || '—';
+    addrEl.textContent = evt.address || '—';
+    renderVisitors(data.visitors||[]);
+    renderWishlist(data.wishlist||[]);
+  }catch(err){
+    errorEl.textContent = err.message;
+  }
+}
+
+load();

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -282,3 +282,18 @@ body.scene-intro .speech{display:block}
   input,textarea{min-width:0}
   .bar-actions,.btn-group{flex-direction:column}
 }
+/* === Analytics page === */
+.ea-list, .wl-list{list-style:none;margin:0;padding:0;}
+.ea-item{display:grid;grid-template-columns:64px 1fr 120px;align-items:center;gap:12px;padding:8px 0;border-bottom:1px solid var(--card-border);}
+.ea-avatar{width:48px;height:48px;border-radius:50%;object-fit:cover;}
+.ea-status{text-align:right;}
+.wl-item{display:grid;grid-template-columns:1fr 200px;align-items:center;gap:12px;padding:8px 0;border-bottom:1px solid var(--card-border);}
+.wl-claimed{display:flex;align-items:center;gap:8px;}
+.wl-ava{width:32px;height:32px;border-radius:50%;object-fit:cover;}
+@media (max-width:640px){
+  .ea-item{grid-template-columns:1fr;text-align:center;}
+  .ea-avatar{margin:0 auto;}
+  .ea-status{text-align:center;margin-top:4px;}
+  .wl-item{grid-template-columns:1fr;text-align:center;}
+  .wl-claimed{justify-content:center;margin-top:4px;}
+}

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "froggyhub",
   "private": true,
@@ -6,7 +7,7 @@
     "dev": "netlify dev",
     "serve:functions": "netlify functions:serve",
     "test": "npm run test:syntax && node tools/smoke.mjs",
-    "test:syntax": "node --check FroggyHub/app.js && node --check api/join-by-code.js && node --check api/event-by-code.js"
+    "test:syntax": "node --check FroggyHub/app.js && node --check api/join-by-code.js && node --check api/event-by-code.js && node --check FroggyHub/event-analytics.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.42.5"


### PR DESCRIPTION
## Summary
- add standalone event analytics page for owners with visitors and wishlist sections
- fetch analytics data and render responsive lists sorted by status
- include css for analytics screen and expand tests to check new script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ee9506f8c8332a3f7f16f5eda13cf