### PR TITLE
Allow local signup without email

### DIFF
--- a/migrations/2025-08-18_make_email_nullable.sql
+++ b/migrations/2025-08-18_make_email_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.users_local
+  ALTER COLUMN email DROP NOT NULL;

--- a/netlify/functions/local-signup.js
+++ b/netlify/functions/local-signup.js
@@ -24,14 +24,12 @@ exports.handler = async (event) => {
     if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors(), body: '' };
     if (event.httpMethod !== 'POST') return err('Method not allowed', 405);
 
-    let payload = {};
+    let nickname, password;
     try {
-      payload = JSON.parse(event.body || '{}');
+      ({ nickname, password } = JSON.parse(event.body || '{}'));
     } catch {
       return err('Invalid JSON body', 400);
     }
-
-    const { nickname, password } = payload;
     if (!nickname || !password) return err('Missing nickname or password', 400);
 
     const conn = process.env.DATABASE_URL;


### PR DESCRIPTION
## Summary
- add migration to make email nullable in `users_local`
- parse nickname and password directly in `local-signup` handler and insert without email

## Testing
- `npm test`
- `curl -sS -X POST https://froggyhubapp.netlify.app/.netlify/functions/local-signup -H "Content-Type: application/json" -d '{"nickname":"test1","password":"pass1234"}'` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a38b8607188332bf359d6621d4928f