### PR TITLE
feat: add jwt auth

### DIFF
--- a/netlify/functions/_auth.js
+++ b/netlify/functions/_auth.js
@@ -1,0 +1,61 @@
+// netlify/functions/_auth.js
+const jwt = require('jsonwebtoken');
+
+const CORS_ORIGIN = 'https://froggyhubapp.netlify.app';
+
+function cors(extra = {}) {
+  return {
+    'Access-Control-Allow-Origin': CORS_ORIGIN,
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    ...extra
+  };
+}
+
+function ok(body, status = 200) {
+  return { statusCode: status, headers: cors(), body: JSON.stringify(body) };
+}
+
+function err(message, status = 400, meta) {
+  return { statusCode: status, headers: cors(), body: JSON.stringify({ success: false, error: message, ...(meta||{}) }) };
+}
+
+function signToken(payload) {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error('JWT_SECRET is not set');
+  return jwt.sign(payload, secret, { expiresIn: '7d' });
+}
+
+function verifyToken(token) {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error('JWT_SECRET is not set');
+  return jwt.verify(token, secret);
+}
+
+// Достаём токен из Authorization: Bearer <token>
+function getBearerToken(event) {
+  const h = event.headers || {};
+  const auth = h.authorization || h.Authorization || '';
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  return m ? m[1] : null;
+}
+
+// Обёртка для защищённых хендлеров
+function requireAuth(handler) {
+  return async (event, context) => {
+    if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors(), body: '' };
+    try {
+      const token = getBearerToken(event);
+      if (!token) return err('Unauthorized', 401);
+      const claims = verifyToken(token);
+      // прокинем user в context
+      context.user = claims;
+      return handler(event, context);
+    } catch (e) {
+      return err('Unauthorized', 401);
+    }
+  };
+}
+
+module.exports = { cors, ok, err, signToken, verifyToken, requireAuth, getBearerToken };

--- a/netlify/functions/local-login.js
+++ b/netlify/functions/local-login.js
@@ -1,23 +1,7 @@
 // netlify/functions/local-login.js
 const { Client } = require('pg');
 const bcrypt = require('bcryptjs');
-
-// helpers (CORS + unified responses)
-function cors(extra = {}) {
-  return {
-    'Access-Control-Allow-Origin': 'https://froggyhubapp.netlify.app',
-    'Access-Control-Allow-Credentials': 'true',
-    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    ...extra
-  };
-}
-function ok(body, status = 200) {
-  return { statusCode: status, headers: cors(), body: JSON.stringify(body) };
-}
-function err(message, status = 400, meta) {
-  return { statusCode: status, headers: cors(), body: JSON.stringify({ success: false, error: message, ...(meta||{}) }) };
-}
+const { cors, ok, err, signToken } = require('./_auth');
 
 exports.handler = async (event) => {
   try {
@@ -25,11 +9,7 @@ exports.handler = async (event) => {
     if (event.httpMethod !== 'POST') return err('Method not allowed', 405);
 
     let payload = {};
-    try {
-      payload = JSON.parse(event.body || '{}');
-    } catch {
-      return err('Invalid JSON body', 400);
-    }
+    try { payload = JSON.parse(event.body || '{}'); } catch { return err('Invalid JSON body', 400); }
 
     const { nickname, password } = payload;
     if (!nickname || !password) return err('Missing nickname or password', 400);
@@ -37,35 +17,28 @@ exports.handler = async (event) => {
     const conn = process.env.DATABASE_URL;
     if (!conn) return err('DATABASE_URL is not set', 500);
 
-    const client = new Client({
-      connectionString: conn,
-      ssl: { rejectUnauthorized: false }
-    });
-
+    const client = new Client({ connectionString: conn, ssl: { rejectUnauthorized: false } });
     await client.connect();
 
     const { rows } = await client.query(
-      'SELECT id, nickname, password_hash FROM public.users_local WHERE nickname = $1 LIMIT 1',
+      'SELECT id, nickname, password_hash FROM public.users_local WHERE nickname=$1 LIMIT 1',
       [nickname]
     );
 
-    if (!rows[0]) {
-      await client.end();
-      return err('User not found', 401);
-    }
+    if (!rows[0]) { await client.end(); return err('User not found', 401); }
 
     const user = rows[0];
-    const match = await bcrypt.compare(password, user.password_hash);
-    if (!match) {
-      await client.end();
-      return err('Invalid password', 401);
-    }
+    const okPass = await bcrypt.compare(password, user.password_hash);
+    if (!okPass) { await client.end(); return err('Invalid password', 401); }
 
     await client.end();
-    return ok({ success: true, user: { id: user.id, nickname: user.nickname } });
+
+    // JWT
+    const token = signToken({ sub: user.id, nickname: user.nickname });
+
+    return ok({ success: true, token, user: { id: user.id, nickname: user.nickname } });
   } catch (e) {
     console.error('local-login error:', e && (e.stack || e.message || e));
     return err(e && e.message ? e.message : 'Internal error', 500);
   }
 };
-

--- a/netlify/functions/profile.js
+++ b/netlify/functions/profile.js
@@ -1,0 +1,29 @@
+// netlify/functions/profile.js
+const { Client } = require('pg');
+const { cors, ok, err, requireAuth } = require('./_auth');
+
+async function handler(event, context) {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors(), body: '' };
+  if (event.httpMethod !== 'GET') return err('Method not allowed', 405);
+
+  const conn = process.env.DATABASE_URL;
+  if (!conn) return err('DATABASE_URL is not set', 500);
+
+  const client = new Client({ connectionString: conn, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+  try {
+    // context.user.sub — id из токена
+    const { rows } = await client.query(
+      'SELECT id, nickname, email, created_at FROM public.users_local WHERE id = $1 LIMIT 1',
+      [context.user.sub]
+    );
+    if (!rows[0]) return err('User not found', 404);
+    return ok({ success: true, profile: rows[0] });
+  } catch (e) {
+    return err(e.message || 'Failed to load profile', 500);
+  } finally {
+    await client.end();
+  }
+}
+
+exports.handler = requireAuth(handler);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "dependencies": {
         "@netlify/neon": "^0.1.0",
         "@supabase/supabase-js": "^2.42.5",
+        "axios": "^1.7.2",
         "bcryptjs": "^2.4.3",
         "jsonwebtoken": "^9.0.2",
-        "pg": "^8.11.3"
+        "pg": "^8.11.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "netlify-cli": "^17.0.0"
@@ -200,6 +203,23 @@
         "@types/node": "*"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
@@ -212,6 +232,54 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -220,6 +288,190 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -305,6 +557,48 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -6359,25 +6653,6 @@
         "stackframe": "^1.3.4"
       }
     },
-    "node_modules/netlify-cli/node_modules/es-define-property": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/es-errors": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/netlify-cli/node_modules/es-module-lexer": {
       "version": "1.5.3",
       "dev": true,
@@ -7217,25 +7492,6 @@
         "from2": "^2.1.0"
       }
     },
-    "node_modules/netlify-cli/node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/netlify-cli/node_modules/foreground-child": {
       "version": "3.1.1",
       "dev": true,
@@ -7360,14 +7616,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/netlify-cli/node_modules/function-bind": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/netlify-cli/node_modules/fuzzy": {
       "version": "0.1.3",
       "dev": true,
@@ -7434,24 +7682,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/netlify-cli/node_modules/get-package-name": {
@@ -7633,17 +7863,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/netlify-cli/node_modules/gopd": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/netlify-cli/node_modules/got": {
       "version": "12.6.1",
       "dev": true,
@@ -7727,28 +7946,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/netlify-cli/node_modules/has-proto": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/has-symbols": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/netlify-cli/node_modules/has-unicode": {
       "version": "2.0.1",
       "dev": true,
@@ -7802,17 +7999,6 @@
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/hasown": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/netlify-cli/node_modules/hosted-git-info": {
@@ -8841,11 +9027,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/netlify-cli/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/netlify-cli/node_modules/js-yaml": {
       "version": "4.1.0",
       "dev": true,
@@ -9676,25 +9857,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/mime-db": {
-      "version": "1.51.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/mime-types": {
-      "version": "2.1.34",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.51.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/netlify-cli/node_modules/mimic-fn": {
@@ -14039,6 +14201,37 @@
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
       "license": "MIT"
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -14058,6 +14251,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.2",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,12 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.42.5",
+    "axios": "^1.7.2",
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^9.0.2",
-    "pg": "^8.11.3",
+    "pg": "^8.11.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "@netlify/neon": "^0.1.0"
   },
   "devDependencies": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,14 +1,20 @@
-import axios from 'axios'
+// src/api.ts (добавить хелперы использования токена)
+import axios from 'axios';
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/.netlify/functions'
-})
+});
 
-export const signup = (nickname: string, password: string) =>
-  api.post('/signup', { nickname, password }).then(r => r.data)
+export const login = async (nickname: string, password: string) => {
+  const { data } = await api.post('/local-login', { nickname, password });
+  if (data?.token) localStorage.setItem('token', data.token);
+  return data;
+};
 
-export const login = (nickname: string, password: string) =>
-  api.post('/login', { nickname, password }).then(r => r.data)
-
-export default api
-
+export const getProfile = async () => {
+  const token = localStorage.getItem('token');
+  const { data } = await api.get('/profile', {
+    headers: token ? { Authorization: `Bearer ${token}` } : {}
+  });
+  return data;
+};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,16 @@
+// src/pages/Login.tsx
+import { login } from '../api';
+import axios from 'axios';
+
+export async function doLogin(
+  nickname: string,
+  password: string,
+  setMsg: (s: string) => void
+) {
+  try {
+    const res = await login(nickname, password);
+    setMsg('Вход выполнен');
+  } catch (e: any) {
+    setMsg(e?.response?.data?.error || 'Ошибка входа');
+  }
+}


### PR DESCRIPTION
## Summary
- add JWT helper and token issuance
- expose profile endpoint secured by JWT
- persist JWT on frontend and use for protected requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a106ef76108332a58f4f045bf89e72