### PR TITLE
Redirect to profile after auth

### DIFF
--- a/src/goProfile.ts
+++ b/src/goProfile.ts
@@ -1,0 +1,15 @@
+export function goProfile() {
+  // если MPA со страницей /profile.html
+  if (document.querySelector('link[href*="profile.html"]') || window.location.pathname.endsWith('.html')) {
+    window.location.href = '/profile.html';
+    return;
+  }
+  // SPA fallback
+  try {
+    // если используем React Router и есть navigate
+    // (если компонента не в React-контексте — просто хардовый переход)
+    // @ts-ignore
+    if (window.navigate) { window.navigate('/profile'); return; }
+  } catch {}
+  window.location.assign('/profile.html');
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 // src/pages/Login.tsx
 import { login, signup } from '../api';
+import { goProfile } from '../goProfile';
 import type { AxiosError } from 'axios';
 
 export async function doLogin(
@@ -10,7 +11,7 @@ export async function doLogin(
   try {
     await login(nickname, password);
     setMsg('Вход выполнен');
-    window.location.href = '/profile.html';
+    goProfile();
   } catch (e) {
     const err = e as AxiosError<{ error?: string }>;
     setMsg(err.response?.data?.error || 'Ошибка входа');
@@ -25,7 +26,7 @@ export async function doSignup(
   try {
     await signup(nickname, password);
     setMsg('Регистрация выполнена');
-    window.location.href = '/profile.html';
+    goProfile();
   } catch (e) {
     const err = e as AxiosError<{ error?: string }>;
     setMsg(err.response?.data?.error || 'Ошибка регистрации');


### PR DESCRIPTION
## Summary
- add goProfile helper to handle MPA/SPA profile redirects
- use goProfile after login or signup to navigate to profile

## Testing
- `npm test`
- `npm run build` *(fails: Could not resolve entry module "index.html".)*

------
https://chatgpt.com/codex/tasks/task_e_68a53f65eabc833284f77bfa0ef221a5