### PR TITLE
fix netlify handlers to use commonjs export

### DIFF
--- a/netlify/functions/local-login.js
+++ b/netlify/functions/local-login.js
@@ -1,6 +1,6 @@
 // netlify/functions/local-login.js
-const bcrypt = require('bcryptjs');
 const { getServiceClient } = require('./_supabase');
+const bcrypt = require('bcryptjs');
 const { ok, err, signToken } = require('./_auth');
 
 exports.handler = async (event) => {

--- a/netlify/functions/local-signup.js
+++ b/netlify/functions/local-signup.js
@@ -1,6 +1,6 @@
 // netlify/functions/local-signup.js
-const bcrypt = require('bcryptjs');
 const { getServiceClient } = require('./_supabase');
+const bcrypt = require('bcryptjs');
 
 const ok = (b, s=200)=>({ statusCode:s, headers:{'Content-Type':'application/json'}, body:JSON.stringify(b) });
 const err = (m, s=400)=> ok({ success:false, error:m }, s);

--- a/netlify/functions/profile.js
+++ b/netlify/functions/profile.js
@@ -1,14 +1,16 @@
 // netlify/functions/profile.js
-const { ok, err, requireAuth } = require('./_auth');
 const { getServiceClient } = require('./_supabase');
+const { ok, err, requireAuth } = require('./_auth');
 
-exports.handler = requireAuth(async (_event, ctx) => {
-  const sb = getServiceClient();
-  const { data, error } = await sb
-    .from('users_local')
-    .select('id, nickname, email, created_at')
-    .eq('id', ctx.user.sub)
-    .single();
-  if (error || !data) return err('User not found', 404);
-  return ok({ success:true, profile: data });
-});
+exports.handler = async (event, context) => {
+  return requireAuth(async (_event, ctx) => {
+    const sb = getServiceClient();
+    const { data, error } = await sb
+      .from('users_local')
+      .select('id, nickname, email, created_at')
+      .eq('id', ctx.user.sub)
+      .single();
+    if (error || !data) return err('User not found', 404);
+    return ok({ success:true, profile: data });
+  })(event, context);
+};


### PR DESCRIPTION
## Summary
- ensure local-login, local-signup, and profile functions use CommonJS `exports.handler`
- move `_supabase` import to the top of each function file
- wrap profile handler with `requireAuth` inside an async export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a51e93760083328783e277379938b2