### PR TITLE
Use shared DATABASE_URL for Postgres connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Set the following environment variables in Netlify:
 
 - `SUPABASE_DB_URL` – connection string to the primary database (read/write).
 - `RW_NEON_URL` – Neon database URL with write access for the sync process.
-- `NETLIFY_DATABASE_URL` – read-only DSN for application queries.
+- `DATABASE_URL` – connection string for application queries.
 - `SYNC_BATCH_LIMIT` – maximum rows per batch (default: `2000`).
 - `SYNC_TABLES` – comma separated list of tables to replicate
   (`profiles,events,participants,wishlist_items,cookie_consents`).

--- a/api/_lib/db.js
+++ b/api/_lib/db.js
@@ -1,2 +1,1 @@
-import { neon } from '@netlify/neon';
-export const sql = neon(); // NETLIFY_DATABASE_URL
+export { getClient } from '../../utils/db.js';

--- a/api/auth-login.js
+++ b/api/auth-login.js
@@ -1,4 +1,4 @@
-import { sql } from './_lib/db.js';
+import { getClient } from '../utils/db.js';
 import { ok, bad } from './_lib/http.js';
 import bcrypt from 'bcryptjs';
 
@@ -6,8 +6,9 @@ export async function handler(event){
   if(event.httpMethod!=='POST') return bad(405,'Method not allowed');
   const { nickname, password } = JSON.parse(event.body||'{}');
   if(!nickname || !password) return bad(400,'Неверные данные');
+  const client = await getClient();
   try{
-    const rows = await sql`select id, password_hash from users_local where nickname = ${nickname} limit 1`;
+    const { rows } = await client.query('select id, password_hash from users_local where nickname = $1 limit 1', [nickname]);
     if(!rows.length) return bad(401,'Неверный ник или пароль');
     const okPass = await bcrypt.compare(password, rows[0].password_hash);
     if(!okPass) return bad(401,'Неверный ник или пароль');
@@ -16,5 +17,7 @@ export async function handler(event){
   }catch(e){
     console.error('auth-login', e);
     return bad(500,'Не удалось войти');
+  }finally{
+    await client.end();
   }
 }

--- a/api/auth-register.js
+++ b/api/auth-register.js
@@ -1,4 +1,4 @@
-import { sql } from './_lib/db.js';
+import { getClient } from '../utils/db.js';
 import { ok, bad } from './_lib/http.js';
 import bcrypt from 'bcryptjs';
 
@@ -6,13 +6,16 @@ export async function handler(event){
   if(event.httpMethod!=='POST') return bad(405,'Method not allowed');
   const { nickname, password } = JSON.parse(event.body||'{}');
   if(!nickname || !password || password.length<4) return bad(400,'Неверные данные');
+  const client = await getClient();
   try{
     const hash = await bcrypt.hash(password, 10);
-    await sql`insert into users_local (nickname, password_hash) values (${nickname}, ${hash})`;
+    await client.query('insert into users_local (nickname, password_hash) values ($1, $2)', [nickname, hash]);
     return ok({ user:{ nickname }});
   }catch(e){
     if(String(e?.message||'').includes('duplicate key')) return bad(409,'Ник уже занят');
     console.error('auth-register', e);
     return bad(500,'Не удалось зарегистрироваться');
+  }finally{
+    await client.end();
   }
 }

--- a/netlify/functions/db-ping.js
+++ b/netlify/functions/db-ping.js
@@ -1,0 +1,18 @@
+import { getClient } from '../../utils/db.js';
+
+export async function handler() {
+  try {
+    const client = await getClient();
+    const res = await client.query("SELECT NOW()");
+    await client.end();
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ ok: true, time: res.rows[0].now })
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ ok: false, error: err.message })
+    };
+  }
+}

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -1,5 +1,5 @@
 import type { Handler } from '@netlify/functions'
-import { Client } from 'pg'
+import { getClient } from '../../utils/db.js'
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
 
@@ -35,8 +35,7 @@ export const handler: Handler = async (event) => {
       return err('Некорректные данные')
     }
 
-    const client = new Client({ connectionString: process.env.NETLIFY_DATABASE_URL })
-    await client.connect()
+    const client = await getClient()
 
     try {
       const { rows } = await client.query(

--- a/netlify/functions/signup.ts
+++ b/netlify/functions/signup.ts
@@ -1,5 +1,5 @@
 import type { Handler } from '@netlify/functions'
-import { Client } from 'pg'
+import { getClient } from '../../utils/db.js'
 import bcrypt from 'bcryptjs'
 
 function cors(extra: Record<string,string> = {}) {
@@ -34,8 +34,7 @@ export const handler: Handler = async (event) => {
       return err('Некорректные данные')
     }
 
-    const client = new Client({ connectionString: process.env.NETLIFY_DATABASE_URL })
-    await client.connect()
+    const client = await getClient()
 
     try {
       const hash = await bcrypt.hash(password, 10)

--- a/utils/db.js
+++ b/utils/db.js
@@ -1,0 +1,10 @@
+import { Client } from "pg";
+
+export async function getClient() {
+  const client = new Client({
+    connectionString: process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: false }
+  });
+  await client.connect();
+  return client;
+}


### PR DESCRIPTION
## Summary
- centralize Postgres connection logic in `utils/db.js` using `DATABASE_URL`
- update login and signup handlers to use shared client and add `db-ping` function
- refactor auth handlers to use new client helper and document `DATABASE_URL` in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1006bfe7483329934924194d9c766