### PR TITLE
Add event lobby flow with Supabase

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -1839,3 +1839,176 @@ uiSmoke();
 if(DEBUG_AUTH){
   dbgAuth('sb_mode', sessionStorage.getItem('sb_mode') || 'direct');
 }
+
+// ==== API helpers (не трогаем существующие экспорты, просто добавляем) ====
+const FH_TOKEN_KEY = 'FH_JWT';
+const FH_EVENT_CODE = 'FH_EVENT_CODE';
+const API_BASE = '/.netlify/functions';
+
+async function apiGet(path) {
+  const res = await fetch(`${API_BASE}${path}`, { credentials: 'include' });
+  const data = await res.json();
+  if (!res.ok || data?.error) throw new Error(data?.error || res.statusText);
+  return data;
+}
+
+async function apiPost(path, body, useAuth = false) {
+  const headers = { 'Content-Type': 'application/json' };
+  const token = localStorage.getItem(FH_TOKEN_KEY);
+  if (useAuth && token) headers['Authorization'] = `Bearer ${token}`;
+  const res = await fetch(`${API_BASE}${path}`, { method: 'POST', headers, body: JSON.stringify(body) });
+  const data = await res.json();
+  if (!res.ok || data?.error) throw new Error(data?.error || res.statusText);
+  return data;
+}
+
+// ==== Создание события (owner) ====
+async function handleCreateEvent(formEl) {
+  const fd = new FormData(formEl);
+  const payload = {
+    title: fd.get('title') || fd.get('party_name') || 'Моё событие',
+    date: fd.get('date') || fd.get('party_date'),
+    time: fd.get('time') || fd.get('party_time'),
+    address: fd.get('address') || fd.get('party_address') || '',
+    dress: fd.get('dress') || '',
+    bring: fd.get('bring') || '',
+    notes: fd.get('notes') || ''
+  };
+  const wishlist = [];
+  (fd.getAll('wishlist[]') || []).forEach(t => wishlist.push({ title: t }));
+  payload.wishlist = wishlist;
+
+  const data = await apiPost('/events-create', payload, true);
+  localStorage.setItem(FH_EVENT_CODE, data.code);
+  // сразу в лобби
+  window.location.href = '/lobby.html';
+}
+
+// ==== Присоединение гостя по коду ====
+async function handleJoinEvent(formEl) {
+  const fd = new FormData(formEl);
+  const code = String(fd.get('code') || '').trim().toUpperCase();
+  const name = String(fd.get('name') || fd.get('guest_name') || '').trim();
+  if (!code || !name) throw new Error('Заполните код и имя');
+  await apiPost('/events-join', { code, name });
+  localStorage.setItem(FH_EVENT_CODE, code);
+  window.location.href = '/lobby.html';
+}
+
+// ==== Рендер лобби ====
+async function loadLobby() {
+  const url = new URL(window.location.href);
+  const code = (url.searchParams.get('code') || localStorage.getItem(FH_EVENT_CODE) || '').toUpperCase();
+  if (!code) { window.location.href = '/'; return; }
+
+  const { event, wishlist, guests } = await apiGet(`/events-get?code=${encodeURIComponent(code)}`);
+
+  // правый блок деталей
+  const right = document.querySelector('#lobby-right');
+  if (right) {
+    right.querySelector('[data-title]').textContent = event.title;
+    right.querySelector('[data-address]').textContent = event.address || '—';
+    right.querySelector('[data-dress]').textContent = event.dress || '—';
+    right.querySelector('[data-bring]').textContent = event.bring || '—';
+    right.querySelector('[data-notes]').textContent = event.notes || '—';
+    right.querySelector('[data-code]').textContent = code;
+
+    const wl = right.querySelector('[data-wishlist]');
+    if (wl) {
+      wl.innerHTML = '';
+      wishlist.forEach(w => {
+        const li = document.createElement('li');
+        li.textContent = w.title || (w.url || 'Пожелание');
+        wl.appendChild(li);
+      });
+      if (wishlist.length === 0) wl.innerHTML = '<li>Список пожеланий пока пуст</li>';
+    }
+
+    // списки гостей
+    const fillList = (sel, arr) => {
+      const ul = right.querySelector(sel);
+      if (ul) {
+        ul.innerHTML = '';
+        (arr || []).forEach(n => {
+          const li = document.createElement('li');
+          li.textContent = n;
+          ul.appendChild(li);
+        });
+        if (!arr || arr.length === 0) ul.innerHTML = '<li>—</li>';
+      }
+    };
+    fillList('[data-guest-yes]', guests.yes);
+    fillList('[data-guest-no]', guests.no);
+    fillList('[data-guest-maybe]', guests.maybe);
+
+    // копирование приглашения
+    const copyBtn = right.querySelector('#copyInviteBtn');
+    if (copyBtn) {
+      copyBtn.onclick = async () => {
+        const invite =
+`Привет! Приглашаю тебя на «${event.title}».
+Когда: ${event.date} ${event.time}
+Где: ${event.address || 'место уточняется'}
+Дресс-код: ${event.dress || 'на твоё усмотрение'}
+
+Чтобы присоединиться, введи код: ${code}
+Или перейди по ссылке: ${location.origin}/?join=${code}`;
+        await navigator.clipboard.writeText(invite);
+        copyBtn.textContent = 'Скопировано!';
+        setTimeout(()=> copyBtn.textContent = 'Скопировать приглашение', 2000);
+      };
+    }
+  }
+
+  // левый блок: счётчик
+  const left = document.querySelector('#lobby-left');
+  if (left) {
+    const big = left.querySelector('[data-countdown-big]');
+    const small = left.querySelector('[data-countdown-small]');
+    const target = new Date(`${event.date}T${(event.time || '00:00')}:00`);
+    const tick = () => {
+      const now = new Date();
+      let diff = target.getTime() - now.getTime();
+      if (diff < 0) diff = 0;
+      const totalMin = Math.floor(diff / 60000);
+      const hours = Math.floor(totalMin / 60);
+      const minutes = totalMin % 60;
+      if (big) big.textContent = `${String(hours).padStart(2,'0')}:${String(minutes).padStart(2,'0')}`;
+
+      const days = Math.floor(diff / 86400000);
+      if (small) {
+        if (days >= 1) {
+          // показываем дату (день и месяц)
+          const d = target.getDate();
+          const m = target.toLocaleString('ru-RU', { month: 'long' });
+          small.textContent = `${d} ${m}`;
+          small.style.display = '';
+        } else {
+          small.style.display = 'none';
+        }
+      }
+    };
+    tick();
+    setInterval(tick, 30000);
+  }
+}
+
+// ==== Привязки к формам (если есть на странице) ====
+document.addEventListener('DOMContentLoaded', () => {
+  const createForm = document.querySelector('form[data-create-event]');
+  if (createForm) createForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try { await handleCreateEvent(createForm); } catch (err) { alert('Ошибка сохранения: ' + err.message); }
+  });
+
+  const joinForm = document.querySelector('form[data-join-event]');
+  if (joinForm) joinForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try { await handleJoinEvent(joinForm); } catch (err) { alert('Ошибка: ' + err.message); }
+  });
+
+  if (document.body.dataset.page === 'lobby') {
+    loadLobby().catch(err => alert('Ошибка загрузки: ' + err.message));
+  }
+});
+

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -1,602 +1,67 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ru">
 <head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>FroggyHub — Лобби</title>
-<link rel="preload" href="assets/frog_idle.png" as="image">
-<link rel="preload" href="assets/frog_jump.png" as="image">
-<link rel="preload" href="assets/stump.png" as="image">
-<style>
-  :root{
-    --dark:#0c3b26; --dark-2:#0f4a31; --text:#103c23; --muted:#3e7053;
-    --water1:#bfe9ff; --water2:#e9f8ff; --shore:#93c47d; --soil:#6b4f3b;
-    --lily:#8fd48d; --lily-dark:#63b36c;
-    --bubble:#e8fbe8; --bubble-bd:#bfe8c5;
-    --brick:#0e5e38; --brick-bd:#0a4a2d; --brick-tx:#e8ffe9;
-    --border:#cfe3d6; --shadow:0 14px 34px rgba(20,80,40,.12);
-  }
-  *{box-sizing:border-box}
-  html,body{height:100%}
-  body{margin:0;font:16px/1.5 ui-sans-serif,system-ui,-apple-system,Inter,Segoe UI,Roboto,Arial;overflow:auto;transition:background .35s ease,color .35s ease}
-  body.scene-intro{background:radial-gradient(120% 120% at 50% 30%, var(--dark-2), var(--dark)); color:#eafff2}
-  body.scene-pond{
-    background:
-      radial-gradient(120% 80% at 50% 22%, var(--water1), var(--water2) 55%, transparent 56%) no-repeat,
-      linear-gradient(180deg, var(--soil) 0 12%, var(--shore) 12% 18%, transparent 18%) top/100% 22vh,
-      linear-gradient(0deg, var(--soil) 0 12%, var(--shore) 12% 18%, transparent 18%) bottom/100% 22vh,
-      radial-gradient(90% 60% at 0% 50%, var(--shore) 0 18%, transparent 19%) left/22vw 100%,
-      radial-gradient(90% 60% at 100% 50%, var(--shore) 0 18%, transparent 19%) right/22vw 100%,
-      linear-gradient(180deg, var(--water2), var(--water1));
-    background-attachment: fixed, scroll, scroll, scroll, scroll, fixed; color:var(--text);
-  }
-  body.scene-final{background:radial-gradient(120% 120% at 50% 30%, var(--dark-2), var(--dark)); color:#eafff2}
-  .wrap{display:grid;grid-template-rows:48vh auto;min-height:100vh;transition:opacity .45s ease}
-  .wrap.fading{opacity:0}
-body.scene-intro .wrap{grid-template-rows:100vh 0}
-body.scene-final .wrap{grid-template-rows:0 100vh}
-  .pond{position:relative}
-  .pads{position:absolute;inset:0;pointer-events:none}
-  body.scene-intro .pads, body.scene-final .pads{display:none}
-  .pad{position:absolute;width:120px;height:120px;transform:translate(-50%,-50%);
-       background:radial-gradient(40% 40% at 30% 30%, var(--lily) 0 60%, var(--lily-dark) 100%);
-       border-radius:50%;box-shadow:0 12px 0 rgba(0,0,0,.06),0 0 0 8px rgba(255,255,255,.35) inset}
-  .ripples{position:absolute;inset:0;pointer-events:none;opacity:.18}
-  .ripples:before,.ripples:after{content:"";position:absolute;left:50%;top:50%;width:70vmin;height:70vmin;border-radius:50%;border:8px solid #fff;transform:translate(-50%,-50%);animation:ripple 7s linear infinite}
-  .ripples:after{animation-delay:3.5s}
-  @keyframes ripple{0%{transform:translate(-50%,-50%) scale(.7);opacity:.25}100%{transform:translate(-50%,-50%) scale(1.3);opacity:0}}
-.stump{display:none;position:absolute;left:50%;top:56%;transform:translate(-50%,-50%);max-width:60vmin;height:auto;pointer-events:none}
-body.scene-intro .stump{display:block}
-#frog{position:absolute;left:50%;top:42%;transform:translate(-50%,-50%);transition:left .45s ease,top .45s ease,transform .2s ease}
-body.scene-pond #frog{top:50%}
-body.scene-final #frog{display:none}
-#frog.turn-left{transform:translate(-50%,-50%) scaleX(-1)}
-  #frog.jump{animation:jump .55s ease}
-  @keyframes jump{0%{transform:translate(-50%,-50%)}35%{transform:translate(-50%,-85%)}100%{transform:translate(-50%,-50%)}}
-  #frog img{width:140px;height:auto;display:block;background:transparent;border:none;padding:0;border-radius:0}
-
-  .speech{position:absolute;left:50%;top:72%;transform:translate(-50%,0);max-width:min(760px,92vw);background:rgba(255,255,255,.12);border:2px solid rgba(255,255,255,.35);border-radius:18px;padding:14px 18px;color:#eafff2;backdrop-filter: blur(2px) saturate(130%);box-shadow:0 10px 0 rgba(0,0,0,.12)}
-  .speech strong{color:#fff}
-  .speech .actions{display:flex;gap:12px;flex-wrap:wrap;margin-top:10px}
-  body.scene-pond .speech{display:none}
-
-  .pill{flex:1;min-width:220px;padding:14px 16px;font-weight:900;cursor:pointer;border:none;border-radius:999px;background:linear-gradient(180deg,#6ad27f,#3db565);color:#092c19;box-shadow:0 14px 0 rgba(0,0,0,.12)}
-  .pill.secondary{background:linear-gradient(180deg,#ffd973,#f0b429);color:#3b2a00}
-
-  .panel{position:relative;padding:22px;margin:18px 5vw 40px;border-radius:22px;background:var(--bubble);border:1px solid var(--bubble-bd);box-shadow:var(--shadow)}
-  body.scene-intro .panel, body.scene-final .panel{display:none}
-
-  .bubble{background:var(--bubble);border:1px solid var(--bubble-bd);border-radius:16px;padding:12px;margin-bottom:12px}
-  .bubble-head{font-weight:800;color:#1c6b3f;margin-bottom:4px}
-  .grid{display:grid;gap:12px}
-  .row2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
-  .brick input,.brick textarea{width:100%;background:var(--brick);color:var(--brick-tx);border:1px solid var(--brick-bd);border-radius:14px;padding:12px 14px;box-shadow:0 0 0 3px rgba(26,122,77,.18) inset,0 10px 20px rgba(8,60,36,.22) inset}
-  .btn{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:14px;border:1px solid rgba(255,255,255,.4);background:linear-gradient(180deg,#58c47a,#2ea85f);color:#fff;cursor:pointer}
-  .btn.ghost{background:#eaffef;color:#1b6c3e;border:1px solid #bde3c7}
-  .btn-group{display:flex;gap:10px;flex-wrap:wrap}
-  .wl-wrap{max-height:50vh;overflow:auto;padding-right:6px}
-  .gridVar{display:grid;grid-template-columns:repeat(5,1fr);gap:8px;background:rgba(255,255,255,.68);border-radius:14px;padding:10px;border:1px solid var(--border)}
-  .cell{aspect-ratio:1/1;border-radius:16px;cursor:pointer;position:relative;background:radial-gradient(45% 45% at 30% 28%, var(--lily) 0 60%, var(--lily-dark) 100%);box-shadow:0 12px 0 rgba(0,0,0,.05),0 0 0 6px rgba(255,255,255,.35) inset;display:grid;place-items:center;color:#0b3b22}
-  .cell .label{font-weight:900;text-align:center;padding:8px 6px;font-size:.9rem}
-  .cell .status{position:absolute;top:8px;left:8px;font-size:.75rem;font-weight:800;padding:4px 8px;border-radius:999px;color:#06301b;background:#fff9}
-  .cell.taken{filter:saturate(60%) brightness(.9)}
-  .cell .action{position:absolute;bottom:8px;left:8px;right:8px;display:flex;justify-content:center}
-  .cell a{display:inline-block;padding:6px 10px;border-radius:12px;background:#fff;border:1px solid #cde8d5;text-decoration:none;font-weight:700;font-size:.82rem}
-  .giftcard{background:#fff;border:1px solid var(--border);border-radius:14px;padding:10px;display:grid;gap:8px}
-  .giftcard .meta{font-size:.85rem;color:var(--muted)}
-  .gift-actions{display:flex;gap:8px;flex-wrap:wrap}
-  .pill-mini{padding:6px 10px;border-radius:999px;font-weight:800;border:none;cursor:pointer}
-  .choose{background:#2ea85f;color:#fff}.unchoose{background:#ff6b6b;color:#fff}.takenTag{background:#ededed;color:#666}
-  dialog{border:1px solid var(--border);border-radius:16px;padding:14px;box-shadow:var(--shadow)}
-  .editor label{display:grid;gap:6px;margin:6px 0}
-  menu{display:flex;gap:10px;justify-content:flex-end;margin:10px 0 0 0;padding:0}
-  .list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-  .list li{background:var(--bubble);border:1px solid var(--bubble-bd);border-radius:12px;padding:10px 12px}
-  .stats{display:flex;gap:12px;flex-wrap:wrap}
-  .stat{background:linear-gradient(180deg,#eaffef,#d7f5e1);border:1px solid #bfe8c5;border-radius:14px;padding:10px 12px;min-width:120px;text-align:center}
-  .num{font-weight:900;font-size:1.5rem}
-  .code-box{font-size:2rem;font-weight:900;background:#eaffef;border:1px solid #bde3c7;display:inline-block;padding:10px 18px;border-radius:12px;margin-top:8px}
-
-  /* mini profile widget */
-  .profile-mini{position:fixed;right:14px;top:14px;z-index:50;background:#ffffffcc;border:1px solid #cfe3d6;border-radius:12px;padding:8px 10px;backdrop-filter:blur(6px);display:flex;gap:8px;align-items:center}
-  .profile-mini b{white-space:nowrap}
-  .profile-mini a,.profile-mini button{all:unset;cursor:pointer;color:#18643a;font-weight:800;padding:4px 6px;border-radius:8px}
-  .profile-mini a:hover,.profile-mini button:hover{background:#eaffef}
-</style>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Лобби — FroggyHub</title>
+  <link rel="stylesheet" href="/style.css" />
 </head>
-<body class="scene-intro">
-<div class="profile-mini" id="miniProfile" hidden>
-  <span>🐸</span><b id="miniName">—</b>
-  <a href="/profile.html" title="Профиль">Профиль</a>
-  <button id="miniLogout" title="Выйти">Выйти</button>
-</div>
+<body data-page="lobby">
+  <header class="fh-header">
+    <a class="fh-logo" href="/">FroggyHub</a>
+    <nav class="fh-nav">
+      <a href="/index.html">Меню</a>
+      <a href="/profile.html">Профиль</a>
+      <button onclick="localStorage.removeItem('FH_JWT');location.href='/'">Выйти</button>
+    </nav>
+  </header>
 
-<div class="wrap" id="root">
-  <section class="pond" id="pond">
-    <div class="ripples" aria-hidden="true"></div>
-    <div class="pads" id="pads"></div>
-    <img id="stumpImg" class="stump" src="assets/stump.png" alt="Пень">
-    <div id="frog" title="Фрогги — проводник"><img id="frogImg" alt="frog" src="assets/frog_idle.png"></div>
-    <div class="speech" id="speech">
-      <div id="speechText"><strong>Фрогги:</strong> Привет! Создать событие или присоединиться?</div>
-      <div class="actions" id="speechActions">
-        <button class="pill" data-next="create">🧪 Создать</button>
-        <button class="pill secondary" data-next="join">🎉 Присоединиться</button>
+  <main class="lobby-grid">
+    <!-- Левая колонка: лягушка + счётчик -->
+    <section id="lobby-left" class="lobby-left">
+      <div class="frog-hero"></div>
+      <div class="countdown">
+        <div class="countdown-big" data-countdown-big>00:00</div>
+        <div class="countdown-small" data-countdown-small>1 января</div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <section class="panel" id="slides">
-    <!-- create: form -->
-    <section id="slide-create-1" hidden>
-      <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Заполни кирпичики — имя, дата/время, адрес.</div></div>
-      <form id="formCreate" class="grid brick">
-        <label>Название события <input id="eventTitle" required placeholder="День рождения (имя)" /></label>
-        <div class="row2">
-          <label>Дата <input id="eventDate" type="date" required /></label>
-          <label>Время <input id="eventTime" type="time" required /></label>
+    <!-- Правая колонка: финальная панель события -->
+    <section id="lobby-right" class="lobby-right card">
+      <h2 data-title>Событие</h2>
+      <div class="event-grid">
+        <div><strong>Код:</strong> <span data-code>—</span> <button id="copyInviteBtn" class="btn">Скопировать приглашение</button></div>
+        <div><strong>Когда:</strong> <span data-when></span></div>
+        <div><strong>Адрес:</strong> <span data-address>—</span></div>
+        <div><strong>Дресс-код:</strong> <span data-dress>—</span></div>
+        <div><strong>Что взять:</strong> <span data-bring>—</span></div>
+        <div><strong>Комментарий:</strong> <span data-notes>—</span></div>
+      </div>
+
+      <h3>Wishlist</h3>
+      <ul class="list" data-wishlist></ul>
+
+      <div class="guests-columns">
+        <div>
+          <h4>Идут</h4>
+          <ul class="list" data-guest-yes></ul>
         </div>
-        <label>Адрес места проведения <input id="eventAddress" placeholder="Улица, дом, город" /></label>
-        <button class="btn" type="submit">Далее • ква!</button>
-      </form>
-    </section>
-
-    <!-- create: wishlist -->
-    <section id="slide-create-wishlist" hidden>
-      <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Клик по кувшинке — впиши предмет или ссылку.</div></div>
-      <div class="wl-wrap"><div id="wlGrid" class="gridVar"></div></div>
-      <div class="bar-actions">
-        <button class="btn" id="addItem">Добавить кувшинку</button>
-        <button class="btn ghost" id="clearWL">Очистить</button>
-        <button class="btn" id="toDetails">Далее • ква!</button>
-      </div>
-      <dialog id="cellEditor">
-        <form method="dialog" class="editor">
-          <h3>Редактор кувшинки</h3>
-          <label>Название/заметка <input id="cellTitle" /></label>
-          <label>Ссылка <input id="cellUrl" placeholder="https://amazon.com/..."/></label>
-          <menu>
-            <button value="cancel" class="btn ghost">Отмена</button>
-            <button id="saveCell" value="default" class="btn">Сохранить</button>
-          </menu>
-        </form>
-      </dialog>
-    </section>
-
-    <!-- create: details -->
-    <section id="slide-create-details" hidden>
-      <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Добавь дресс-код, что взять и как пройти.</div></div>
-      <form id="formDetails" class="grid brick">
-        <label>Дресс-код <input id="eventDress" placeholder="Зелёные акценты" /></label>
-        <label>Что взять <input id="eventBring" placeholder="Настроение, фотоаппарат, закуски" /></label>
-        <label>Как пройти / комментарии <textarea id="eventNotes" rows="3" placeholder="Вход со двора, 3 этаж, домофон 12"></textarea></label>
-        <button class="btn" type="submit">Далее • ква!</button>
-      </form>
-    </section>
-
-    <!-- admin -->
-    <section id="slide-admin" hidden>
-      <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Поделись кодом — и к финалу.</div></div>
-      <p><strong>6-значный код события:</strong></p>
-      <div class="code-box" id="eventCode">—</div>
-      <div class="stats" style="margin-top:12px">
-        <div class="stat"><div class="num" id="stYes">0</div><div>Идут</div></div>
-        <div class="stat"><div class="num" id="stMaybe">0</div><div>Возможно</div></div>
-        <div class="stat"><div class="num" id="stNo">0</div><div>Не идут</div></div>
-      </div>
-      <div style="margin-top:10px">
-        <h3>Вишлист (занято/свободно)</h3>
-        <ul id="adminGifts" class="list"></ul>
-      </div>
-      <div class="bar-actions"><button class="btn" id="finishCreate">Перейти к финалу</button></div>
-    </section>
-
-    <!-- join: enter code -->
-    <section id="slide-join-code" hidden>
-      <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Введи код и прыгай дальше!</div></div>
-      <div class="grid" style="place-items:center">
-        <input id="joinCodeInput" placeholder="Например: 345812"
-               style="max-width:260px;text-align:center;font-weight:800;color:var(--brick-tx); background:var(--brick); border:1px solid var(--brick-bd); border-radius:12px; padding:12px 14px" />
-        <button class="btn" id="joinCodeBtn">Проверить • ква!</button>
-      </div>
-    </section>
-
-    <!-- join: rsvp -->
-    <section id="slide-join-1" hidden>
-      <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Назовись и отметься: идёшь?</div></div>
-      <form id="formJoin" class="grid brick">
-        <label>Ваше имя <input id="guestName" required placeholder="Имя" autocomplete="name"/></label>
-        <div class="btn-group">
-          <button type="button" class="btn" data-rsvp="yes">Ква! Иду</button>
-          <button type="button" class="btn maybe" data-rsvp="maybe">Возможно</button>
-          <button type="button" class="btn no" data-rsvp="no">Увы, не смогу</button>
+        <div>
+          <h4>Не идут</h4>
+          <ul class="list" data-guest-no></ul>
         </div>
-        <button id="toGuestWishlist" class="btn" type="button">Выбрать подарок • ква!</button>
-      </form>
-    </section>
-
-    <!-- join: guest wishlist -->
-    <section id="slide-join-wishlist" hidden>
-      <div class="bubble"><div class="bubble-head">Фрогги:</div>
-        <div class="bubble-body">Выбери один пункт из списка. <strong>Занято</strong> — кто-то уже взял.</div></div>
-      <div id="guestGifts" class="grid" style="gap:10px"></div>
-      <div class="bar-actions">
-        <button class="btn ghost" id="skipWishlist">Пропустить</button>
-        <button class="btn" id="toGuestFinal">Готово • к финалу</button>
-      </div>
-    </section>
-  </section>
-</div>
-
-<script>
-/* ---------- auth mini widget ---------- */
-const TOKEN_KEY='FH_JWT';
-const token=localStorage.getItem(TOKEN_KEY);
-async function loadMiniProfile(){
-  if(!token) return;
-  try{
-    const r=await fetch('/.netlify/functions/profile',{headers:{Authorization:'Bearer '+token}});
-    if(!r.ok) throw new Error('unauth');
-    const {profile}=await r.json();
-    const box=document.getElementById('miniProfile');
-    document.getElementById('miniName').textContent=profile?.nickname||'—';
-    box.hidden=false;
-  }catch(e){ /* ignore */ }
-}
-document.getElementById('miniLogout').onclick=()=>{ localStorage.removeItem(TOKEN_KEY); location.href='/'; };
-loadMiniProfile();
-
-/* API helpers */
-const api = {
-  async createEvent(payload){
-    const r = await fetch('/.netlify/functions/events-create', {
-      method:'POST',
-      headers:{'Content-Type':'application/json', Authorization: 'Bearer '+(localStorage.getItem(TOKEN_KEY)||'')},
-      body: JSON.stringify(payload)
-    });
-    return r.json();
-  },
-  async getEvent(code){
-    const r = await fetch('/.netlify/functions/events-get?code='+encodeURIComponent(code));
-    return r.json();
-  },
-  async rsvp(payload){
-    const r = await fetch('/.netlify/functions/events-rsvp', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
-    return r.json();
-  },
-  async myEvents(){
-    const r = await fetch('/.netlify/functions/events-list', { headers:{ Authorization: 'Bearer '+(localStorage.getItem(TOKEN_KEY)||'') }});
-    return r.json();
-  }
-};
-
-let lastInviteText = '';
-function makeInviteText(ev){
-  const dt = `${ev.date||''} ${ev.time||''}`.trim();
-  const addr = ev.address ? `📍 ${ev.address}` : '';
-  const dress = ev.dress ? `👗 Дресс-код: ${ev.dress}` : '';
-  const bring = ev.bring ? `🧺 Что взять: ${ev.bring}` : '';
-  const notes = ev.notes ? `📝 ${ev.notes}` : '';
-  return `Привет! Приглашаю тебя на «${ev.title}».
-🗓 ${dt}
-${addr}
-${dress}
-${bring}
-${notes}
-
-Код участия: ${ev.code}
-Зайди на FroggyHub и введи код.
-До встречи! 🐸`;
-}
-async function copyInvite(ev){
-  try { await navigator.clipboard.writeText(makeInviteText(ev)); alert('Приглашение скопировано'); }
-  catch { alert('Не удалось скопировать'); }
-}
-
-/* ---------- lobby flow (localStorage prototype) ---------- */
-const FROG_IDLE="assets/frog_idle.png", FROG_JUMP="assets/frog_jump.png", CROAK_URL="assets/croak.mp3";
-const STORAGE='froggyhub_state_v7';
-let eventData = JSON.parse(localStorage.getItem(STORAGE)||'null') || {
-  id:Math.random().toString(36).slice(2,8),
-  title:'',date:'',time:'',address:'',dress:'',bring:'',notes:'',
-  wishlist:Array.from({length:25},(_,i)=>({id:i+1,title:'',url:'',claimedBy:''})),
-  guests:[], code:null
-};
-const save=()=>localStorage.setItem(STORAGE,JSON.stringify(eventData));
-let currentGuestName='';
-let croakAudio=null; try{croakAudio=new Audio(CROAK_URL);croakAudio.volume=.75}catch(e){}
-const croak=()=>{if(!croakAudio)return;try{croakAudio.currentTime=0;croakAudio.play();}catch(e){}}
-const body=document.body, pond=document.getElementById('pond');
-const frog=document.getElementById('frog'), frogImg=document.getElementById('frogImg');
-const padsWrap=document.getElementById('pads');
-const speech=document.getElementById('speech'), speechText=document.getElementById('speechText'), speechActions=document.getElementById('speechActions');
-const root=document.getElementById('root');
-
-function setScene(scene){
-  body.classList.remove('scene-intro','scene-pond','scene-final');
-  body.classList.add(`scene-${scene}`);
-  document.getElementById('slides').style.display=(scene==='pond'||scene==='final')?'block':'none';
-  speech.style.display=(scene==='intro')?'block':'none';
-}
-const stepsCreate=['create-1','create-wishlist','create-details','admin'];
-function renderPads(total=stepsCreate.length){
-  padsWrap.innerHTML='';
-  const H=(pond.getBoundingClientRect().height||480), baseY=H*0.70;
-  for(let i=0;i<total;i++){
-    const pad=document.createElement('div');pad.className='pad';
-    const x=12+(i*(75/(total-1||1)));
-    pad.style.left=x+'%';pad.style.top=(i%2?baseY-60:baseY)+'px';padsWrap.appendChild(pad);
-  }
-}
-function withTransition(next){ root.classList.add('fading'); setTimeout(()=>{ next&&next(); root.classList.remove('fading'); }, 450); }
-function frogJumpToPad(index,faceRight=true){
-  const pad=padsWrap.children[index]; if(!pad) return;
-  const rect=pad.getBoundingClientRect(), stage=document.body.getBoundingClientRect();
-  frog.style.left=(rect.left+rect.width/2-stage.left)+'px';
-  frog.style.top =(rect.top +rect.height*0.52-stage.top )+'px';
-  frog.classList.remove('turn-left'); if(!faceRight) frog.classList.add('turn-left');
-  frogImg.src=FROG_JUMP; frog.classList.remove('jump'); void frog.offsetWidth; frog.classList.add('jump'); croak();
-  setTimeout(()=>{ frogImg.src=FROG_IDLE; },550);
-}
-function showSlide(id){ document.querySelectorAll('#slides > section').forEach(s=>s.hidden=true); document.getElementById('slide-'+id).hidden=false; }
-
-/* intro */
-setScene('intro');
-speechText.innerHTML="<strong>Фрогги:</strong> Привет! Создать событие или присоединиться?";
-speechActions.innerHTML=`<button class="pill" data-next="create">🧪 Создать</button><button class="pill secondary" data-next="join">🎉 Присоединиться</button>`;
-speechActions.onclick=(e)=>{
-  const btn=e.target.closest('button'); if(!btn) return;
-  withTransition(()=>{
-    if(btn.dataset.next==='create'){ setScene('pond'); renderPads(stepsCreate.length); frogJumpToPad(0,true); showSlide('create-1'); }
-    else { setScene('pond'); renderPads(3); frogJumpToPad(0,false); showSlide('join-code'); }
-  });
-};
-
-/* create: step 1 */
-formCreate.addEventListener('submit',(e)=>{
-  e.preventDefault();
-  const title=eventTitle.value.trim(), date=eventDate.value, time=eventTime.value, address=eventAddress.value.trim();
-  if(!title||!date||!time){ alert('Заполни название, дату и время'); return; }
-  Object.assign(eventData,{title,date,time,address}); save();
-  withTransition(()=>{ frogJumpToPad(1,true); showSlide('create-wishlist'); renderGrid(); });
-});
-
-/* wishlist (host) */
-const wlGrid=document.getElementById('wlGrid'), editor=document.getElementById('cellEditor');
-const cellTitle=document.getElementById('cellTitle'), cellUrl=document.getElementById('cellUrl'); let currentCellId=null;
-function renderGrid(){
-  wlGrid.innerHTML=''; wlGrid.style.gridTemplateColumns=`repeat(5,1fr)`;
-  eventData.wishlist.forEach(cell=>{
-    const div=document.createElement('div'); div.className='cell'+(cell.claimedBy?' taken':''); div.dataset.id=cell.id;
-    div.innerHTML=`${cell.claimedBy?'<div class="status">Занято</div>':'<div class="status" style="background:#d8ffdb">Свободно</div>'}
-                   <div class="label">${cell.title||''}</div>
-                   <div class="action">${cell.url?`<a href="${cell.url}" target="_blank" rel="noopener">Открыть</a>`:''}</div>`;
-    div.addEventListener('click',()=>openEditor(cell.id)); wlGrid.appendChild(div);
-  });
-}
-function openEditor(id){ currentCellId=id; const c=eventData.wishlist.find(x=>x.id===id); cellTitle.value=c.title||''; cellUrl.value=c.url||''; editor.showModal?editor.showModal():editor.setAttribute('open',''); }
-saveCell.onclick=()=>{ const c=eventData.wishlist.find(x=>x.id===currentCellId); c.title=cellTitle.value.trim(); c.url=cellUrl.value.trim(); save(); renderGrid(); };
-clearWL.onclick=()=>{ eventData.wishlist.forEach(c=>{c.title='';c.url='';c.claimedBy='';}); save(); renderGrid(); };
-addItem.onclick=()=>{ const nextId=eventData.wishlist.length?Math.max(...eventData.wishlist.map(i=>i.id))+1:1; eventData.wishlist.push({id:nextId,title:'',url:'',claimedBy:''}); save(); renderGrid(); };
-toDetails.onclick=()=>withTransition(()=>{ frogJumpToPad(2,true); showSlide('create-details'); });
-editor.addEventListener('click',e=>{ const r=editor.getBoundingClientRect(); if(e.clientX<r.left||e.clientX>r.right||e.clientY<r.top||e.clientY>r.bottom) editor.close(); });
-
-/* details → admin */
-formDetails.addEventListener('submit', async (e)=>{
-  e.preventDefault();
-  Object.assign(eventData,{dress:eventDress.value.trim(),bring:eventBring.value.trim(),notes:eventNotes.value.trim()});
-
-  // подготовим wishlist для сервера
-  const wishlist = eventData.wishlist.filter(i=>i.title||i.url).map(({title,url})=>({title,url}));
-
-  const payload = { title:eventData.title, date:eventData.date, time:eventData.time, address:eventData.address, dress:eventData.dress, bring:eventData.bring, notes:eventData.notes, wishlist };
-  const res = await api.createEvent(payload);
-  if (!res.ok) { alert('Ошибка сохранения: '+(res.error||'')); return; }
-
-  eventData.code = res.code; eventData.id = res.eventId;
-  save();
-
-  // копировать приглашение (кнопка появится в дашборде тоже)
-  lastInviteText = makeInviteText(eventData);
-  withTransition(()=> openDashboard({ code: eventData.code, role:'host' }));
-});
-function renderAdmin(){
-  eventCode.textContent=eventData.code||'—';
-  const html=(eventData.wishlist.filter(i=>i.title||i.url).map(i=>`${i.title||'Подарок'} — ${i.claimedBy?'🔒 занято':'🟢 свободно'} ${i.url?`• <a href="${i.url}" target="_blank">ссылка</a>`:''}`)).map(s=>`<li>${s}</li>`).join('');
-  adminGifts.innerHTML=html||'<li>Вишлист пуст</li>';
-}
-finishCreate.onclick=()=>withTransition(()=>toFinalScene('host'));
-
-/* join: code → rsvp */
-joinCodeBtn.onclick = async ()=>{
-  const v = (joinCodeInput.value||'').trim();
-  if(!v){ alert('Введите код'); return; }
-  const res = await api.getEvent(v);
-  if (!res.ok) { alert('Код не найден'); return; }
-  eventData.code = v;
-  eventData.title = res.event.title; eventData.date=res.event.date; eventData.time=res.event.time;
-  eventData.address=res.event.address; eventData.dress=res.event.dress; eventData.bring=res.event.bring; eventData.notes=res.event.notes;
-  eventData.wishlist = (res.wishlist||[]).map(i=>({ id:i.id, title:i.title, url:i.url, claimedBy:i.claimed_by||'' }));
-  save();
-  withTransition(()=>{ showSlide('join-1'); renderPads(3); frogJumpToPad(1,false); });
-};
-
-/* RSVP + guest wishlist */
-document.querySelectorAll('[data-rsvp]').forEach(b=>b.addEventListener('click',async e=>{
-  const code=e.currentTarget.dataset.rsvp, name=(guestName.value||'').trim();
-  if(!name){alert('Введите имя');return;}
-  currentGuestName=name;
-  const ex=eventData.guests.find(g=>g.name.toLowerCase()===name.toLowerCase());
-  if(ex) ex.rsvp=code; else eventData.guests.push({name,rsvp:code});
-  save();
-  await api.rsvp({ code: eventData.code, name: currentGuestName, rsvp: code });
-  croak();
-}));
-toGuestWishlist.onclick=()=>{
-  const name=(guestName.value||'').trim(); if(!name){alert('Введите имя и статус');return;}
-  currentGuestName=name; withTransition(()=>{ showSlide('join-wishlist'); renderGuestWishlist(); frogJumpToPad(2,false); });
-};
-const guestGifts=document.getElementById('guestGifts');
-function renderGuestWishlist(){
-  const items=eventData.wishlist.filter(i=>i.title||i.url);
-  guestGifts.innerHTML=items.map(item=>{
-    const me=item.claimedBy && item.claimedBy.toLowerCase()===currentGuestName.toLowerCase();
-    const taken=!!item.claimedBy && !me;
-    const status=taken?`<span class="pill-mini takenTag">Занято</span>`:me?`<span class="pill-mini" style="background:#d8ffdb;color:#0b3b22">Вы выбрали</span>`:`<span class="pill-mini" style="background:#fff8c6;color:#614a00">Свободно</span>`;
-    const chooseBtn=taken?'': me ? `<button data-id="${item.id}" class="pill-mini unchoose">Снять выбор</button>` : `<button data-id="${item.id}" class="pill-mini choose">Выбрать</button>`;
-    const link=item.url?` • <a href="${item.url}" target="_blank" rel="noopener">ссылка</a>`:'';
-    return `<div class="giftcard"><div><strong>${item.title||'Подарок'}</strong><span class="meta">${link}</span></div><div class="gift-actions">${status}${chooseBtn}</div></div>`;
-  }).join('');
-  guestGifts.querySelectorAll('.choose').forEach(b=>b.addEventListener('click',async e=>{
-    const id=+e.currentTarget.dataset.id; const it=eventData.wishlist.find(x=>x.id===id);
-    if(it.claimedBy && it.claimedBy.toLowerCase()!==currentGuestName.toLowerCase()){ alert('Этот подарок уже выбрали'); return; }
-    eventData.wishlist.forEach(x=>{ if(x.claimedBy && x.claimedBy.toLowerCase()===currentGuestName.toLowerCase()) x.claimedBy=''; });
-    it.claimedBy=currentGuestName; save(); renderGuestWishlist();
-    await api.rsvp({ code: eventData.code, name: currentGuestName, claimItemId: id });
-  }));
-  guestGifts.querySelectorAll('.unchoose').forEach(b=>b.addEventListener('click',async e=>{
-    const id=+e.currentTarget.dataset.id; const it=eventData.wishlist.find(x=>x.id===id);
-    if(it.claimedBy && it.claimedBy.toLowerCase()===currentGuestName.toLowerCase()){ it.claimedBy=''; save(); renderGuestWishlist(); await api.rsvp({ code: eventData.code, name: currentGuestName, unclaimItemId: id }); }
-  }));
-}
-skipWishlist.onclick=()=>withTransition(()=>toFinalScene('guest'));
-toGuestFinal.onclick=()=>withTransition(()=>toFinalScene('guest'));
-
-/* final */
-function toFinalScene(role){
-  setScene('final');
-
-  const leftHTML = `
-    <div style="display:grid;place-items:center;height:100vh">
-      <div style="text-align:center">
-        <div id="bigClock" style="font-weight:900;font-size:64px;line-height:1;margin-bottom:6px">--:--</div>
-        <div id="bigDate" style="font-weight:700;opacity:.9">—</div>
-        <img src="assets/stump.png" alt="" style="width:48vmin;max-width:420px;margin-top:16px;filter:drop-shadow(0 16px 28px rgba(0,0,0,.25))">
-        <img src="assets/frog_idle.png" alt="" style="position:relative;top:-18vmin;width:22vmin">
-      </div>
-    </div>`;
-
-  const addr = eventData.address ? `<a href="https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(eventData.address)}" target="_blank" rel="noopener">${eventData.address}</a>` : '—';
-  const chosen = eventData.wishlist.filter(i=>i.claimedBy).length;
-  const totalWL = eventData.wishlist.filter(i=>i.title||i.url).length;
-
-  const rightHTML = `
-    <div style="padding:24px 26px">
-      <h1 style="margin:0 0 8px 0">${eventData.title||'Событие'}</h1>
-      <div class="bubble">
-        <div class="bubble-head">Детали</div>
-        <div>🗓 ${eventData.date||'—'} • ⏰ ${eventData.time||'—'}</div>
-        <div>📍 ${addr}</div>
-        <div>👗 ${eventData.dress||'—'}</div>
-        <div>🧺 ${eventData.bring||'—'}</div>
-        ${eventData.notes?`<div>📝 ${eventData.notes}</div>`:''}
-      </div>
-
-      <div class="bubble">
-        <div class="bubble-head">Вишлист</div>
-        <div>Занято: ${chosen} • Свободно: ${Math.max(0,totalWL - chosen)}</div>
-      </div>
-
-      <div class="btn-group">
-        <button class="btn" id="btnCopyInvite">Скопировать приглашение</button>
-        <button class="btn ghost" id="btnToLobby">Перейти в лобби</button>
-      </div>
-    </div>`;
-
-  document.getElementById('slides').innerHTML = `
-    <section style="display:grid;grid-template-columns:1fr min(760px,60vw);gap:24px;height:100%">
-      <div>${leftHTML}</div>
-      <div>${rightHTML}</div>
-    </section>`;
-
-  const bigClock = document.getElementById('bigClock'), bigDate = document.getElementById('bigDate');
-  function tick(){
-    const now = new Date();
-    const t = new Date(`${eventData.date}T${eventData.time}`) - now;
-    if (isNaN(t)) { bigClock.textContent='--:--'; bigDate.textContent='—'; return; }
-    const H = Math.max(0, Math.floor((t % 86400000) / 3600000));
-    const M = Math.max(0, Math.floor((t % 3600000) / 60000));
-    bigClock.textContent = `${String(H).padStart(2,'0')}:${String(M).padStart(2,'0')}`;
-    const days = Math.floor(t/86400000);
-    if (days >= 1) {
-      const d = new Date(`${eventData.date}T00:00:00`);
-      const mName = d.toLocaleString('ru-RU',{ month:'long' });
-      bigDate.textContent = `${d.getDate()} ${mName}`;
-      bigDate.style.display = '';
-    } else {
-      bigDate.style.display = 'none';
-    }
-  }
-  tick(); clearInterval(window._clock); window._clock = setInterval(tick, 1000);
-
-document.getElementById('btnCopyInvite').onclick = ()=> copyInvite(eventData);
-document.getElementById('btnToLobby').onclick = ()=> openDashboard({ code: eventData.code, role: role==='host'?'host':'guest' });
-}
-
-async function openDashboard({ code, role }){
-  setScene('pond'); // фон как в лобби
-  const box = document.getElementById('slides');
-  box.innerHTML = `
-    <section id="slide-dashboard">
-      <div class="bubble"><div class="bubble-head">Лобби</div>
-        <div class="btn-group">
-          <button class="btn" id="backToMenu">Вернуться в меню</button>
-          <button class="btn" id="copyInviteDash">Скопировать приглашение</button>
+        <div>
+          <h4>Может быть</h4>
+          <ul class="list" data-guest-maybe></ul>
         </div>
       </div>
-      <div id="dashBody" class="grid"></div>
-    </section>`;
-  document.getElementById('backToMenu').onclick = ()=>{ location.href='/lobby.html'; };
-  document.getElementById('copyInviteDash').onclick = ()=> copyInvite(eventData);
 
-  const data = await api.getEvent(code);
-  if (!data.ok){ box.querySelector('#dashBody').innerHTML = `<div class="bubble">Код не найден</div>`; return; }
-
-  // синхронизируем локальное
-  eventData.code = code;
-  eventData.title = data.event.title; eventData.date=data.event.date; eventData.time=data.event.time;
-  eventData.address=data.event.address; eventData.dress=data.event.dress; eventData.bring=data.event.bring; eventData.notes=data.event.notes;
-  eventData.wishlist = data.wishlist.map(i=>({ id:i.id, title:i.title, url:i.url, claimedBy:i.claimed_by||'' }));
-  save();
-
-  const yes = (data.guests||[]).filter(g=>g.rsvp==='yes').map(g=>g.name);
-  const no  = (data.guests||[]).filter(g=>g.rsvp==='no').map(g=>g.name);
-  const maybe = (data.guests||[]).filter(g=>g.rsvp==='maybe').map(g=>g.name);
-
-  document.getElementById('dashBody').innerHTML = `
-    <div class="grid" style="grid-template-columns:1fr 1fr;gap:16px">
-      <div class="bubble"><div class="bubble-head">Событие</div>
-        <div><strong>${data.event.title}</strong></div>
-        <div>Код: <code>${data.event.code}</code></div>
-        <div>Дата: ${data.event.date} • ${data.event.time}</div>
-        <div>Адрес: ${data.event.address||'—'}</div>
+      <div class="actions">
+        <a class="btn" href="/index.html">Вернуться в меню</a>
       </div>
-      <div class="bubble"><div class="bubble-head">Статистика</div>
-        <div class="stats">
-          <div class="stat"><div class="num">${yes.length}</div><div>Идут</div></div>
-          <div class="stat"><div class="num">${maybe.length}</div><div>Возможно</div></div>
-          <div class="stat"><div class="num">${no.length}</div><div>Не идут</div></div>
-        </div>
-      </div>
-      <div class="bubble"><div class="bubble-head">Иду</div><ul class="list">${yes.map(n=>`<li>${n}</li>`).join('') || '<li>—</li>'}</ul></div>
-      <div class="bubble"><div class="bubble-head">Не иду</div><ul class="list">${no.map(n=>`<li>${n}</li>`).join('') || '<li>—</li>'}</ul></div>
-      <div class="bubble" style="grid-column:1 / -1">
-        <div class="bubble-head">Вишлист</div>
-        <div class="grid" style="grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:10px">
-          ${eventData.wishlist.map(i=>{
-            const tag = i.claimedBy ? `<span class=\"pill-mini takenTag\">Занято: ${i.claimedBy}</span>` : `<span class=\"pill-mini\" style=\"background:#d8ffdb;color:#0b3b22\">Свободно</span>`;
-            const link = i.url ? ` • <a href=\"${i.url}\" target=\"_blank\" rel=\"noopener\">ссылка</a>` : '';
-            return `<div class=\"giftcard\"><div><strong>${i.title||'Подарок'}</strong><span class=\"meta\">${link}</span></div><div>${tag}</div></div>`;
-          }).join('')}
-        </div>
-      </div>
-    </div>`;
-}
+    </section>
+  </main>
 
-/* start */
-function initIntro(){ renderPads(3); }
-initIntro();
-window.addEventListener('resize',()=>{ if(body.classList.contains('scene-pond')) renderPads(); });
-</script>
+  <script src="/app.js" type="module"></script>
 </body>
 </html>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -359,3 +359,85 @@ body.scene-intro .speech{display:block}
   box-shadow:none;
   cursor:default;
 }
+
+/* Lobby layout */
+.lobby-grid {
+  display: grid;
+  grid-template-columns: 1fr minmax(420px, 700px);
+  gap: 24px;
+  padding: 24px;
+  align-items: start;
+}
+
+.lobby-left {
+  position: relative;
+  min-height: 420px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.frog-hero {
+  width: 100%;
+  min-height: 360px;
+  background: url('/img/frog-stump.svg') center/contain no-repeat;
+  filter: drop-shadow(0 8px 16px rgba(0,0,0,.25));
+}
+
+.countdown {
+  position: absolute;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  text-align: center;
+}
+
+.countdown-big {
+  font-size: clamp(40px, 8vw, 72px);
+  line-height: 1;
+  font-weight: 800;
+}
+
+.countdown-small {
+  margin-top: 6px;
+  opacity: .85;
+}
+
+.lobby-right.card {
+  background: rgba(255,255,255,.06);
+  border-radius: 16px;
+  padding: 20px;
+  backdrop-filter: blur(6px);
+}
+
+.event-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.guests-columns {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.list { margin: 8px 0; padding-left: 18px; }
+.list li { margin: 3px 0; }
+
+.btn {
+  display: inline-block;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: #2ea44f;
+  color: #fff;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+}
+
+.fh-header { display:flex; justify-content:space-between; align-items:center; padding:12px 20px; }
+.fh-logo { font-weight:800; text-decoration:none; }
+.fh-nav a, .fh-nav button { margin-left:12px; }

--- a/netlify/functions/_auth.js
+++ b/netlify/functions/_auth.js
@@ -42,19 +42,33 @@ export function getBearerToken(event) {
 }
 
 // Обёртка для защищённых хендлеров
-export function requireAuth(handler) {
-  return async (event, context) => {
-    if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors(), body: '' };
-    try {
-      const token = getBearerToken(event);
-      if (!token) return err('Unauthorized', 401);
-      const claims = verifyToken(token);
-      // прокинем user в context
-      context.user = claims;
-      return handler(event, context);
-    } catch (e) {
-      return err('Unauthorized', 401);
-    }
-  };
+export function requireAuth(arg) {
+  // Если передали обработчик, вернём враппер (старый синтаксис)
+  if (typeof arg === 'function') {
+    const handler = arg;
+    return async (event, context = {}) => {
+      if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors(), body: '' };
+      try {
+        const token = getBearerToken(event);
+        if (!token) return err('Unauthorized', 401);
+        const claims = verifyToken(token);
+        context.user = claims;
+        return handler(event, context);
+      } catch (e) {
+        return err('Unauthorized', 401);
+      }
+    };
+  }
+
+  // Иначе считаем, что передали событие и просто вернём распарсенный токен
+  const event = arg;
+  try {
+    const token = getBearerToken(event);
+    if (!token) return null;
+    const claims = verifyToken(token);
+    return { user: claims };
+  } catch {
+    return null;
+  }
 }
 

--- a/netlify/functions/events-create.js
+++ b/netlify/functions/events-create.js
@@ -1,44 +1,60 @@
-// ESM
-import jwt from 'jsonwebtoken';
+// netlify/functions/events-create.js
 import { getServiceClient } from './_supabase.js';
+import { cors, ok, err, requireAuth } from './_auth.js';
 
-const getUserId = (event) => {
-  const h = event.headers?.authorization || '';
-  const t = h.startsWith('Bearer ') ? h.slice(7) : null;
-  if (!t) return null;
-  try { return jwt.verify(t, process.env.JWT_SECRET).sub; } catch { return null; }
-};
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors() };
+  if (event.httpMethod !== 'POST') return err('Method not allowed', 405);
 
-const genCode = () => (Math.floor(100000 + Math.random()*900000)).toString();
-
-export const handler = async (event) => {
-  if (event.httpMethod !== 'POST') return { statusCode: 405, body: 'Method not allowed' };
-  const uid = getUserId(event);
-  if (!uid) return { statusCode: 401, body: 'Unauthorized' };
-
-  const sb = getServiceClient();
-  const { title, date, time, address, dress, bring, notes, wishlist = [] } = JSON.parse(event.body || '{}');
+  const auth = await requireAuth(event);
+  if (!auth || !auth.user?.sub) return err('Unauthorized', 401);
 
   try {
-    // уникальный код
-    let code; for (let i=0;i<7;i++){ code = genCode();
-      const { data:ex } = await sb.from('events').select('id').eq('code', code).maybeSingle();
-      if (!ex) break; code=null;
+    const payload = JSON.parse(event.body || '{}');
+    const { title, date, time, address, dress, bring, notes, wishlist = [] } = payload;
+    if (!title || !date || !time) return err('Missing required fields', 400);
+
+    const sb = getServiceClient();
+
+    // сгенерировать уникальный 6-символьный код
+    let code;
+    for (let i = 0; i < 6; i++) {
+      code = Math.random().toString(36).slice(2, 8).toUpperCase();
+      const { data: exists } = await sb.from('events').select('id').eq('code', code).maybeSingle();
+      if (!exists) break;
     }
-    if (!code) throw new Error('Failed to generate code');
 
-    const { data: ev, error } = await sb.from('events')
-      .insert({ code, host_user_id: uid, title, date, time, address, dress, bring, notes })
-      .select('id, code').single();
-    if (error) throw error;
+    // создать событие
+    const { data: evt, error: e1 } = await sb
+      .from('events')
+      .insert({
+        code,
+        host_user_id: auth.user.sub,
+        title,
+        date,
+        time,
+        address: address || null,
+        dress: dress || null,
+        bring: bring || null,
+        notes: notes || null
+      })
+      .select('id, code, title, date, time, address, dress, bring, notes, host_user_id, created_at')
+      .single();
+    if (e1) throw e1;
 
+    // вишлист (bulk insert, если есть)
     if (Array.isArray(wishlist) && wishlist.length) {
-      const rows = wishlist.map(i => ({ event_id: ev.id, title: i.title || '', url: i.url || '' }));
-      await sb.from('wishlist_items').insert(rows);
+      const rows = wishlist.map(w => ({
+        event_id: evt.id,
+        title: w?.title || null,
+        url: w?.url || null
+      }));
+      const { error: e2 } = await sb.from('wishlist_items').insert(rows);
+      if (e2) throw e2;
     }
 
-    return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ok:true, code: ev.code, eventId: ev.id }) };
+    return ok({ ok: true, code: evt.code, eventId: evt.id, event: evt }, 201);
   } catch (e) {
-    return { statusCode: 200, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ok:false, error: e.message }) };
+    return err(e.message || 'Failed to create event', 500);
   }
-};
+}

--- a/netlify/functions/events-get.js
+++ b/netlify/functions/events-get.js
@@ -1,21 +1,36 @@
+// netlify/functions/events-get.js
 import { getServiceClient } from './_supabase.js';
+import { cors, ok, err } from './_auth.js';
 
-export const handler = async (event) => {
-  const code = event.queryStringParameters?.code || JSON.parse(event.body||'{}').code;
-  if (!code) return { statusCode: 400, body: 'code required' };
-  const sb = getServiceClient();
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors() };
+
+  const code = (event.queryStringParameters?.code || '').toUpperCase();
+  if (!code) return err('Code required', 400);
 
   try {
-    const { data: ev, error } = await sb.from('events').select('id, code, title, date, time, address, dress, bring, notes, created_at, host_user_id').eq('code', code).single();
-    if (error) throw error;
+    const sb = getServiceClient();
 
-    const [{ data: wl }, { data: guests }] = await Promise.all([
-      sb.from('wishlist_items').select('id, title, url, claimed_by').eq('event_id', ev.id).order('id'),
-      sb.from('guests').select('id, name, rsvp, created_at').eq('event_id', ev.id).order('created_at')
+    const { data: evt, error } = await sb
+      .from('events')
+      .select('id, code, title, date, time, address, dress, bring, notes, host_user_id, created_at')
+      .eq('code', code)
+      .single();
+    if (error || !evt) return err('Код не найден', 404);
+
+    const [{ data: wl = [] }, { data: g = [] }] = await Promise.all([
+      sb.from('wishlist_items').select('id, title, url, claimed_by').eq('event_id', evt.id),
+      sb.from('guests').select('id, name, rsvp, created_at').eq('event_id', evt.id).order('created_at', { ascending: true })
     ]);
 
-    return { statusCode: 200, headers:{'Content-Type':'application/json'}, body: JSON.stringify({ ok:true, event: ev, wishlist: wl||[], guests: guests||[] }) };
+    const guests = {
+      yes: g.filter(x => x.rsvp === 'yes').map(x => x.name),
+      no: g.filter(x => x.rsvp === 'no').map(x => x.name),
+      maybe: g.filter(x => x.rsvp === 'maybe').map(x => x.name),
+    };
+
+    return ok({ ok: true, event: evt, wishlist: wl, guests });
   } catch (e) {
-    return { statusCode: 200, headers:{'Content-Type':'application/json'}, body: JSON.stringify({ ok:false, error: e.message }) };
+    return err(e.message || 'Failed to load', 500);
   }
-};
+}

--- a/netlify/functions/events-join.js
+++ b/netlify/functions/events-join.js
@@ -1,0 +1,28 @@
+// netlify/functions/events-join.js
+import { getServiceClient } from './_supabase.js';
+import { cors, ok, err } from './_auth.js';
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors() };
+  if (event.httpMethod !== 'POST') return err('Method not allowed', 405);
+
+  try {
+    const { code, name } = JSON.parse(event.body || '{}');
+    if (!code || !name) return err('Code and name required', 400);
+
+    const sb = getServiceClient();
+    const { data: evt, error } = await sb.from('events').select('id').eq('code', code.toUpperCase()).single();
+    if (error || !evt) return err('Код не найден', 404);
+
+    const { data: g, error: e2 } = await sb
+      .from('guests')
+      .insert({ event_id: evt.id, name, rsvp: 'maybe' })
+      .select('id')
+      .single();
+    if (e2) throw e2;
+
+    return ok({ ok: true, guestId: g.id, eventId: evt.id });
+  } catch (e) {
+    return err(e.message || 'Failed to join', 500);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "serve:functions": "netlify functions:serve",
     "test": "npm run test:syntax",
-    "test:syntax": "node --check FroggyHub/app.js && node --check FroggyHub/event-analytics.js && node --check netlify/functions/_auth.js && node --check netlify/functions/db-ping.js && node --check netlify/functions/local-login.js && node --check netlify/functions/local-signup.js && node --check netlify/functions/profile.js && node --check netlify/functions/events-create.js && node --check netlify/functions/events-get.js && node --check netlify/functions/events-rsvp.js && node --check netlify/functions/events-list.js"
+    "test:syntax": "node --check FroggyHub/app.js && node --check FroggyHub/event-analytics.js && node --check netlify/functions/_auth.js && node --check netlify/functions/db-ping.js && node --check netlify/functions/local-login.js && node --check netlify/functions/local-signup.js && node --check netlify/functions/profile.js && node --check netlify/functions/events-create.js && node --check netlify/functions/events-get.js && node --check netlify/functions/events-join.js && node --check netlify/functions/events-rsvp.js && node --check netlify/functions/events-list.js"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- implement Netlify functions to create, fetch, and join events backed by Supabase and JWT auth
- add lobby page with frog countdown, wishlist and guest lists
- extend frontend with helpers for creating/joining events and lobby rendering
- include lobby styles and update auth helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5553241188332bcb8a95a42ad64c0