### PR TITLE
refactor: use ESM named handlers for Netlify functions

### DIFF
--- a/netlify/functions/_auth.js
+++ b/netlify/functions/_auth.js
@@ -1,9 +1,9 @@
 // netlify/functions/_auth.js
-const jwt = require('jsonwebtoken');
+import jwt from 'jsonwebtoken';
 
 const CORS_ORIGIN = 'https://froggyhubapp.netlify.app';
 
-function cors(extra = {}) {
+export function cors(extra = {}) {
   return {
     'Access-Control-Allow-Origin': CORS_ORIGIN,
     'Access-Control-Allow-Credentials': 'true',
@@ -13,28 +13,28 @@ function cors(extra = {}) {
   };
 }
 
-function ok(body, status = 200) {
+export function ok(body, status = 200) {
   return { statusCode: status, headers: cors(), body: JSON.stringify(body) };
 }
 
-function err(message, status = 400, meta) {
+export function err(message, status = 400, meta) {
   return { statusCode: status, headers: cors(), body: JSON.stringify({ success: false, error: message, ...(meta||{}) }) };
 }
 
-function signToken(payload) {
+export function signToken(payload) {
   const secret = process.env.JWT_SECRET;
   if (!secret) throw new Error('JWT_SECRET is not set');
   return jwt.sign(payload, secret, { expiresIn: '7d' });
 }
 
-function verifyToken(token) {
+export function verifyToken(token) {
   const secret = process.env.JWT_SECRET;
   if (!secret) throw new Error('JWT_SECRET is not set');
   return jwt.verify(token, secret);
 }
 
 // Достаём токен из Authorization: Bearer <token>
-function getBearerToken(event) {
+export function getBearerToken(event) {
   const h = event.headers || {};
   const auth = h.authorization || h.Authorization || '';
   const m = auth.match(/^Bearer\s+(.+)$/i);
@@ -42,7 +42,7 @@ function getBearerToken(event) {
 }
 
 // Обёртка для защищённых хендлеров
-function requireAuth(handler) {
+export function requireAuth(handler) {
   return async (event, context) => {
     if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors(), body: '' };
     try {
@@ -58,4 +58,3 @@ function requireAuth(handler) {
   };
 }
 
-module.exports = { cors, ok, err, signToken, verifyToken, requireAuth, getBearerToken };

--- a/netlify/functions/_supabase.js
+++ b/netlify/functions/_supabase.js
@@ -1,10 +1,9 @@
-const { createClient } = require('@supabase/supabase-js');
+import { createClient } from '@supabase/supabase-js';
 
-function getServiceClient() {
+export function getServiceClient() {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) throw new Error('Supabase server credentials missing');
   return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
 }
 
-module.exports = { getServiceClient };

--- a/netlify/functions/db-ping.js
+++ b/netlify/functions/db-ping.js
@@ -1,6 +1,6 @@
 import { getClient } from '../../utils/db.js';
 
-export async function handler() {
+export async function handler(event, context) {
   try {
     const client = await getClient();
     const res = await client.query("SELECT NOW()");

--- a/netlify/functions/db-url-check.js
+++ b/netlify/functions/db-url-check.js
@@ -1,6 +1,6 @@
 // GET /.netlify/functions/db-url-check
 // Парсит DATABASE_URL и возвращает отдельные поля (без пароля), чтобы проверить корректность значения.
-export default async function handler() {
+export async function handler(event, context) {
   const raw = process.env.DATABASE_URL || '';
   if (!raw) {
     return new Response(JSON.stringify({ ok:false, error:'DATABASE_URL is not set' }), {

--- a/netlify/functions/db-whoami.js
+++ b/netlify/functions/db-whoami.js
@@ -8,7 +8,7 @@ function json(body, status = 200) {
   });
 }
 
-export default async function handler() {
+export async function handler(event, context) {
   const url = process.env.DATABASE_URL;
   if (!url) return json({ ok: false, error: 'DATABASE_URL is not set' }, 500);
 

--- a/netlify/functions/diag-auth.js
+++ b/netlify/functions/diag-auth.js
@@ -1,6 +1,6 @@
-const { getServiceClient } = require('./_supabase');
+import { getServiceClient } from './_supabase.js';
 
-exports.handler = async () => {
+export async function handler(event, context) {
   const urlDefined = !!process.env.SUPABASE_URL;
   const hasServiceRole = !!process.env.SUPABASE_SERVICE_ROLE_KEY;
 
@@ -34,4 +34,4 @@ exports.handler = async () => {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ok, urlDefined, hasServiceRole, tableExists, count, supabaseError }),
   };
-};
+}

--- a/netlify/functions/local-login.js
+++ b/netlify/functions/local-login.js
@@ -1,9 +1,9 @@
 // netlify/functions/local-login.js
-const { getServiceClient } = require('./_supabase');
-const bcrypt = require('bcryptjs');
-const { ok, err, signToken } = require('./_auth');
+import { getServiceClient } from './_supabase.js';
+import bcrypt from 'bcryptjs';
+import { ok, err, signToken } from './_auth.js';
 
-exports.handler = async (event) => {
+export async function handler(event, context) {
   try {
     const { nickname, password } = JSON.parse(event.body || '{}');
     if (!nickname || !password) return err('nickname and password required', 400);
@@ -22,4 +22,4 @@ exports.handler = async (event) => {
   } catch (e) {
     return err(e.message || 'login failed', 500);
   }
-};
+}

--- a/netlify/functions/local-signup.js
+++ b/netlify/functions/local-signup.js
@@ -1,9 +1,9 @@
 // netlify/functions/local-signup.js
-const { getServiceClient } = require('./_supabase');
-const bcrypt = require('bcryptjs');
-const { ok, err } = require('./_auth');
+import { getServiceClient } from './_supabase.js';
+import bcrypt from 'bcryptjs';
+import { ok, err } from './_auth.js';
 
-exports.handler = async (event) => {
+export async function handler(event, context) {
   try {
     const { nickname, password } = JSON.parse(event.body || '{}');
     if (!nickname || !password) return err('nickname and password required', 400);
@@ -27,4 +27,4 @@ exports.handler = async (event) => {
   } catch (e) {
     return err(e.message || 'signup failed', 500);
   }
-};
+}

--- a/netlify/functions/profile.js
+++ b/netlify/functions/profile.js
@@ -1,8 +1,8 @@
 // netlify/functions/profile.js
-const { getServiceClient } = require('./_supabase');
-const { ok, err, requireAuth } = require('./_auth');
+import { getServiceClient } from './_supabase.js';
+import { ok, err, requireAuth } from './_auth.js';
 
-exports.handler = async (event, context) => {
+export async function handler(event, context) {
   return requireAuth(async (_event, ctx) => {
     const sb = getServiceClient();
     const { data, error } = await sb
@@ -13,4 +13,4 @@ exports.handler = async (event, context) => {
     if (error || !data) return err('User not found', 404);
     return ok({ success:true, profile: data });
   })(event, context);
-};
+}


### PR DESCRIPTION
## Summary
- convert Netlify helper modules and handlers to ESM with named exports
- ensure all functions expose `export async function handler(event, context)`
- verify Netlify configuration for esbuild bundling and external modules

## Testing
- `npm test`
- `node --check netlify/functions/diag-auth.js && node --check netlify/functions/db-whoami.js && node --check netlify/functions/db-url-check.js && node --check netlify/functions/_supabase.js`

------
https://chatgpt.com/codex/tasks/task_e_68a5326137f88332ba0b0ecb029a75a0