### PR TITLE
Add realtime analytics counters

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -27,12 +27,30 @@
 
     <section class="card" id="visitorsBlock" aria-labelledby="visitorsTitle">
       <h2 id="visitorsTitle">Посетители</h2>
+      <div class="stats">
+        <span class="badge yes" id="rsvpYesCount">0</span>
+        <span class="badge maybe" id="rsvpMaybeCount">0</span>
+        <span class="badge no" id="rsvpNoCount">0</span>
+      </div>
+      <div class="progress" id="rsvpProgress" aria-hidden="true">
+        <div class="yes" id="rsvpYesBar"></div>
+        <div class="maybe" id="rsvpMaybeBar"></div>
+        <div class="no" id="rsvpNoBar"></div>
+      </div>
       <ul id="visitorsList" class="ea-list" role="list" aria-describedby="visitorsHint"></ul>
       <p id="visitorsHint" class="hint">Статусы: 🟢 Иду, 🟡 Возможно, 🔴 Не иду</p>
     </section>
 
     <section class="card" id="wishlistBlock" aria-labelledby="wishlistTitle">
       <h2 id="wishlistTitle">Wishlist</h2>
+      <div class="stats">
+        <span class="badge free" id="giftFreeCount">0</span>
+        <span class="badge taken" id="giftTakenCount">0</span>
+      </div>
+      <div class="progress" id="giftProgress" aria-hidden="true">
+        <div class="free" id="giftFreeBar"></div>
+        <div class="taken" id="giftTakenBar"></div>
+      </div>
       <ul id="wishlistList" class="wl-list" role="list" aria-describedby="wishlistHint"></ul>
       <p id="wishlistHint" class="hint">🟢 свободно, 🔒 занято</p>
     </section>

--- a/FroggyHub/event-analytics.js
+++ b/FroggyHub/event-analytics.js
@@ -7,6 +7,16 @@ const addrEl = document.getElementById('eventAddr');
 const visitorsList = document.getElementById('visitorsList');
 const wishlistList = document.getElementById('wishlistList');
 const errorEl = document.getElementById('error');
+const rsvpYesCountEl = document.getElementById('rsvpYesCount');
+const rsvpMaybeCountEl = document.getElementById('rsvpMaybeCount');
+const rsvpNoCountEl = document.getElementById('rsvpNoCount');
+const rsvpYesBar = document.getElementById('rsvpYesBar');
+const rsvpMaybeBar = document.getElementById('rsvpMaybeBar');
+const rsvpNoBar = document.getElementById('rsvpNoBar');
+const giftFreeCountEl = document.getElementById('giftFreeCount');
+const giftTakenCountEl = document.getElementById('giftTakenCount');
+const giftFreeBar = document.getElementById('giftFreeBar');
+const giftTakenBar = document.getElementById('giftTakenBar');
 
 const params = new URLSearchParams(location.search);
 const eventId = params.get('id');
@@ -100,6 +110,7 @@ function setVisitors(list){
   visitors.clear(); visitorEls.clear();
   visitorsList.innerHTML = '';
   list.forEach(v => { visitors.set(v.id, v); insertVisitor(v); });
+  updateRsvpStats();
 }
 
 function wishlistHtml(i){
@@ -138,6 +149,33 @@ function setWishlist(items){
   wishlist.clear(); wishlistEls.clear();
   wishlistList.innerHTML = '';
   items.forEach(i => { wishlist.set(i.id, i); insertWishlist(i); });
+  updateGiftStats();
+}
+
+function updateRsvpStats(){
+  let yes = 0, maybe = 0, no = 0;
+  visitors.forEach(v => {
+    if(v.rsvp === 'yes') yes++;
+    else if(v.rsvp === 'maybe') maybe++;
+    else no++;
+  });
+  rsvpYesCountEl.textContent = yes;
+  rsvpMaybeCountEl.textContent = maybe;
+  rsvpNoCountEl.textContent = no;
+  const total = yes + maybe + no || 1;
+  rsvpYesBar.style.width = (yes/total*100) + '%';
+  rsvpMaybeBar.style.width = (maybe/total*100) + '%';
+  rsvpNoBar.style.width = (no/total*100) + '%';
+}
+
+function updateGiftStats(){
+  let free = 0, taken = 0;
+  wishlist.forEach(i => { if(i.taken_by) taken++; else free++; });
+  giftFreeCountEl.textContent = free;
+  giftTakenCountEl.textContent = taken;
+  const total = free + taken || 1;
+  giftFreeBar.style.width = (free/total*100) + '%';
+  giftTakenBar.style.width = (taken/total*100) + '%';
 }
 
 async function load(){
@@ -194,6 +232,7 @@ async function handleParticipantChange(payload){
     const id = payload.old?.user_id;
     visitors.delete(id);
     removeVisitor(id);
+    updateRsvpStats();
     return;
   }
   const p = payload.new;
@@ -212,6 +251,7 @@ async function handleParticipantChange(payload){
   };
   visitors.set(v.id, v);
   updateVisitor(v);
+  updateRsvpStats();
 }
 
 async function handleWishlistChange(payload){
@@ -220,6 +260,7 @@ async function handleWishlistChange(payload){
     const id = payload.old?.id;
     wishlist.delete(id);
     removeWishlist(id);
+    updateGiftStats();
     return;
   }
   const w = payload.new;
@@ -231,6 +272,7 @@ async function handleWishlistChange(payload){
   const item = { id:w.id, title:w.title, url:w.url, taken_by:taken };
   wishlist.set(item.id, item);
   updateWishlist(item);
+  updateGiftStats();
 }
 
 function subscribeRealtime(){

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -306,6 +306,20 @@ body.scene-intro .speech{display:block}
 .wl-free{color:#35c97f;}
 .wl-taken{color:#f0b429;}
 
+.stats{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:6px}
+.badge{display:inline-block;padding:4px 8px;border-radius:999px;font-weight:700;font-size:.85rem}
+.badge.yes,.badge.free{background:#35c97f;color:#0a1e14}
+.badge.maybe{background:#f0b429;color:#0a1e14}
+.badge.no{background:#ff6b6b;color:#0a1e14}
+.badge.taken{background:#f0b429;color:#0a1e14}
+.progress{height:8px;background:#133b25;border-radius:6px;overflow:hidden;display:flex;margin:4px 0 12px}
+.progress>div{height:100%}
+.progress .yes{background:#35c97f}
+.progress .maybe{background:#f0b429}
+.progress .no{background:#ff6b6b}
+.progress .free{background:#35c97f}
+.progress .taken{background:#f0b429}
+
 /* Event edit form */
 .edit-form .save-row{display:flex;justify-content:flex-end;}
 @media(max-width:600px){


### PR DESCRIPTION
## Summary
- show RSVP and wishlist counters with badges and progress bars
- recalc aggregates when realtime events arrive

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f77286b548332bc36f406d4486cd3