### PR TITLE
Handle DB auth errors with friendly JSON and docs

### DIFF
--- a/docs/TROUBLESHOOTING_DB.md
+++ b/docs/TROUBLESHOOTING_DB.md
@@ -1,0 +1,19 @@
+# DB Troubleshooting
+
+## Error: `password authentication failed` (Postgres code 28P01)
+
+Причина: неверный пароль в `DATABASE_URL`.
+
+### Как исправить (Neon)
+1. Открой Neon → **Roles** → выбери нужную роль (например, `neondb_owner`) → **Reset password**.
+2. Перейди Neon → **Connect** → скопируй **Connection string (URI)**.
+   - ДОЛЖНО БЫТЬ: `postgresql://USER:PASS@HOST/DB?sslmode=require&channel_binding=require`
+   - НЕЛЬЗЯ: `psql 'postgresql://…'` (это CLI-команда; не вставляй `psql` и кавычки)
+3. Netlify → **Site settings → Environment variables** → замени `DATABASE_URL` во **всех** контекстах  
+   (Production, Deploy Previews, Branch).
+4. Нажми **Trigger deploy**.
+
+### Проверка
+- `/.netlify/functions/db-url-check` — парсинг `DATABASE_URL` (пароль скрыт): протокол `postgres`/`postgresql`, хост `*.neon.tech`, `hasPassword=true`, в `search` есть `sslmode=require`.
+- `/.netlify/functions/db-whoami` — успешное подключение вернёт `{ ok:true, current_user, db, host }`.  
+  При ошибке 28P01 вернётся дружелюбный JSON с подсказкой.

--- a/netlify/functions/db-whoami.js
+++ b/netlify/functions/db-whoami.js
@@ -1,22 +1,37 @@
-// GET /.netlify/functions/db-whoami
-// Возвращает current_user, БД и адрес сервера. Используется только для отладки.
 import pg from 'pg';
 const { Client } = pg;
 
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
 export default async function handler() {
   const url = process.env.DATABASE_URL;
-  if (!url) {
-    return new Response(JSON.stringify({ ok:false, error:'DATABASE_URL is not set' }), {
-      status: 500, headers: { 'Content-Type': 'application/json' }
-    });
-  }
+  if (!url) return json({ ok:false, error:'DATABASE_URL is not set' }, 500);
+
   const client = new Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
-  await client.connect();
-  const { rows } = await client.query(`
-    select current_user, current_database() as db, inet_server_addr()::text as host;
-  `);
-  await client.end();
-  return new Response(JSON.stringify({ ok:true, ...rows[0] }), {
-    status: 200, headers: { 'Content-Type': 'application/json' }
-  });
+  try {
+    await client.connect();
+    const { rows } = await client.query(`
+      select current_user, current_database() as db, inet_server_addr()::text as host;
+    `);
+    return json({ ok:true, ...rows[0] });
+  } catch (e) {
+    if (e?.code === '28P01' || /password authentication failed/i.test(e?.message || '')) {
+        return json({
+          ok: false,
+          code: '28P01',
+          error: 'Database password is invalid for the provided user.',
+          hint:
+            'In Neon → Roles → Reset password for the selected role (e.g., neondb_owner). Copy the URI (without psql/quotes). '
+            + 'In Netlify → Environment variables update DATABASE_URL in ALL scopes (Production, Deploy Previews, Branch). Redeploy and try again.'
+        }, 500);
+      }
+    return json({ ok:false, error: e?.message || 'DB error' }, 500);
+  } finally {
+    try { await client.end(); } catch {}
+  }
 }


### PR DESCRIPTION
## Summary
- Return JSON error response for invalid database password (28P01)
- Document troubleshooting steps for password authentication failures

## Testing
- `npm test`
- `node --check netlify/functions/db-whoami.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2e9d049c88332b0f5d177eb6b48c2