### PR TITLE
Add events schema migration and docs

### DIFF
--- a/docs/db.md
+++ b/docs/db.md
@@ -1,0 +1,8 @@
+## Database Setup
+
+To create the base tables in a new project:
+
+1. Open the Supabase SQL Editor.
+2. Copy the contents of `migrations/2025-08-19_events_schema.sql` and run them.
+
+Netlify functions use the `SERVICE_ROLE` key, so row level security is not required for these tables.

--- a/migrations/2025-08-19_events_schema.sql
+++ b/migrations/2025-08-19_events_schema.sql
@@ -1,0 +1,32 @@
+CREATE TABLE public.events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text UNIQUE NOT NULL,
+  host_user_id uuid REFERENCES auth.users NOT NULL,
+  title text NOT NULL,
+  date date,
+  time text,
+  address text,
+  dress text,
+  bring text,
+  notes text,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE public.wishlist_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id uuid NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  url text,
+  claimed_by text,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE public.guests (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id uuid NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  rsvp text,
+  created_at timestamptz DEFAULT now()
+);
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- define `events`, `wishlist_items`, and `guests` tables
- document how to apply the migration and note SERVICE_ROLE usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a553f8eb7883328915b7cc8cfe4d89