### PR TITLE
feat: add DB diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,26 @@ Compare `count(*)` for each table between the primary and secondary databases.
 Cascade deletes are not synchronised. Use `deleted_at` columns and filter on
 `where deleted_at is null` in analytics queries.
 
+## DATABASE_URL (Neon)
+
+**Важно:** в Netlify переменная `DATABASE_URL` должнa быть **чистым URL**, а не psql-командой.
+
+❌ Неверно (это CLI-команда):
+psql 'postgresql://neondb_owner:PASS@ep-...neon.tech/neondb?sslmode=require&channel_binding=require'
+
+✅ Верно (только URL, без `psql` и без кавычек):
+postgresql://neondb_owner:PASS@ep-...neon.tech/neondb?sslmode=require&channel_binding=require
+
+Если видите `password authentication failed`:
+1. В Neon → **Connect → Role** выберите роль (например, `neondb_owner`) и нажмите **Reset password**.
+2. Скопируйте **Connection string (URI)** *без* префикса `psql` и *без* кавычек.
+3. В Netlify → **Environment variables** замените `DATABASE_URL` во **всех** контекстах (Production, Deploy Previews, Branch).
+4. Нажмите **Trigger deploy**.
+
+### Диагностика
+- `/.netlify/functions/db-url-check` — проверка структуры `DATABASE_URL` (пароль скрыт).
+- `/.netlify/functions/db-whoami` — покажет `current_user`, базу и хост, если авторизация удалась.
+
 ## Cookie consent
 A simple banner is rendered at the bottom of the page asking the visitor to accept or decline cookies. The choice is stored in `localStorage` and synchronised with the `cookie_consents` table when the user is authenticated. Declining removes optional scripts such as analytics.
 

--- a/netlify/functions/db-url-check.js
+++ b/netlify/functions/db-url-check.js
@@ -1,0 +1,29 @@
+// GET /.netlify/functions/db-url-check
+// Парсит DATABASE_URL и возвращает отдельные поля (без пароля), чтобы проверить корректность значения.
+export default async function handler() {
+  const raw = process.env.DATABASE_URL || '';
+  if (!raw) {
+    return new Response(JSON.stringify({ ok:false, error:'DATABASE_URL is not set' }), {
+      status: 500, headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  try {
+    const u = new URL(raw);
+    const masked = raw.replace(/:(.*?)@/, ':***@');
+    return new Response(JSON.stringify({
+      ok: true,
+      masked,                // для визуальной проверки
+      protocol: u.protocol,  // должно быть "postgres:" или "postgresql:"
+      host: u.hostname,      // должен выглядеть как *.neon.tech (или *.supabase.co)
+      port: u.port || '5432',
+      database: u.pathname.replace(/^\//,''),
+      user: decodeURIComponent(u.username),
+      hasPassword: Boolean(u.password),
+      search: u.search       // должен содержать ?sslmode=require (или &sslmode=require)
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  } catch (e) {
+    return new Response(JSON.stringify({ ok:false, error: String(e) }), {
+      status: 400, headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}

--- a/netlify/functions/db-whoami.js
+++ b/netlify/functions/db-whoami.js
@@ -1,0 +1,22 @@
+// GET /.netlify/functions/db-whoami
+// Возвращает current_user, БД и адрес сервера. Используется только для отладки.
+import pg from 'pg';
+const { Client } = pg;
+
+export default async function handler() {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    return new Response(JSON.stringify({ ok:false, error:'DATABASE_URL is not set' }), {
+      status: 500, headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  const client = new Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+  const { rows } = await client.query(`
+    select current_user, current_database() as db, inet_server_addr()::text as host;
+  `);
+  await client.end();
+  return new Response(JSON.stringify({ ok:true, ...rows[0] }), {
+    status: 200, headers: { 'Content-Type': 'application/json' }
+  });
+}


### PR DESCRIPTION
## Summary
- add Netlify function to show current database connection user and host
- add function to validate DATABASE_URL without exposing password
- document correct Neon connection URL and diagnostic endpoints

## Testing
- `node --check netlify/functions/db-whoami.js`
- `node --check netlify/functions/db-url-check.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2e63f56f48332a47b6c233f115433