### PR TITLE
feat: enhance auth flows

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -37,11 +37,23 @@
         </label>
         <button type="button" class="btn primary" id="loginBtn">Войти</button>
         <button type="button" class="btn" id="loginOtpBtn">Войти по ссылке на e‑mail</button>
+        <button type="button" class="btn" id="resetPassBtn">Забыли пароль?</button>
         <div id="loginError" class="form-error" aria-live="polite"></div>
         <p id="loginInfo" class="hint" hidden></p>
         <div id="loginAnnounce" class="visually-hidden" aria-live="assertive"></div>
         <p class="hint">Нет аккаунта? Перейдите на вкладку «Регистрация».</p>
         <input type="submit" hidden>
+      </form>
+
+      <form id="newPassForm" class="grid" hidden>
+        <label>Новый пароль
+          <input id="newPass" type="password" minlength="4" required autocomplete="new-password">
+        </label>
+        <label>Повторите пароль
+          <input id="newPass2" type="password" minlength="4" required autocomplete="new-password">
+        </label>
+        <button type="button" class="btn primary" id="setNewPassBtn">Сменить пароль</button>
+        <div id="newPassError" class="form-error" aria-live="polite"></div>
       </form>
 
       <!-- РЕГИСТРАЦИЯ -->
@@ -61,6 +73,8 @@
         <button type="button" class="btn primary" id="regBtn">Зарегистрироваться</button>
         <div id="regError" class="form-error" aria-live="polite"></div>
         <div id="regAnnounce" class="visually-hidden" aria-live="assertive"></div>
+        <button type="button" class="btn" id="resendConfirmBtn" hidden>Переотправить письмо</button>
+        <p id="resendHint" class="hint" hidden>Ссылка действует 1 час</p>
         <input type="submit" hidden>
       </form>
     </div>
@@ -273,6 +287,19 @@
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
   <script defer src="app.js"></script>
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
+  <dialog id="otpModal">
+    <form method="dialog" class="grid">
+      <p>Войти по ссылке</p>
+      <label>Почта
+        <input id="otpEmail" type="email" required>
+      </label>
+      <div class="row2">
+        <button class="btn primary" id="otpSendBtn" type="button">Отправить ссылку</button>
+        <button class="btn" value="cancel">Отмена</button>
+      </div>
+      <p id="otpStatus" class="hint" aria-live="polite"></p>
+    </form>
+  </dialog>
     <div id="cookieBanner" role="dialog" aria-modal="true" hidden>
       <div class="cookie-text">
         <p>Мы используем cookies. Согласны?</p>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Профиль</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <main class="container" role="main">
+    <div class="card" style="max-width:480px;margin:40px auto">
+      <h1>Профиль</h1>
+      <form id="changePassForm" class="grid" aria-describedby="changePassError">
+        <label>Текущий пароль
+          <input id="currPass" type="password" required autocomplete="current-password">
+        </label>
+        <label>Новый пароль
+          <input id="newProfilePass" type="password" minlength="4" required autocomplete="new-password">
+        </label>
+        <label>Повторите новый пароль
+          <input id="newProfilePass2" type="password" minlength="4" required autocomplete="new-password">
+        </label>
+        <button type="button" class="btn primary" id="changePassBtn">Сменить пароль</button>
+        <div id="changePassError" class="form-error" aria-live="polite"></div>
+      </form>
+      <hr>
+      <button type="button" class="btn no" id="deleteAccountBtn">Удалить аккаунт</button>
+      <p class="hint">Удаление необратимо</p>
+    </div>
+  </main>
+  <dialog id="deleteConfirm">
+    <p>Точно удалить аккаунт? Это действие нельзя отменить.</p>
+    <div class="row2">
+      <button class="btn no" id="confirmDeleteBtn">Удалить</button>
+      <button class="btn" value="cancel">Отмена</button>
+    </div>
+  </dialog>
+  <script>
+    window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
+    window.PROXY_SUPABASE_URL = location.origin + '/supabase';
+    window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
+  </script>
+  <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
+  <script defer src="app.js"></script>
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+  <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -64,3 +64,8 @@ Some regions block direct access to `*.supabase.co`. The app can automatically f
 - Sign-up with email confirmation enabled shows a “Check your inbox” message; after confirming, the session is established.
 - Logging in via email link (OTP) creates a session without a password.
 - Reloading the page preserves the session (`persistSession=true`).
+- Reset password flow sends email and successfully updates the password.
+- Resend confirmation email works when the initial link expires.
+- `autoRefreshToken` keeps the session alive for over an hour during activity.
+- Throttling limits password attempts and falls back to OTP after repeated failures.
+- Logout clears session, temp data and proxy mode.

--- a/api/delete-account.js
+++ b/api/delete-account.js
@@ -1,0 +1,31 @@
+import { createClient } from '@supabase/supabase-js';
+import { json, getUserFromAuth } from './_utils.js';
+
+export async function handler(event){
+  if(event.httpMethod !== 'POST' && event.httpMethod !== 'DELETE'){
+    return json(405, { error: 'Method Not Allowed' });
+  }
+  try{
+    const user = await getUserFromAuth(event);
+    const client = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+    const uid = user.id;
+    await client.from('participants').delete().eq('user_id', uid);
+    await client.from('cookie_consents').delete().eq('user_id', uid);
+    await client.from('profiles').delete().eq('id', uid);
+    const res = await fetch(`${process.env.SUPABASE_URL}/auth/v1/admin/users/${uid}`, {
+      method: 'DELETE',
+      headers:{
+        Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+        apikey: process.env.SUPABASE_SERVICE_ROLE_KEY
+      }
+    });
+    if(!res.ok){ throw new Error('admin_delete_failed'); }
+    return json(200, { success: true });
+  }catch(err){
+    console.error('delete-account', err);
+    if(err.message === 'NO_TOKEN' || err.message === 'INVALID_TOKEN'){
+      return json(401, { error: 'unauthorized' });
+    }
+    return json(500, { error: 'server_error' });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "netlify dev",
     "serve:functions": "netlify functions:serve",
     "test": "npm run test:syntax && node tools/smoke.mjs",
-    "test:syntax": "node --check FroggyHub/app.js && node --check api/join-by-code.js && node --check api/event-by-code.js && node --check FroggyHub/event-analytics.js && node --check api/get-event-analytics.js && node --check api/update-event.js && node --check api/get-event-details.js"
+    "test:syntax": "node --check FroggyHub/app.js && node --check api/join-by-code.js && node --check api/event-by-code.js && node --check FroggyHub/event-analytics.js && node --check api/get-event-analytics.js && node --check api/update-event.js && node --check api/get-event-details.js && node --check api/delete-account.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.42.5"


### PR DESCRIPTION
## Summary
- add password reset and confirmation resend support
- throttle login attempts with OTP fallback and auto-refresh recovery
- implement profile password change and account deletion API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fab2b724083329a11cb2ad6205662