### PR TITLE
feat: intercept auth forms and redirect to menu

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -810,25 +810,30 @@ document.addEventListener('DOMContentLoaded', () => {
   renderUserBadge({ nickname: getNickname(), email });
 });
 
+const url = new URL(location.href);
+const isHome = url.pathname === '/' || url.pathname.endsWith('/index.html');
+
 ensureSupabase().then(async sb => {
   if(!sb) return;
   const { data:{ session } } = await sb.auth.getSession();
   currentUser = session?.user || null;
   toggleAuthButtons(!currentUser);
-  if(currentUser){
-    window.currentUserEmail = currentUser.email || '';
-    renderUserBadge({ nickname: getNickname(), email: window.currentUserEmail });
-    show('#screen-lobby');
-    const pending = sessionStorage.getItem('pendingCreate');
-    if(pending){
-      Object.assign(eventData, JSON.parse(pending));
-      sessionStorage.removeItem('pendingCreate');
-      save();
-      startCreateFlow();
+  if(isHome){
+    if(currentUser){
+      window.currentUserEmail = currentUser.email || '';
+      renderUserBadge({ nickname: getNickname(), email: window.currentUserEmail });
+      show('#screen-lobby');
+      const pending = sessionStorage.getItem('pendingCreate');
+      if(pending){
+        Object.assign(eventData, JSON.parse(pending));
+        sessionStorage.removeItem('pendingCreate');
+        save();
+        startCreateFlow();
+      }
+    } else {
+      show('#screen-auth');
+      setAuthState('login');
     }
-  } else {
-    show('#screen-auth');
-    setAuthState('login');
   }
   sb.auth.onAuthStateChange(async (event, session)=>{
     if(event === 'TOKEN_REFRESHED' || event === 'SIGNED_IN'){
@@ -852,32 +857,36 @@ ensureSupabase().then(async sb => {
     currentUser = session?.user || null;
     toggleAuthButtons(!currentUser);
     if(event === 'PASSWORD_RECOVERY'){
-      setAuthState('reset');
-      resetEmailBlock.hidden = true;
-      resetPassBlock.hidden = false;
-      show('#screen-auth');
+      if(isHome){
+        setAuthState('reset');
+        resetEmailBlock.hidden = true;
+        resetPassBlock.hidden = false;
+        show('#screen-auth');
+      }
       return;
     }
     if(event === 'SIGNED_IN' && currentUser){
       window.currentUserEmail = currentUser.email || '';
       renderUserBadge({ nickname: getNickname(), email: window.currentUserEmail });
-      show('#screen-lobby');
-      const pendingProfile = sessionStorage.getItem('pendingProfileName');
-      if(pendingProfile){
-        try{ await sb.from('profiles').upsert({ id: currentUser.id, nickname: pendingProfile }); }catch(e){ console.warn('profile upsert', e); }
-        sessionStorage.removeItem('pendingProfileName');
-      }
-      const hash = location.hash || '';
-      if(hash.includes('error=')){
-        const code = new URLSearchParams(hash.slice(1)).get('error');
-        sessionBanner.innerHTML = `Ошибка: ${code}. <button id="resendFromBanner" class="btn ghost">Переотправить письмо</button>`;
-        sessionBanner.hidden = false;
-        document.getElementById('resendFromBanner')?.addEventListener('click', async ()=>{
-          try{ await sb.auth.resend({ type:'signup', email: currentUser.email }); sessionBanner.textContent='Письмо отправлено'; }catch(_){ sessionBanner.textContent='Не удалось отправить'; }
-        });
-        sendAuthTelemetry('redirect_error_'+code);
-      } else {
-        sessionBanner.hidden = true;
+      if(isHome){
+        show('#screen-lobby');
+        const pendingProfile = sessionStorage.getItem('pendingProfileName');
+        if(pendingProfile){
+          try{ await sb.from('profiles').upsert({ id: currentUser.id, nickname: pendingProfile }); }catch(e){ console.warn('profile upsert', e); }
+          sessionStorage.removeItem('pendingProfileName');
+        }
+        const hash = location.hash || '';
+        if(hash.includes('error=')){
+          const code = new URLSearchParams(hash.slice(1)).get('error');
+          sessionBanner.innerHTML = `Ошибка: ${code}. <button id="resendFromBanner" class="btn ghost">Переотправить письмо</button>`;
+          sessionBanner.hidden = false;
+          document.getElementById('resendFromBanner')?.addEventListener('click', async ()=>{
+            try{ await sb.auth.resend({ type:'signup', email: currentUser.email }); sessionBanner.textContent='Письмо отправлено'; }catch(_){ sessionBanner.textContent='Не удалось отправить'; }
+          });
+          sendAuthTelemetry('redirect_error_'+code);
+        } else {
+          sessionBanner.hidden = true;
+        }
       }
       const temp = localStorage.getItem(COOKIE_TEMP_KEY);
       const uid = session?.user?.id;
@@ -1685,11 +1694,6 @@ if (joinBtn2){
   }));
 }
 
-function safeRedirect(url){
-  try { window.location.assign(url); }
-  catch { window.location.href = url; }
-}
-
 async function login(nickname, password){
   const { token } = await callFn('local-login', { nickname, password });
   if(token){ setToken(token); }
@@ -2271,5 +2275,72 @@ document.querySelectorAll('#copyInviteBtn').forEach(copyBtn => {
   ok?.addEventListener('click', close);
   no?.addEventListener('click', close);
 })();
+
+// ---------- Auth intercept (global, capture) ----------
+function safeRedirect(url) {
+  try { window.location.assign(url); } catch { window.location.href = url; }
+}
+
+// Пытаемся угадать тип формы, если нет data-auth
+function guessAuthFormKind(form) {
+  if (form.dataset.auth) return form.dataset.auth; // 'login' | 'signup'
+  if (form.id === 'loginForm'  || form.matches('.login-form'))  return 'login';
+  if (form.id === 'signupForm' || form.matches('.signup-form')) return 'signup';
+  const txt = (form.querySelector('button[type="submit"],button')?.textContent || '').toLowerCase();
+  if (txt.includes('войти') || txt.includes('login')) return 'login';
+  if (txt.includes('рег')   || txt.includes('sign'))  return 'signup';
+  return null;
+}
+
+async function handleAuthSubmit(e) {
+  const form = e.target;
+  if (!(form instanceof HTMLFormElement)) return;
+
+  // Обрабатываем только auth-формы
+  const kind = guessAuthFormKind(form);
+  if (!kind) return;
+
+  // Гасим нативный сабмит ДО того, как браузер перезагрузит страницу
+  e.preventDefault();
+  e.stopPropagation();
+
+  // Подготавливаем данные
+  const nickname = form.querySelector('input[name="nickname"], #nickname, [data-field="nickname"]')?.value?.trim();
+  const password = form.querySelector('input[name="password"], #password, [data-field="password"]')?.value ?? '';
+  if (!nickname || !password) {
+    console.warn('Auth: пустые поля'); 
+    return;
+  }
+
+  try {
+    if (kind === 'login') {
+      // используй существующую функцию клиента
+      await login(nickname, password);
+    } else {
+      await signup(nickname, password); // твоя существующая signup уже логинит
+    }
+    // После успешной auth → в меню
+    safeRedirect('/');
+  } catch (err) {
+    console.error('Auth error', err);
+    // здесь можно показать тост/модалку, если в проекте есть хелпер
+  }
+}
+
+// Глобальный перехват всех submit'ов на фазе захвата
+function installAuthIntercept() {
+  // Уберём action у auth-форм, если он задан
+  document.querySelectorAll('form[data-auth], form.login-form, form.signup-form, #loginForm, #signupForm')
+    .forEach(f => { f.setAttribute('action', 'javascript:void(0)'); f.setAttribute('novalidate',''); });
+
+  window.addEventListener('submit', handleAuthSubmit, true); // capture=true
+}
+
+// Гарантируем установку перехватчика
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', installAuthIntercept);
+} else {
+  installAuthIntercept();
+}
 
 

--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -80,6 +80,7 @@
     import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm";
     window.createSupabaseClient = createClient;
   </script>
+  <script src="/app.js" defer></script>
   <script type="module" src="event-analytics.js"></script>
 </body>
 </html>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -46,7 +46,7 @@
     import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm";
     window.createSupabaseClient = createClient;
   </script>
-  <script type="module" src="app.js"></script>
+  <script src="/app.js" defer></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -38,7 +38,7 @@
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
   </script>
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
-  <script defer src="app.js"></script>
+  <script src="/app.js" defer></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -276,7 +276,7 @@
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
   </script>
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
-  <script defer src="app.js"></script>
+  <script src="/app.js" defer></script>
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
   <dialog id="otpModal">
     <form method="dialog" class="grid">

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -62,7 +62,7 @@
     </section>
   </main>
 
-  <script src="/app.js" type="module"></script>
+  <script src="/app.js" defer></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -22,7 +22,7 @@
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
   </script>
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
-  <script defer src="app.js"></script>
+  <script src="/app.js" defer></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>


### PR DESCRIPTION
## Summary
- load `app.js` with `defer` on all pages
- add global auth submit interceptor to prevent reloads and redirect to menu
- avoid automatic lobby/final navigation unless on the home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a56fd7086c8332a11e975bb25b81c7