### PR TITLE
Persist login token and redirect to profile

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -7,7 +7,7 @@ function clearToken(){ localStorage.removeItem('FH_JWT'); }
 
 function toast(msg, type='info'){
   console[type==='error'?'error':'log']('[toast]', msg);
-  try { window.showToast?.(msg, type) ?? alert(msg); } catch {}
+  try { window.showToast?.(msg, type); } catch {}
 }
 
 function withBusy(btn, fn){

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,16 +5,19 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || '/.netlify/functions'
 });
 
+export function setToken(t: string) { localStorage.setItem('FH_JWT', t); }
+export function getToken() { return localStorage.getItem('FH_JWT'); }
+export function clearToken() { localStorage.removeItem('FH_JWT'); }
+
 export const login = async (nickname: string, password: string) => {
   const { data } = await api.post('/local-login', { nickname, password });
-  if (data?.token) localStorage.setItem('token', data.token);
+  if (data?.token) setToken(data.token);
   return data;
 };
 
 export const getProfile = async () => {
-  const token = localStorage.getItem('token');
   const { data } = await api.get('/profile', {
-    headers: token ? { Authorization: `Bearer ${token}` } : {}
+    headers: { Authorization: 'Bearer ' + getToken() }
   });
   return data;
 };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,5 @@
 // src/pages/Login.tsx
 import { login } from '../api';
-import axios from 'axios';
 
 export async function doLogin(
   nickname: string,
@@ -8,8 +7,9 @@ export async function doLogin(
   setMsg: (s: string) => void
 ) {
   try {
-    const res = await login(nickname, password);
+    await login(nickname, password);
     setMsg('Вход выполнен');
+    window.location.href = '/profile.html';
   } catch (e: any) {
     setMsg(e?.response?.data?.error || 'Ошибка входа');
   }


### PR DESCRIPTION
## Summary
- add helpers to manage JWT token in localStorage
- store token after local-login and include it when loading profile
- redirect UI to profile page after successful login and drop blocking alerts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a53a276b608332a791572aa7fd9767