### PR TITLE
feat: supabase proxy fallback and otp login

### DIFF
--- a/FroggyHub/_headers
+++ b/FroggyHub/_headers
@@ -4,3 +4,9 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
   Content-Security-Policy: default-src 'self' https:; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https:; script-src 'self' 'unsafe-inline' https:; connect-src 'self' https://*.supabase.co https://*.supabase.net wss://*.supabase.co wss://*.supabase.net;
+
+/supabase/*
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Headers: authorization, x-client-info, apikey, content-type
+  Access-Control-Allow-Methods: GET, POST, PATCH, PUT, DELETE, OPTIONS
+  Cache-Control: no-store

--- a/FroggyHub/_redirects
+++ b/FroggyHub/_redirects
@@ -1,1 +1,2 @@
+/supabase/* https://smamhlfzserjkdfhthwhdv.supabase.co/:splat 200
 /*   /index.html   200

--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -60,11 +60,12 @@
   <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
   <script>
     window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
+    window.PROXY_SUPABASE_URL = location.origin + '/supabase';
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
   </script>
   <script type="module">
     import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm";
-    window.supabase = createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY);
+    window.createSupabaseClient = createClient;
   </script>
   <script type="module" src="event-analytics.js"></script>
 </body>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -39,11 +39,12 @@
   </main>
   <script>
     window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
+    window.PROXY_SUPABASE_URL = location.origin + '/supabase';
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
   </script>
   <script type="module">
     import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm";
-    window.supabase = createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY);
+    window.createSupabaseClient = createClient;
   </script>
   <script type="module" src="app.js"></script>
 </body>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -36,7 +36,9 @@
           <input id="loginPass" type="password" placeholder="••••••••" minlength="4" required>
         </label>
         <button type="submit" class="btn primary">Войти</button>
+        <button type="button" class="btn" id="loginOtpBtn">Войти по ссылке на e‑mail</button>
         <p id="loginError" class="error" role="status" aria-live="polite"></p>
+        <p id="loginInfo" class="hint" hidden></p>
         <p class="hint">Нет аккаунта? Перейдите на вкладку «Регистрация».</p>
       </form>
 
@@ -261,14 +263,12 @@
   <script>
     // TODO: заполнить для проды через переменные окружения Netlify
     window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
+    window.PROXY_SUPABASE_URL = location.origin + '/supabase';
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
   </script>
   <script type="module">
     import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm";
-    window.supabase = createClient(
-      window.SUPABASE_URL,
-      window.SUPABASE_ANON_KEY
-    );
+    window.createSupabaseClient = createClient;
   </script>
   <div id="cookieBanner" role="dialog" aria-modal="true" hidden>
     <div class="cookie-text">

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ A simple banner is rendered at the bottom of the page asking the visitor to acce
 2. Run tests and lint: `npm test`.
 3. Start local development with Netlify: `npm run dev`.
 
+## Regional connectivity & proxy
+
+Some regions block direct access to `*.supabase.co`. The app can automatically fall back to a proxied endpoint.
+
+- `PROXY_SUPABASE_URL` points to `/supabase` which is proxied to the original project through Netlify `_redirects`.
+- On start the client performs a quick health probe to `SUPABASE_URL`. If it fails within 1500 ms, the client re‑initialises with the proxy URL and stores the choice in `sessionStorage`.
+- Auth, REST, Storage and Functions requests are proxied; Realtime can also be proxied through an optional edge function.
+- The proxy must not expose a `SERVICE_ROLE` key – only the anonymous key is used in the browser.
+- To disable the proxy, remove the fallback code and the `/supabase` rules when regional restrictions are not an issue.
+
 ## Testing checklist
 - Apply the SQL migrations.
 - Create users and profiles, create an event, join via code from another user.


### PR DESCRIPTION
## Summary
- add health-check based Supabase client init with proxy fallback and telemetry
- support login via email link and clearer auth errors
- clean up analytics subscriptions and Netlify proxy rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f81c5609483329c5d872fd0c4c2a8