### PR TITLE
Harden auth buttons and add debug overlay

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -10,7 +10,7 @@
 <body class="scene-intro">
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <div id="screen-auth" class="container" role="main">
-    <div class="card" style="max-width:620px;margin:40px auto">
+    <div class="card" id="authPanel" style="max-width:620px;margin:40px auto">
       <div class="hero">
         <div class="avatar frog-ava">🐸</div>
         <div class="hero-text">

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -99,6 +99,8 @@ input, textarea, select { font-size: 16px; }
 .tab.active{background:var(--accent);color:#0a1e14;font-weight:700}
 #paneLogin,#paneSignup,#paneReset{max-width:420px;margin:0 auto;}
 section[hidden]{display:none !important;}
+#authPanel{position:relative;z-index:15;}
+.auth-debug{font-size:.75rem;opacity:.7;margin-bottom:4px;}
 
 /* Пруд и сцены */
 .wrap{display:grid;grid-template-rows:48vh auto;min-height:100vh;transition:opacity .45s ease}

--- a/README.md
+++ b/README.md
@@ -80,3 +80,11 @@ Some regions block direct access to `*.supabase.co`. The app can automatically f
 - Registration with confirmation **ON** shows the “Check your inbox” screen and a “Resend” button without hanging.
 - Mobile users in restricted regions hit a timeout first, switch to the proxy and complete registration or email delivery.
 - Cancelling during “Регистрируем…” returns the UI to idle state.
+
+## Быстрый чек авторизации
+
+- Переключение «Регистрация» → кнопка кликается, активируется только при валидных полях.
+- Логин: при неверном пароле — кнопка возвращается из «Входим…».
+- Таймаут сети → кнопка не зависает, срабатывает прокси‑ретрай один раз.
+- Баннер cookies скрыт → форма кликабельна.
+- На мобиле вкладки меняются, всё кликается.


### PR DESCRIPTION
## Summary
- add DEBUG_AUTH status line over auth buttons with overlay detection
- guard login/signup with single pending flag and proxy retry
- document manual auth checks and raise auth panel z-index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fc80d79b48332b5df2e972d21a972