### PR TITLE
Improve authentication forms with validation and proxy fallback

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -30,16 +30,18 @@
       <!-- ЛОГИН -->
       <form id="authFormLogin" class="grid" autocomplete="on" role="tabpanel" aria-labelledby="tabLogin">
         <label>Почта
-          <input id="loginEmail" type="email" placeholder="you@email.com" required>
+          <input id="loginEmail" type="email" placeholder="you@email.com" required autocomplete="username" inputmode="email">
         </label>
         <label>Пароль
-          <input id="loginPass" type="password" placeholder="••••••••" minlength="4" required>
+          <input id="loginPass" type="password" placeholder="••••••••" minlength="4" required autocomplete="current-password">
         </label>
-        <button type="submit" class="btn primary">Войти</button>
+        <button type="button" class="btn primary" id="loginBtn">Войти</button>
         <button type="button" class="btn" id="loginOtpBtn">Войти по ссылке на e‑mail</button>
-        <p id="loginError" class="error" role="status" aria-live="polite"></p>
+        <div id="loginError" class="form-error" aria-live="polite"></div>
         <p id="loginInfo" class="hint" hidden></p>
+        <div id="loginAnnounce" class="visually-hidden" aria-live="assertive"></div>
         <p class="hint">Нет аккаунта? Перейдите на вкладку «Регистрация».</p>
+        <input type="submit" hidden>
       </form>
 
       <!-- РЕГИСТРАЦИЯ -->
@@ -48,16 +50,18 @@
           <input id="regName" type="text" placeholder="Как вас называть?" required>
         </label>
         <label>Почта
-          <input id="regEmail" type="email" placeholder="you@email.com" required>
+          <input id="regEmail" type="email" placeholder="you@email.com" required autocomplete="username" inputmode="email">
         </label>
         <label>Пароль
-          <input id="regPass" type="password" placeholder="минимум 4 символа" minlength="4" required>
+          <input id="regPass" type="password" placeholder="минимум 4 символа" minlength="4" required autocomplete="new-password">
         </label>
         <label>Повтор пароля
-          <input id="regPass2" type="password" placeholder="повторите пароль" minlength="4" required>
+          <input id="regPass2" type="password" placeholder="повторите пароль" minlength="4" required autocomplete="new-password">
         </label>
-        <button type="submit" class="btn primary">Зарегистрироваться</button>
-        <p id="regError" class="error" role="status" aria-live="polite"></p>
+        <button type="button" class="btn primary" id="regBtn">Зарегистрироваться</button>
+        <div id="regError" class="form-error" aria-live="polite"></div>
+        <div id="regAnnounce" class="visually-hidden" aria-live="assertive"></div>
+        <input type="submit" hidden>
       </form>
     </div>
   </div>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -19,6 +19,7 @@
   --shore:#173826;
   --soil:#0d2218;
   --shadow:0 10px 26px rgba(0,0,0,.5);
+  --danger:#ff6b6b;
 }
 
 *{box-sizing:border-box}
@@ -49,8 +50,22 @@ body{
     border:1px solid var(--input-border);
     background:var(--input-bg); color:var(--text);
   }
+  input.is-invalid, textarea.is-invalid{
+    border-color:var(--danger);
+    box-shadow:0 0 0 1px var(--danger);
+  }
+  input.is-invalid:focus-visible, textarea.is-invalid:focus-visible{
+    outline-color:var(--danger);
+  }
 /* Всегда 16px+ на инпутах, чтобы мобильный браузер не зумил */
 input, textarea, select { font-size: 16px; }
+
+.field-error{color:var(--danger);font-size:.88rem;margin-top:6px;}
+.form-error{color:var(--danger);font-size:.95rem;margin-top:8px;}
+
+@keyframes shake{0%{transform:translateX(0);}25%{transform:translateX(-4px);}75%{transform:translateX(4px);}100%{transform:translateX(0);}}
+.shake{animation:shake .15s linear;}
+@media (prefers-reduced-motion: reduce){.shake{animation:none;}}
 
 .btn{
   display:inline-flex;align-items:center;justify-content:center;


### PR DESCRIPTION
## Summary
- add detailed auth error formatting and client-side validation
- enhance login and signup handlers with proxy fallback and button states
- style and expose field-level form errors for accessible feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f8c99c6788332ba9dfba3c05b4ed6