### PR TITLE
Add simple login page and handler

### DIFF
--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Вход</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container" role="main">
+    <div class="card" style="max-width:480px;margin:40px auto">
+      <h1>Вход</h1>
+      <form id="login-form" class="grid" novalidate>
+        <label>Никнейм
+          <input id="login-nick" type="text" autocomplete="username" required />
+        </label>
+        <label>Пароль
+          <input id="login-pass" type="password" autocomplete="current-password" required />
+        </label>
+        <button class="btn btn--primary" type="submit">Войти</button>
+      </form>
+    </div>
+  </div>
+  <script src="/login.js" defer></script>
+</body>
+</html>

--- a/FroggyHub/login.js
+++ b/FroggyHub/login.js
@@ -1,0 +1,33 @@
+(() => {
+  const form = document.querySelector('#login-form');
+  const nick = document.querySelector('#login-nick');
+  const pass = document.querySelector('#login-pass');
+
+  if (!form || !nick || !pass) { console.warn('login form not found'); return; }
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+
+    const nickname = nick.value.trim();
+    const password = pass.value;
+
+    if (!nickname || !password) return;
+
+    const res = await fetch('/.netlify/functions/local-login', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({ nickname, password })
+    });
+
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data?.token) {
+      localStorage.setItem('FH_JWT', data.token);
+      location.assign('/'); // на страницу выбора “создать / присоединиться”
+    } else {
+      alert(data?.error || 'Ошибка входа');
+    }
+  }, { once: true });
+
+  console.log('Login submit hooked');
+})();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "serve:functions": "netlify functions:serve",
     "test": "npm run test:syntax",
-    "test:syntax": "node --check FroggyHub/app.js && node --check FroggyHub/event-analytics.js && node --check netlify/functions/_auth.js && node --check netlify/functions/db-ping.js && node --check netlify/functions/local-login.js && node --check netlify/functions/local-signup.js && node --check netlify/functions/profile.js && node --check netlify/functions/events-create.js && node --check netlify/functions/events-get.js && node --check netlify/functions/events-join.js && node --check netlify/functions/events-rsvp.js && node --check netlify/functions/events-list.js"
+    "test:syntax": "node --check FroggyHub/app.js && node --check FroggyHub/event-analytics.js && node --check FroggyHub/login.js && node --check netlify/functions/_auth.js && node --check netlify/functions/db-ping.js && node --check netlify/functions/local-login.js && node --check netlify/functions/local-signup.js && node --check netlify/functions/profile.js && node --check netlify/functions/events-create.js && node --check netlify/functions/events-get.js && node --check netlify/functions/events-join.js && node --check netlify/functions/events-rsvp.js && node --check netlify/functions/events-list.js"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- add standalone login form with fields for nickname and password
- implement client-side handler to call local login function and store JWT
- include new script in syntax check pipeline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a58407b1908332b2e2337875651ef7