### PR TITLE
feat: handle auth token and profile auth

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -7,14 +7,27 @@ const api = axios.create({
 
 export const login = async (nickname: string, password: string) => {
   const { data } = await api.post('/local-login', { nickname, password });
-  if (data?.token) localStorage.setItem('token', data.token);
+  if (data?.token) localStorage.setItem('FH_JWT', data.token);
   return data;
 };
 
+export const signup = async (nickname: string, password: string) => {
+  await api.post('/local-signup', { nickname, password });
+  return login(nickname, password);
+};
+
 export const getProfile = async () => {
-  const token = localStorage.getItem('token');
-  const { data } = await api.get('/profile', {
-    headers: token ? { Authorization: `Bearer ${token}` } : {}
-  });
-  return data;
+  const token = localStorage.getItem('FH_JWT');
+  try {
+    const { data } = await api.get('/profile', {
+      headers: token ? { Authorization: `Bearer ${token}` } : {}
+    });
+    return data;
+  } catch (e: any) {
+    if (e?.response?.status === 401) {
+      localStorage.removeItem('FH_JWT');
+      window.location.href = '/';
+    }
+    throw e;
+  }
 };

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,5 @@
 // src/pages/Login.tsx
-import { login } from '../api';
-import axios from 'axios';
+import { login, signup } from '../api';
 
 export async function doLogin(
   nickname: string,
@@ -8,9 +7,24 @@ export async function doLogin(
   setMsg: (s: string) => void
 ) {
   try {
-    const res = await login(nickname, password);
+    await login(nickname, password);
     setMsg('Вход выполнен');
+    window.location.href = '/profile.html';
   } catch (e: any) {
     setMsg(e?.response?.data?.error || 'Ошибка входа');
+  }
+}
+
+export async function doSignup(
+  nickname: string,
+  password: string,
+  setMsg: (s: string) => void
+) {
+  try {
+    await signup(nickname, password);
+    setMsg('Регистрация выполнена');
+    window.location.href = '/profile.html';
+  } catch (e: any) {
+    setMsg(e?.response?.data?.error || 'Ошибка регистрации');
   }
 }


### PR DESCRIPTION
## Summary
- store JWT under FH_JWT and add signup/login helpers
- send auth header when fetching profile and reset on 401
- add signup and login redirects to profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a53bacdaac8332ad444cefbecd2131