### PR TITLE
feat: add hub page and redirect

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -1687,7 +1687,7 @@ $('#loginForm')?.addEventListener('submit', withBusy($('#login-btn'), async (e)=
     const { token } = await callFn('local-login', { nickname, password });
     if(token){ setToken(token); }
     setNickname(nickname);
-    window.location.href = '/profile.html';
+    window.location.href = '/hub.html';
   }catch(e){ toast(e.message||'Не удалось войти','error'); }
 }));
 
@@ -1701,7 +1701,7 @@ $('#signupForm')?.addEventListener('submit', withBusy($('#signup-btn'), async (e
     const { token } = await callFn('local-login', { nickname, password:p1 });
     if(token){ setToken(token); }
     setNickname(nickname);
-    window.location.href = '/profile.html';
+    window.location.href = '/hub.html';
   }catch(e){ toast(e.message||'Не удалось зарегистрироваться','error'); }
 }));
 
@@ -1736,6 +1736,79 @@ async function loadProfile(){
   }catch(e){ console.warn('profile load failed', e); }
 }
 
+async function loadMyEvents(){
+  const list = $('#my-events');
+  if(!list) return;
+  list.innerHTML = '';
+  try{
+    const res = await fetch('/.netlify/functions/events-my', {
+      headers:{ Authorization: 'Bearer ' + getToken() }
+    });
+    const data = await res.json().catch(()=> ({}));
+    if(data?.success && Array.isArray(data.events) && data.events.length){
+      for(const ev of data.events){
+        const li = document.createElement('li');
+        const date = ev.starts_at ? new Date(ev.starts_at).toLocaleDateString('ru-RU') : '';
+        li.textContent = `${ev.title||''} ${date && ('('+date+')')}`;
+        li.addEventListener('click', ()=>{ window.location.href = `/event.html?id=${ev.id}`; });
+        list.appendChild(li);
+      }
+    }else{
+      const li = document.createElement('li');
+      li.textContent = 'Событий нет';
+      list.appendChild(li);
+    }
+  }catch(e){
+    console.warn('loadMyEvents failed', e);
+    const li = document.createElement('li');
+    li.textContent = 'Ошибка загрузки';
+    list.appendChild(li);
+  }
+}
+
+async function initHubPage(){
+  if(!/\/hub\.html$/.test(location.pathname)) return;
+  if(!getToken()){ window.location.href='/'; return; }
+  try{
+    const res = await fetch('/.netlify/functions/profile', {
+      headers:{ Authorization:'Bearer '+getToken() }
+    });
+    if(res.status===401 || res.status===403){
+      clearToken();
+      window.location.href='/';
+      return;
+    }
+    const data = await res.json().catch(()=> ({}));
+    const p = data?.profile || {};
+    const nickEl = $('#mp-nick');
+    if(nickEl) nickEl.textContent = p.nickname || '';
+    if(p.created_at){
+      try{
+        const crEl = $('#mp-created');
+        if(crEl) crEl.textContent = new Date(p.created_at).toLocaleDateString('ru-RU');
+      }catch{}
+    }
+  }catch(e){ console.warn('hub profile load failed', e); }
+  loadMyEvents();
+  $('#hub-logout')?.addEventListener('click', ()=>{
+    clearToken();
+    window.location.href = '/';
+  });
+  $('[data-action="create"]')?.addEventListener('click', (e)=>{
+    e.preventDefault();
+    window.location.href = '/event-edit.html';
+  });
+  $('[data-action="join"]')?.addEventListener('click', ()=>{
+    const code = $('[data-input="join-code"]')?.value?.trim();
+    if(!code) return;
+    if(/^https?:/i.test(code)){
+      window.location.href = code;
+    }else{
+      window.location.href = '/event.html?code=' + encodeURIComponent(code);
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   if(/\/profile\.html$/.test(location.pathname)){
     if(!getToken()){
@@ -1745,6 +1818,8 @@ document.addEventListener('DOMContentLoaded', () => {
     loadProfile();
   }
 });
+
+document.addEventListener('DOMContentLoaded', initHubPage);
 
 async function uiSmoke(){
   const report = [];

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Хаб</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="mini-profile" style="position:absolute;top:10px;right:10px;text-align:right;">
+    Ник: <span id="mp-nick"></span>, Создан: <span id="mp-created"></span>
+    <button id="hub-logout" class="btn small">Выйти</button>
+  </div>
+  <main class="container" role="main">
+    <div class="card" style="max-width:760px;margin:40px auto">
+      <h1>Хаб</h1>
+      <div class="grid">
+        <div class="card inner">
+          <a class="btn" href="/event-edit.html" data-action="create">Создать ивент</a>
+        </div>
+        <div class="card inner">
+          <h3>Войти в ивент</h3>
+          <div class="row2">
+            <input data-input="join-code" placeholder="Код или ссылка" />
+            <button class="btn" data-action="join">Войти</button>
+          </div>
+        </div>
+      </div>
+      <section>
+        <h2>Мои ивенты</h2>
+        <ul id="my-events"></ul>
+      </section>
+    </div>
+  </main>
+  <script>
+    window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
+    window.PROXY_SUPABASE_URL = location.origin + '/supabase';
+    window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
+  </script>
+  <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
+  <script defer src="app.js"></script>
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+  <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new hub.html page with mini-profile, event list and CTAs
- redirect login/signup to hub and load profile/events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5445e76248332b4a0bd3a34f56e54