### PR TITLE
feat(ui): unify inputs/buttons and add cookies card; theme = green

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -6,6 +6,10 @@ const setToken = t => localStorage.setItem(TOKEN_KEY, t);
 const getToken = () => localStorage.getItem(TOKEN_KEY);
 const clearToken = () => localStorage.removeItem(TOKEN_KEY);
 
+document.querySelectorAll('input, textarea, select').forEach(el=>{
+  el.classList.add('input');
+});
+
 function toast(msg, type='info'){
   console[type==='error'?'error':'log']('[toast]', msg);
   try { window.showToast?.(msg, type); } catch {}
@@ -1273,7 +1277,6 @@ function renderAdmin(){
 }
 $('#finishCreate')?.addEventListener('click',()=>withTransition(()=>toFinalScene()));
 
-$('#copyCodeBtn')?.addEventListener('click', ()=>shareInvite(eventData.join_code));
 
 /* ПРИСОЕДИНЕНИЕ ПО КОДУ */
 async function authHeader(){
@@ -1514,12 +1517,11 @@ function toFinalScene(){
     <div style="margin-top:6px"><strong>Подарки:</strong> Занято — <b>${chosen}</b>, Свободно — <b>${Math.max(0,totalW-chosen)}</b></div>
   `;
   $('#fShare').innerHTML = `
-    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-      <div>Код события: <span class="pill-mini" style="background:#1b4a33">${eventData.join_code||'—'}</span></div>
-      <button class="btn small" id="copyCodeBtn">Поделиться</button>
+    <div class="codeRow">
+      <span id="eventCodeText">Код: <strong id="eventCode">${eventData.join_code||'—'}</strong></span>
+      <button class="btn btn--ghost btn--sm" id="copyInviteBtn">Скопировать приглашение</button>
     </div>
   `;
-  document.getElementById('copyCodeBtn')?.addEventListener('click', () => shareInvite(eventData.join_code));
 
   function tickClock(){
     const dt = getEventDate();
@@ -2165,5 +2167,32 @@ async function loadWishlist(eventId){
     list.appendChild(div);
   });
 }
+
+document.querySelectorAll('#copyInviteBtn').forEach(copyBtn => {
+  copyBtn.addEventListener('click', async () => {
+    const code = (copyBtn.closest('.codeRow')?.querySelector('#eventCode')?.textContent || '').trim();
+    if (!code) return;
+    const msg = `Привет! Приглашаю тебя на моё мероприятие 🎉\n\nКод для входа: ${code}\nОткрой https://froggyhubapp.netlify.app и введи код на главной странице.\n\nЖду тебя! 🐸`;
+    try {
+      await navigator.clipboard.writeText(msg);
+      copyBtn.textContent = 'Скопировано!';
+      setTimeout(()=>copyBtn.textContent = 'Скопировать приглашение', 2000);
+    } catch {
+      alert('Не удалось скопировать. Скопируй вручную:\n\n' + msg);
+    }
+  });
+});
+
+(() => {
+  const KEY = 'fh_cookies_accepted_v1';
+  const el = document.getElementById('cookieCard');
+  if (!el) return;
+  if (!localStorage.getItem(KEY)) el.style.display = 'flex';
+  const ok = document.getElementById('cookieAccept');
+  const no = document.getElementById('cookieDecline');
+  const close = () => { localStorage.setItem(KEY, '1'); el.style.display = 'none'; };
+  ok?.addEventListener('click', close);
+  no?.addEventListener('click', close);
+})();
 
 

--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -20,8 +20,8 @@
         </div>
       </div>
       <div class="bar-actions">
-        <button class="btn ghost small" id="backBtn" aria-label="Назад в меню">Назад</button>
-        <button class="btn small" id="editEventBtn" aria-label="Редактировать событие">Редактировать событие</button>
+        <button class="btn btn--ghost btn--sm" id="backBtn" aria-label="Назад в меню">Вернуться в меню</button>
+        <button class="btn btn--primary btn--sm" id="editEventBtn" aria-label="Редактировать событие">Изменить</button>
       </div>
     </div>
 
@@ -57,6 +57,19 @@
 
     <p id="error" class="error" role="status" aria-live="polite"></p>
   </main>
+  <div id="cookieCard" class="card" style="display:none">
+    <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
+      <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
+    </svg>
+    <div class="cookieHeading">Cookies</div>
+    <div class="cookieDescription">
+      Мы используем файлы cookies, чтобы сайт работал быстрее и удобнее. Продолжая, вы соглашаетесь с их использованием.
+    </div>
+    <div class="buttonContainer">
+      <button class="btn btn--primary acceptButton" id="cookieAccept">Ок</button>
+      <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
+    </div>
+  </div>
   <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
   <script>
     window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -32,7 +32,7 @@
         <input id="editBring" />
       </label>
       <div class="save-row">
-        <button id="saveEvent" type="submit" class="btn primary">Сохранить</button>
+        <button id="saveEvent" type="submit" class="btn btn--primary">Сохранить</button>
       </div>
     </form>
     <p id="editError" class="error" role="status" aria-live="polite"></p>
@@ -47,5 +47,19 @@
     window.createSupabaseClient = createClient;
   </script>
   <script type="module" src="app.js"></script>
+  <div id="cookieCard" class="card" style="display:none">
+    <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
+      <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
+    </svg>
+    <div class="cookieHeading">Cookies</div>
+    <div class="cookieDescription">
+      Мы используем файлы cookies, чтобы сайт работал быстрее и удобнее. Продолжая, вы соглашаетесь с их использованием.
+    </div>
+    <div class="buttonContainer">
+      <button class="btn btn--primary acceptButton" id="cookieAccept">Ок</button>
+      <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
+    </div>
+  </div>
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
 </body>
 </html>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -9,20 +9,20 @@
 <body>
   <div id="mini-profile" style="position:absolute;top:10px;right:10px;text-align:right;">
     Ник: <span id="mp-nick"></span>, Создан: <span id="mp-created"></span>
-    <button id="hub-logout" class="btn small">Выйти</button>
+    <button id="hub-logout" class="btn btn--ghost btn--sm">Выйти</button>
   </div>
   <main class="container" role="main">
     <div class="card" style="max-width:760px;margin:40px auto">
       <h1>Хаб</h1>
       <div class="grid">
         <div class="card inner">
-          <a class="btn" href="/event-edit.html" data-action="create">Создать ивент</a>
+          <a class="btn btn--primary" href="/event-edit.html" data-action="create">Создать событие</a>
         </div>
         <div class="card inner">
           <h3>Войти в ивент</h3>
           <div class="row2">
             <input data-input="join-code" placeholder="Код или ссылка" />
-            <button class="btn" data-action="join">Войти</button>
+            <button class="btn btn--primary" data-action="join">Присоединиться</button>
           </div>
         </div>
       </div>
@@ -39,6 +39,19 @@
   </script>
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
   <script defer src="app.js"></script>
+  <div id="cookieCard" class="card" style="display:none">
+    <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
+      <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
+    </svg>
+    <div class="cookieHeading">Cookies</div>
+    <div class="cookieDescription">
+      Мы используем файлы cookies, чтобы сайт работал быстрее и удобнее. Продолжая, вы соглашаетесь с их использованием.
+    </div>
+    <div class="buttonContainer">
+      <button class="btn btn--primary acceptButton" id="cookieAccept">Ок</button>
+      <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
+    </div>
+  </div>
   <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
 </body>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -35,8 +35,8 @@
           <label>Пароль
             <input id="login-password" type="password" placeholder="••••••••" minlength="4" required autocomplete="current-password">
           </label>
-          <button class="btn primary" id="login-btn" type="submit">Войти</button>
-          <button type="button" class="btn" id="showReset" data-forgot="false">Забыли пароль?</button>
+            <button class="btn btn--primary" id="login-btn" type="submit">Войти</button>
+            <button type="button" class="btn btn--ghost" id="showReset" data-forgot="false">Забыли пароль?</button>
           <div id="resetPassBlock" class="grid is-hidden">
             <label>Новый пароль
               <input id="resetPass" type="password" minlength="4" autocomplete="new-password">
@@ -60,7 +60,7 @@
           <label>Повтор пароля
             <input id="signup-password2" type="password" required minlength="4" autocomplete="new-password">
           </label>
-          <button id="signup-btn" class="btn primary" type="submit">Зарегистрироваться</button>
+            <button id="signup-btn" class="btn btn--primary" type="submit">Зарегистрироваться</button>
           <div id="reg-status" aria-live="polite"></div>
         </form>
       </section>
@@ -77,18 +77,18 @@
           <div class="chips">
             <span class="chip">Шаг 2</span>
             <span class="pill" data-user-badge>гость</span>
-            <button class="btn ghost small" id="logout-btn" data-action="logout" title="Выйти">Выйти</button>
+              <button class="btn btn--ghost btn--sm" id="logout-btn" data-action="logout" title="Выйти">Выйти</button>
           </div>
         </div>
       </div>
 
       <div class="grid">
-        <button class="btn primary" id="goCreate" data-requires-auth data-action="create-event">🧪 Создать ивент</button>
+          <button class="btn btn--primary btn--lg" id="goCreate" data-requires-auth data-action="create-event">Создать событие</button>
         <div class="card inner">
           <h3>Присоединиться к ивенту</h3>
           <div class="row2">
             <input id="join-code" placeholder="Введите 6-значный код" inputmode="numeric" pattern="\d*" autocomplete="one-time-code" maxlength="6">
-            <button class="btn" id="join-btn" data-action="join-event" disabled>🎉 Присоединиться</button>
+            <button class="btn btn--ghost" id="join-btn" data-action="join-event" disabled>Присоединиться</button>
           </div>
         </div>
       </div>
@@ -180,7 +180,7 @@
               <label>Время <input id="eventTime" type="time" required /></label>
             </div>
             <label>Адрес <input id="eventAddress" placeholder="Улица, дом, город" /></label>
-            <button class="btn" type="submit">Далее</button>
+            <button class="btn btn--primary" type="submit">Далее</button>
           </form>
         </section>
 
@@ -189,9 +189,9 @@
           <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Добавьте пожелания.</div></div>
           <div class="wl-wrap"><div id="wlGrid" class="gridVar"></div></div>
           <div class="bar-actions">
-            <button class="btn" id="addItem">Добавить</button>
-            <button class="btn ghost" id="clearWL">Очистить</button>
-            <button class="btn" id="toDetails">Далее</button>
+            <button class="btn btn--primary" id="addItem">Добавить</button>
+            <button class="btn btn--ghost" id="clearWL">Очистить</button>
+            <button class="btn btn--primary" id="toDetails">Далее</button>
           </div>
           <dialog id="cellEditor" aria-modal="true" role="dialog">
             <form method="dialog" class="editor">
@@ -199,8 +199,8 @@
               <label>Название <input id="cellTitle" /></label>
               <label>Ссылка <input id="cellUrl" placeholder="https://..." /></label>
               <menu>
-                <button value="cancel" class="btn ghost">Отмена</button>
-                <button id="saveCell" value="default" class="btn">Сохранить</button>
+                <button value="cancel" class="btn btn--ghost">Отмена</button>
+                <button id="saveCell" value="default" class="btn btn--primary">Сохранить</button>
               </menu>
             </form>
           </dialog>
@@ -213,7 +213,7 @@
             <label>Дресс-код <input id="eventDress" /></label>
             <label>Что взять <input id="eventBring" /></label>
             <label>Как пройти / комментарии <textarea id="eventNotes" rows="3"></textarea></label>
-            <button class="btn" type="submit" data-requires-auth>Сгенерировать код</button>
+            <button class="btn btn--primary" type="submit" data-requires-auth>Сгенерировать код</button>
           </form>
           <p id="createEventStatus" class="error" role="status" aria-live="polite"></p>
         </section>
@@ -221,11 +221,15 @@
         <!-- СОЗДАТЬ: админ -->
         <section id="slide-admin" hidden>
           <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Поделитесь кодом.</div></div>
-          <p><strong>Код события:</strong> <span class="code-box" id="eventCode">—</span> <button class="btn small" id="copyCodeBtn">Скопировать код</button> <a id="analyticsLink" class="btn small" href="#" hidden>Аналитика события</a></p>
+          <div class="codeRow">
+            <span id="eventCodeText">Код: <strong id="eventCode" data-code>—</strong></span>
+            <button class="btn btn--ghost btn--sm" id="copyInviteBtn">Скопировать приглашение</button>
+            <a id="analyticsLink" class="btn btn--ghost btn--sm" href="#" hidden>Аналитика события</a>
+          </div>
           <p id="codeExpire" class="hint"></p>
           <h3>Вишлист</h3>
           <ul id="adminGifts" class="list"></ul>
-          <div class="bar-actions"><button class="btn" id="finishCreate">К финальной инфо</button></div>
+          <div class="bar-actions"><button class="btn btn--primary" id="finishCreate">Далее</button></div>
         </section>
 
         <!-- ПРИСОЕДИНИТЬСЯ: код -->
@@ -233,7 +237,7 @@
           <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Введите код.</div></div>
           <div class="grid" style="place-items:center">
             <input id="joinCodeInput" placeholder="Например: 345812" style="max-width:260px;text-align:center" inputmode="numeric" pattern="\d*" autocomplete="one-time-code" maxlength="6" />
-            <button class="btn" id="joinCodeBtn" disabled>Проверить</button>
+            <button class="btn btn--primary" id="joinCodeBtn" disabled>Проверить</button>
             <div id="joinCodeError" class="error" role="status" aria-live="polite"></div>
           </div>
         </section>
@@ -244,11 +248,11 @@
           <form id="formJoin" class="grid brick">
             <label>Имя <input id="guestName" required /></label>
             <div class="btn-group">
-              <button type="button" class="btn yes" data-rsvp="yes">Иду</button>
-              <button type="button" class="btn maybe" data-rsvp="maybe">Возможно</button>
-              <button type="button" class="btn no" data-rsvp="no">Не иду</button>
+              <button type="button" class="btn btn--primary" data-rsvp="yes">Иду</button>
+              <button type="button" class="btn btn--ghost" data-rsvp="maybe">Возможно</button>
+              <button type="button" class="btn btn--ghost" data-rsvp="no">Не иду</button>
             </div>
-            <button id="toGuestWishlist" class="btn" type="button">Выбрать подарок</button>
+            <button id="toGuestWishlist" class="btn btn--primary" type="button">Выбрать подарок</button>
           </form>
         </section>
 
@@ -257,8 +261,8 @@
           <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Выберите один пункт.</div></div>
           <div id="guestGifts" class="wishlist-grid"></div>
           <div class="bar-actions">
-            <button class="btn ghost" id="skipWishlist">Пропустить</button>
-            <button class="btn" id="toGuestFinal">Готово</button>
+            <button class="btn btn--ghost" id="skipWishlist">Пропустить</button>
+            <button class="btn btn--primary" id="toGuestFinal">Готово</button>
           </div>
         </section>
       </section>
@@ -281,23 +285,25 @@
         <input id="otpEmail" type="email" required>
       </label>
       <div class="row2">
-        <button class="btn primary" id="otpSendBtn" type="button">Отправить ссылку</button>
-        <button class="btn" value="cancel">Отмена</button>
+        <button class="btn btn--primary" id="otpSendBtn" type="button">Отправить</button>
+        <button class="btn btn--ghost" value="cancel">Отмена</button>
       </div>
       <p id="otpStatus" class="hint" aria-live="polite"></p>
     </form>
   </dialog>
-    <div id="cookieBanner" role="dialog" aria-modal="true" hidden>
-      <div class="cookie-text">
-        <p>Мы используем cookies. Согласны?</p>
-        <label><input type="checkbox" id="cookieAnalytics"> Аналитика</label>
-        <div id="cookieStatus" class="visually-hidden" aria-live="polite"></div>
+      <div id="cookieCard" class="card" style="display:none">
+        <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
+          <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
+        </svg>
+        <div class="cookieHeading">Cookies</div>
+        <div class="cookieDescription">
+          Мы используем файлы cookies, чтобы сайт работал быстрее и удобнее. Продолжая, вы соглашаетесь с их использованием.
+        </div>
+        <div class="buttonContainer">
+          <button class="btn btn--primary acceptButton" id="cookieAccept">Ок</button>
+          <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
+        </div>
       </div>
-      <div class="cookie-actions">
-        <button id="cookieAccept" type="button" class="btn yes">Принять все</button>
-        <button id="cookieDecline" type="button" class="btn ghost">Сохранить выбор</button>
-      </div>
-    </div>
-    <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
-  </body>
-  </html>
+      <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+    </body>
+    </html>

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -12,7 +12,7 @@
     <nav class="fh-nav">
       <a href="/index.html">Меню</a>
       <a href="/profile.html">Профиль</a>
-      <button onclick="localStorage.removeItem('FH_JWT');location.href='/'">Выйти</button>
+      <button class="btn btn--ghost" onclick="localStorage.removeItem('FH_JWT');location.href='/'">Выйти</button>
     </nav>
   </header>
 
@@ -30,7 +30,7 @@
     <section id="lobby-right" class="lobby-right card">
       <h2 data-title>Событие</h2>
       <div class="event-grid">
-        <div><strong>Код:</strong> <span data-code>—</span> <button id="copyInviteBtn" class="btn">Скопировать приглашение</button></div>
+        <div class="codeRow"><span id="eventCodeText">Код: <strong id="eventCode" data-code>—</strong></span> <button id="copyInviteBtn" class="btn btn--ghost btn--sm">Скопировать приглашение</button></div>
         <div><strong>Когда:</strong> <span data-when></span></div>
         <div><strong>Адрес:</strong> <span data-address>—</span></div>
         <div><strong>Дресс-код:</strong> <span data-dress>—</span></div>
@@ -57,11 +57,24 @@
       </div>
 
       <div class="actions">
-        <a class="btn" href="/index.html">Вернуться в меню</a>
+        <a class="btn btn--ghost" href="/index.html">Вернуться в меню</a>
       </div>
     </section>
   </main>
 
   <script src="/app.js" type="module"></script>
+  <div id="cookieCard" class="card" style="display:none">
+    <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
+      <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
+    </svg>
+    <div class="cookieHeading">Cookies</div>
+    <div class="cookieDescription">
+      Мы используем файлы cookies, чтобы сайт работал быстрее и удобнее. Продолжая, вы соглашаетесь с их использованием.
+    </div>
+    <div class="buttonContainer">
+      <button class="btn btn--primary acceptButton" id="cookieAccept">Ок</button>
+      <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
+    </div>
+  </div>
 </body>
 </html>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -13,7 +13,7 @@
       <h1>Профиль</h1>
       <p>Никнейм: <strong id="profile-nickname"></strong></p>
       <p>Создан: <span id="profile-created"></span></p>
-      <button type="button" class="btn" id="logout-btn">Выйти</button>
+      <button type="button" class="btn btn--ghost" id="logout-btn">Выйти</button>
     </div>
   </main>
   <script>
@@ -23,6 +23,19 @@
   </script>
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
   <script defer src="app.js"></script>
+  <div id="cookieCard" class="card" style="display:none">
+    <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
+      <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
+    </svg>
+    <div class="cookieHeading">Cookies</div>
+    <div class="cookieDescription">
+      Мы используем файлы cookies, чтобы сайт работал быстрее и удобнее. Продолжая, вы соглашаетесь с их использованием.
+    </div>
+    <div class="buttonContainer">
+      <button class="btn btn--primary acceptButton" id="cookieAccept">Ок</button>
+      <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
+    </div>
+  </div>
   <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
 </body>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -1,11 +1,19 @@
 /* ТЁМНАЯ ЗЕЛЁНАЯ ТЕМА */
 :root{
+  --brand: #2E7D61;
+  --brand-600: #256a52;
+  --brand-700: #1d5643;
+  --surface: #123A2F;
+  --surface-2: #0F2F26;
+  --text: #EAF7F1;
+  --muted: #A4CDBD;
+  --ring: #4FE2A7;
+  --shadow: rgba(0,0,0,.35);
+
   --bg-dark:#0a1e14;
   --bg-dark2:#0f2b1b;
   --card-dark:#132b20;
   --card-border:#1b3b2a;
-  --text:#e9ffef;
-  --muted:#9bc6a7;
   --accent:#2ec774;
   --accent-2:#43e68d;
   --input-bg:#1d4330;
@@ -18,7 +26,6 @@
   --water2:#214a3a;
   --shore:#173826;
   --soil:#0d2218;
-  --shadow:0 10px 26px rgba(0,0,0,.5);
   --danger:#ff6b6b;
 }
 
@@ -36,7 +43,7 @@ body{
   border:1px solid var(--card-border);
   border-radius:18px;
   padding:20px;
-  box-shadow:var(--shadow);
+  box-shadow:0 10px 26px var(--shadow);
   margin:18px 0;
   overflow-wrap:anywhere;
 }
@@ -45,18 +52,42 @@ body{
 .grid{display:grid;gap:14px}
 .row2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
   label{display:grid;gap:6px}
-  input,textarea{
-    padding:12px 14px;border-radius:14px;
-    border:1px solid var(--input-border);
-    background:var(--input-bg); color:var(--text);
-  }
-  input.is-invalid, textarea.is-invalid{
-    border-color:var(--danger);
-    box-shadow:0 0 0 1px var(--danger);
-  }
-  input.is-invalid:focus-visible, textarea.is-invalid:focus-visible{
-    outline-color:var(--danger);
-  }
+
+/* Универсальный инпут */
+.input {
+  border: 2px solid #e8e8e8;
+  padding: 15px;
+  border-radius: 10px;
+  background-color: #212121;
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+  color: var(--text);
+}
+.input:focus {
+  outline: 2px solid var(--ring);
+  background-color: #212121;
+  color: #e8e8e8;
+  box-shadow: 0 6px 18px var(--shadow);
+}
+
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="number"],
+textarea,
+select {
+  color: var(--text);
+  background: #212121;
+  border: 2px solid #e8e8e8;
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+input:focus, textarea:focus, select:focus {
+  outline: 2px solid var(--ring);
+  box-shadow: 0 6px 18px var(--shadow);
+}
+
 /* Всегда 16px+ на инпутах, чтобы мобильный браузер не зумил */
 input, textarea, select { font-size: 16px; }
 
@@ -68,22 +99,54 @@ input, textarea, select { font-size: 16px; }
 .shake{animation:shake .15s linear;}
 @media (prefers-reduced-motion: reduce){.shake{animation:none;}}
 
-.btn{
-  display:inline-flex;align-items:center;justify-content:center;
-  padding:10px 16px;border-radius:14px;border:1px solid var(--input-border);
-  background:var(--accent);color:#0a1e14;cursor:pointer;transition:.2s;
+/* Базовая кнопка */
+.btn {
+  -webkit-appearance: none;
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  min-height: 42px;
+  padding: 0 16px;
+  border-radius: 12px;
+  border: 0;
+  font-weight: 700;
+  letter-spacing: .2px;
+  cursor: pointer;
+  transition: transform .06s ease, background-color .2s ease, box-shadow .2s ease;
+  box-shadow: 0 8px 22px var(--shadow);
+  user-select: none;
 }
-.btn.primary{background:var(--accent-2)}
-.btn:hover{filter:brightness(1.08)}
-.btn.ghost{background:transparent;color:var(--accent);border-color:#2a7c56}
-.btn.yes{background:#35c97f;color:#0a1e14;border-color:transparent}
-.btn.maybe{background:#f0b429;color:#0a1e14;border-color:transparent}
-.btn.no{background:#ff6b6b;color:#0a1e14;border-color:transparent}
-.btn.small{padding:6px 10px;font-size:.9rem;border-radius:10px}
+
+.btn--primary{
+  background: var(--brand);
+  color: #fff;
+}
+.btn--primary:hover{ background: var(--brand-600); }
+.btn--primary:active{ background: var(--brand-700); transform: translateY(1px); }
+.btn--primary:focus-visible{ outline: 2px solid var(--ring); outline-offset: 2px; }
+
+.btn--ghost{
+  background: transparent;
+  color: var(--text);
+  border: 2px solid var(--brand-600);
+}
+.btn--ghost:hover{ background: rgba(46,125,97,.1); }
+.btn--ghost:active{ transform: translateY(1px); }
+
+.btn--danger{
+  background: #b93737;
+  color: #fff;
+}
+.btn--danger:hover{ background: #a12f2f; }
+
+.btn--sm{ min-height: 34px; padding: 0 12px; font-size: 14px; }
+.btn--lg{ min-height: 48px; padding: 0 18px; font-size: 16px; }
 
 :focus-visible{
-  outline:3px solid var(--accent-2);
-  outline-offset:3px;
+  outline:2px solid var(--ring);
+  outline-offset:2px;
   border-radius:10px;
 }
 
@@ -229,7 +292,7 @@ body.force-mobile .final-card { padding: 14px; border-radius: 14px; }
 .pill.secondary{background:linear-gradient(180deg,#ffd973,#f0b429);color:#2b2300}
 
 /* Панель шагов */
-.panel{position:relative;padding:22px;margin:18px 5vw 40px;border-radius:22px;background:var(--panel);border:1px solid var(--panel-bd);box-shadow:var(--shadow);overflow-wrap:anywhere}
+.panel{position:relative;padding:22px;margin:18px 5vw 40px;border-radius:22px;background:var(--panel);border:1px solid var(--panel-bd);box-shadow:0 10px 26px var(--shadow);overflow-wrap:anywhere}
 .bubble{background:rgba(20,70,45,.6);border:1px solid #2a7c56;border-radius:16px;padding:12px;margin-bottom:12px}
 .bubble-head{font-weight:800;color:#93e8b6;margin-bottom:4px}
 
@@ -263,20 +326,35 @@ body.force-mobile .final-card { padding: 14px; border-radius: 14px; }
 .bar-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:10px}
 .pill-mini{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;border:1px solid #2a7c56;background:#143d2a;color:#dfffe6;font-weight:700}
 
-#sessionBanner{position:fixed;left:0;right:0;top:0;max-width:1100px;margin:12px auto 0;padding:12px 16px;padding-top:calc(12px + env(safe-area-inset-top));background:var(--panel);border:1px solid var(--panel-bd);box-shadow:var(--shadow);text-align:center;}
+#sessionBanner{position:fixed;left:0;right:0;top:0;max-width:1100px;margin:12px auto 0;padding:12px 16px;padding-top:calc(12px + env(safe-area-inset-top));background:var(--panel);border:1px solid var(--panel-bd);box-shadow:0 10px 26px var(--shadow);text-align:center;}
 #sessionBanner[hidden]{display:none;pointer-events:none;opacity:0;}
 .error{color:#ff6b6b;font-size:.9rem;min-height:1.2em}
 
 /* Cookie banner */
-#cookieBanner{position:fixed;left:0;right:0;bottom:0;max-width:1100px;margin:0 auto 12px;padding:12px 16px;padding-bottom:calc(12px + env(safe-area-inset-bottom));background:var(--panel);border:1px solid var(--panel-bd);box-shadow:var(--shadow);display:grid;gap:12px;}
-#cookieBanner:not([hidden]){z-index:1100;}
-#cookieBanner[hidden]{display:none;pointer-events:none;opacity:0;}
-#cookieBanner .cookie-actions{display:flex;justify-content:flex-end;gap:12px;}
-#cookieBanner .cookie-text{display:grid;gap:8px;}
-@media (min-width:960px){#cookieBanner{grid-template-columns:1fr auto;align-items:center;}#cookieBanner .cookie-actions{flex-direction:row;}}
-@media (max-width:959px){#cookieBanner .cookie-actions{flex-direction:column;align-items:stretch;}}
+
 .visually-hidden{position:absolute!important;height:1px;width:1px;overflow:hidden;clip:rect(1px,1px,1px,1px);white-space:nowrap;}
-.toast{position:fixed;left:50%;bottom:20px;transform:translateX(-50%);background:var(--panel);border:1px solid var(--panel-bd);box-shadow:var(--shadow);padding:10px 16px;border-radius:12px;z-index:1200;}
+.toast{position:fixed;left:50%;bottom:20px;transform:translateX(-50%);background:var(--panel);border:1px solid var(--panel-bd);box-shadow:0 10px 26px var(--shadow);padding:10px 16px;border-radius:12px;z-index:1200;}
+
+#cookieCard{
+  position: fixed; right: 24px; bottom: 24px; z-index: 1000;
+  width: 340px; max-width: calc(100% - 32px);
+  background: var(--surface);
+  color: var(--text);
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  padding: 18px 20px; gap: 12px; border-radius: 16px;
+  box-shadow: 0 12px 30px var(--shadow);
+  border: 1px solid rgba(255,255,255,.06);
+  margin: 0;
+}
+#cookieSvg{ width: 50px; }
+#cookieSvg g path{ fill: var(--muted); }
+.cookieHeading{ font-size: 1.1rem; font-weight: 800; color: var(--text); }
+.cookieDescription{ text-align: center; font-size: .85rem; color: var(--muted); }
+
+.buttonContainer{ display: flex; gap: 12px; }
+.acceptButton{ background: var(--brand); }
+.acceptButton:hover{ background: var(--brand-600); }
+.declineButton{ border: 2px solid var(--brand-600); }
 
 /* на финале скрыть нижние элементы шагов */
 body.scene-final #slides,
@@ -299,7 +377,7 @@ body.scene-intro .speech{display:block}
   .container{ padding:16px; }
   .final-card{ padding:14px; border-radius:14px; }
   input, textarea, button{ font-size:16px; }
-  .pill, .btn{ padding:12px 14px; }
+  .pill{ padding:12px 14px; }
   body{font-size:clamp(14px,4vw,16px)}
   .card{padding:16px;margin:14px 0}
   .card.inner{padding:12px}
@@ -427,17 +505,6 @@ body.scene-intro .speech{display:block}
 .list { margin: 8px 0; padding-left: 18px; }
 .list li { margin: 3px 0; }
 
-.btn {
-  display: inline-block;
-  padding: 8px 12px;
-  border-radius: 10px;
-  background: #2ea44f;
-  color: #fff;
-  text-decoration: none;
-  border: none;
-  cursor: pointer;
-}
-
 .fh-header { display:flex; justify-content:space-between; align-items:center; padding:12px 20px; }
 .fh-logo { font-weight:800; text-decoration:none; }
 .fh-nav a, .fh-nav button { margin-left:12px; }
@@ -529,11 +596,3 @@ body.scene-intro .speech{display:block}
 .wl-free { background:#d7fbe8; color:#0b3d2a; }
 .wl-taken { background:#ffe3e3; color:#7a1c1c; }
 
-/* кнопки в стиле проекта */
-.btn { border:1px solid #bfe3d3; background:#f1fff8; color:#0b3d2a; border-radius:10px; padding:10px 14px; cursor:pointer; }
-.btn:hover { background:#e7fbf3; }
-.btn-primary { background:#39b982; border-color:#39b982; color:white; }
-.btn-primary:hover { background:#2aa273; }
-.btn-ghost { background:transparent; border-color:#bfe3d3; }
-.btn-danger { background:#ff4d4f; border-color:#ff4d4f; color:white; }
-.btn-danger:hover { filter:brightness(.95); }


### PR DESCRIPTION
## Summary
- unify theme variables, inputs, and buttons into a consistent green UI
- add reusable cookie consent card and copy invite handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5609746488332b3521cec591b5e71