### PR TITLE
Add Netlify auth functions and API client

### DIFF
--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -1,0 +1,69 @@
+import type { Handler } from '@netlify/functions'
+import { Client } from 'pg'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+
+function cors(extra: Record<string,string> = {}) {
+  return {
+    'Access-Control-Allow-Origin': 'https://froggyhubapp.netlify.app',
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+    ...extra
+  }
+}
+
+function ok(body: any, status = 200) {
+  return { statusCode: status, headers: cors(), body: JSON.stringify(body) }
+}
+
+function err(message: string, status = 400) {
+  return { statusCode: status, headers: cors(), body: JSON.stringify({ message }) }
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: cors() }
+  }
+  if (event.httpMethod !== 'POST') {
+    return err('Method not allowed', 405)
+  }
+
+  try {
+    const { nickname, password } = JSON.parse(event.body || '{}')
+    if (!nickname || !password) {
+      return err('Некорректные данные')
+    }
+
+    const client = new Client({ connectionString: process.env.NETLIFY_DATABASE_URL })
+    await client.connect()
+
+    try {
+      const { rows } = await client.query(
+        'SELECT id, nickname, password_hash FROM users_local WHERE nickname=$1 LIMIT 1',
+        [nickname]
+      )
+      if (rows.length === 0) {
+        return err('Пользователь не найден', 401)
+      }
+      const user = rows[0]
+      const match = await bcrypt.compare(password, user.password_hash)
+      if (!match) {
+        return err('Неверный пароль', 401)
+      }
+      const token = jwt.sign(
+        { sub: user.id, nickname: user.nickname },
+        process.env.JWT_SECRET as string,
+        { expiresIn: '7d' }
+      )
+      return ok({ ok: true, token, user: { id: user.id, nickname: user.nickname } })
+    } catch (e) {
+      return err('Ошибка сервера', 500)
+    } finally {
+      await client.end()
+    }
+  } catch (e) {
+    return err('Ошибка сервера', 500)
+  }
+}
+

--- a/netlify/functions/signup.ts
+++ b/netlify/functions/signup.ts
@@ -1,0 +1,59 @@
+import type { Handler } from '@netlify/functions'
+import { Client } from 'pg'
+import bcrypt from 'bcryptjs'
+
+function cors(extra: Record<string,string> = {}) {
+  return {
+    'Access-Control-Allow-Origin': 'https://froggyhubapp.netlify.app',
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+    ...extra
+  }
+}
+
+function ok(body: any, status = 200) {
+  return { statusCode: status, headers: cors(), body: JSON.stringify(body) }
+}
+
+function err(message: string, status = 400) {
+  return { statusCode: status, headers: cors(), body: JSON.stringify({ message }) }
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: cors() }
+  }
+  if (event.httpMethod !== 'POST') {
+    return err('Method not allowed', 405)
+  }
+
+  try {
+    const { nickname, password } = JSON.parse(event.body || '{}')
+    if (!nickname || !password) {
+      return err('Некорректные данные')
+    }
+
+    const client = new Client({ connectionString: process.env.NETLIFY_DATABASE_URL })
+    await client.connect()
+
+    try {
+      const hash = await bcrypt.hash(password, 10)
+      await client.query(
+        'INSERT INTO users_local (nickname, password_hash) VALUES ($1, $2)',
+        [nickname, hash]
+      )
+      return ok({ ok: true, message: 'Регистрация успешна' })
+    } catch (e: any) {
+      if (e.code === '23505') {
+        return err('Такой ник уже есть')
+      }
+      return err('Ошибка сервера', 500)
+    } finally {
+      await client.end()
+    }
+  } catch (e) {
+    return err('Ошибка сервера', 500)
+  }
+}
+

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,14 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/.netlify/functions'
+})
+
+export const signup = (nickname: string, password: string) =>
+  api.post('/signup', { nickname, password }).then(r => r.data)
+
+export const login = (nickname: string, password: string) =>
+  api.post('/login', { nickname, password }).then(r => r.data)
+
+export default api
+


### PR DESCRIPTION
## Summary
- implement Netlify signup function with Postgres, bcrypt, and CORS helpers
- add login function issuing JWT tokens after credential check
- provide Axios API client for signup and login on Vite/React frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f2a84924833295ddc885fa3efece