### PR TITLE
Make email optional for local signup

### DIFF
--- a/migrations/users_local_email_optional.sql
+++ b/migrations/users_local_email_optional.sql
@@ -1,0 +1,3 @@
+-- make email optional
+ALTER TABLE public.users_local
+  ALTER COLUMN email DROP NOT NULL;

--- a/netlify/functions/local-signup.js
+++ b/netlify/functions/local-signup.js
@@ -31,7 +31,7 @@ exports.handler = async (event) => {
       return err('Invalid JSON body', 400);
     }
 
-    const { nickname, password, email } = payload;
+    const { nickname, password } = payload;
     if (!nickname || !password) return err('Missing nickname or password', 400);
 
     const conn = process.env.DATABASE_URL;
@@ -51,10 +51,10 @@ exports.handler = async (event) => {
     let result;
     try {
       result = await client.query(
-        `INSERT INTO public.users_local (nickname, email, password_hash)
-         VALUES ($1, $2, $3)
+        `INSERT INTO public.users_local (nickname, password_hash)
+         VALUES ($1, $2)
          RETURNING id, nickname, email, created_at`,
-        [nickname, email || null, passwordHash]
+        [nickname, passwordHash]
       );
     } catch (e) {
       // PG duplicate key


### PR DESCRIPTION
## Summary
- allow local signup to work without an email by removing the column from inserts
- add migration to drop NOT NULL constraint on users_local.email

## Testing
- `npm test`
- `psql "$DATABASE_URL" -c "SELECT column_name, is_nullable FROM information_schema.columns WHERE table_schema='public' AND table_name='users_local' ORDER BY ordinal_position;"` *(fails: command not found: psql)*
- `curl -sS -X POST https://froggyhubapp.netlify.app/.netlify/functions/local-signup -H "Content-Type: application/json" -d '{"nickname":"test1","password":"pass1234"}' | jq` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a388f301f0833294881f1b62dd30d1