### PR TITLE
feat: optimistic updates for owner actions

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -57,6 +57,7 @@
 
     <p id="error" class="error" role="status" aria-live="polite"></p>
   </main>
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
   <script>
     window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";


### PR DESCRIPTION
## Summary
- implement optimistic edit of events with local state and rollback on error
- allow owners to toggle wishlist items with optimistic updates and realtime reconciliation
- add toast notifications for analytics page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f78d28ce88332b603c1d067b6bde5