### PR TITLE
feat: add delegated navigation and unified buttons

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -2,6 +2,14 @@ const $  = (s, r=document) => r.querySelector(s);
 const $$ = (s, r=document) => Array.from(r.querySelectorAll(s));
 const on = (el, ev, fn) => el && el.addEventListener(ev, fn);
 
+function onDelegated(selector, type, handler, options){
+  document.addEventListener(type, (e)=>{
+    const el = e.target.closest(selector);
+    if(!el) return;
+    handler(e, el);
+  }, options || false);
+}
+
 const TOKEN_KEY = 'FH_JWT';
 const saveToken  = t => { try { localStorage.setItem(TOKEN_KEY, t); } catch {} };
 const getToken   = () => { try { return localStorage.getItem(TOKEN_KEY); } catch { return null } };
@@ -16,12 +24,11 @@ const screens = {
 
 function showScreen(name){
   Object.entries(screens).forEach(([k, el])=>{
-    if (!el) return;
-    if (k === name) { el.hidden = false; el.removeAttribute('hidden'); }
-    else { el.hidden = true; el.setAttribute('hidden',''); }
+    if(!el) return;
+    el.hidden = (k !== name);
   });
-  // для удобства CSS
   document.body.dataset.screen = name;
+  console.debug('[screen]', name);
 }
 
 async function apiPost(fnPath, payload) {
@@ -42,6 +49,33 @@ const LS_NICK = 'fh:nickname';
 
 document.querySelectorAll('input, textarea, select').forEach(el=>{
   el.classList.add('input');
+});
+
+['create-event','join-event','login-btn','signup-btn','logout-btn'].forEach(id=>{
+  const el = document.getElementById(id);
+  console.debug('[btn]', id, 'present=', !!el);
+});
+
+// Экранная навигация по data-go
+onDelegated('[data-go]', 'click', (e, el) => {
+  if (el.tagName === 'A') e.preventDefault();
+  const target = el.dataset.go;
+  if (target === 'app' || target === 'profile') {
+    console.debug('[nav] goto app from', el.id || el.className);
+    showScreen('app');
+    const first = document.querySelector('#screen-app input, #screen-app textarea, #screen-app button');
+    if (first) first.focus();
+    return;
+  }
+  if (target === 'menu') {
+    console.debug('[nav] goto menu');
+    showScreen('lobby');
+    return;
+  }
+  if (target === 'auth') {
+    console.debug('[nav] goto auth');
+    showScreen('auth');
+  }
 });
 
 function toast(msg, type='info'){
@@ -1006,7 +1040,7 @@ $('#confirmDeleteBtn')?.addEventListener('click', async ()=>{
 });
 
 /* ---------- ЛОББИ: переходы ---------- */
-$('#goCreate')?.addEventListener('click', startCreateFlow);
+$('#create-event')?.addEventListener('click', startCreateFlow);
 $('#goJoinByCode')?.addEventListener('click', ()=>{
   show('#screen-app');
   setScene('pond'); renderPads(); frogJumpToPad(0,true); showSlide('join-code');
@@ -2356,15 +2390,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
   if (getToken()) showScreen('lobby');
   else            showScreen('auth');
 
-  // Кнопки/ссылки "Меню" и "Профиль" не должны перегружать страницу
-  const menuLink = $('#nav-menu, a[href="/menu"], a[href="#menu"]');
-  if (menuLink){
-    menuLink.addEventListener('click', (e)=>{ e.preventDefault(); showScreen('lobby'); });
-  }
-  const profileLink = $('#nav-profile, a[href="/profile"], a[href="#profile"]');
-  if (profileLink){
-    profileLink.addEventListener('click', (e)=>{ e.preventDefault(); showScreen('app'); });
-  }
+  // Навешанные делегированные клики работают всегда, ничего больше не нужно
 });
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -8,9 +8,11 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="scene-intro">
-  <nav class="top-nav">
-    <a id="nav-menu" href="#">Меню</a>
-    <a id="nav-profile" href="#">Профиль</a>
+  <!-- Шапка -->
+  <nav class="topbar">
+    <button id="nav-menu" class="btn btn--ghost btn--sm" data-go="menu" type="button">Меню</button>
+    <button id="nav-profile" class="btn btn--ghost btn--sm" data-go="profile" type="button">Профиль</button>
+    <button id="logout-btn" class="btn btn--ghost btn--sm" type="button">Выйти</button>
   </nav>
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <div id="screen-auth" class="container" role="main">
@@ -39,8 +41,8 @@
           <label>Пароль
             <input id="login-password" name="password" type="password" placeholder="••••••••" minlength="4" required autocomplete="current-password">
           </label>
-            <button class="btn btn--primary" id="login-btn" type="submit">Войти</button>
-            <button type="button" class="btn btn--ghost" id="showReset" data-forgot="false">Забыли пароль?</button>
+            <button id="login-btn" class="btn btn--primary btn--xl w-full" type="submit">Войти</button>
+            <button id="showReset" class="btn btn--ghost w-full" type="button" data-forgot="false">Забыли пароль?</button>
           <div id="resetPassBlock" class="grid is-hidden">
             <label>Новый пароль
               <input id="resetPass" type="password" minlength="4" autocomplete="new-password">
@@ -64,7 +66,7 @@
           <label>Повтор пароля
             <input id="signup-password2" name="password2" type="password" required minlength="4" autocomplete="new-password">
           </label>
-            <button id="signup-btn" class="btn btn--primary" type="submit">Зарегистрироваться</button>
+            <button id="signup-btn" class="btn btn--primary btn--xl w-full" type="submit">Зарегистрироваться</button>
           <div id="reg-status" aria-live="polite"></div>
         </form>
       </section>
@@ -81,18 +83,17 @@
           <div class="chips">
             <span class="chip">Шаг 2</span>
             <span class="pill" data-user-badge>гость</span>
-              <button class="btn btn--ghost btn--sm" id="logout-btn" data-action="logout" title="Выйти">Выйти</button>
           </div>
         </div>
       </div>
 
       <div class="grid">
-          <button class="btn btn--primary btn--lg" id="goCreate" data-requires-auth data-action="create-event">Создать событие</button>
+          <button id="create-event" class="btn btn--primary btn--xl w-full" data-requires-auth data-action="create-event" data-go="app" type="button">Создать событие</button>
         <div class="card inner">
           <h3>Присоединиться к ивенту</h3>
           <div class="row2">
-            <input id="join-code" placeholder="Введите 6-значный код" inputmode="numeric" pattern="\d*" autocomplete="one-time-code" maxlength="6">
-            <button class="btn btn--ghost" id="join-btn" data-action="join-event" disabled>Присоединиться</button>
+            <input id="join-code" class="input" placeholder="Введите 6-значный код" inputmode="numeric" pattern="\d*" autocomplete="one-time-code" maxlength="6">
+            <button id="join-event" class="btn btn--ghost" data-action="join-event" data-go="app" type="button" disabled>Присоединиться</button>
           </div>
         </div>
       </div>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -3,6 +3,11 @@
   --brand: #2E7D61;
   --brand-600: #256a52;
   --brand-700: #1d5643;
+  --brand-500:#1f6e57;
+  --brand-400:#298a6d;
+  --on-brand:#e9fff2;
+  --border:#2c5b4b;
+  --glass:rgba(255,255,255,.06);
   --surface: #123A2F;
   --surface-2: #0F2F26;
   --text: #EAF7F1;
@@ -54,21 +59,21 @@ body{
   label{display:grid;gap:6px}
 
 /* Универсальный инпут */
-.input {
-  border: 2px solid #e8e8e8;
-  padding: 15px;
-  border-radius: 10px;
-  background-color: #212121;
-  font-size: 14px;
-  font-weight: 700;
-  text-align: center;
-  color: var(--text);
+.input{
+  border:2px solid #2e5b4c;
+  padding:15px;
+  border-radius:10px;
+  background:#151f1b;
+  font-size:14px;
+  font-weight:700;
+  text-align:center;
+  color:#e8e8e8;
 }
-.input:focus {
-  outline: 2px solid var(--ring);
-  background-color: #212121;
-  color: #e8e8e8;
-  box-shadow: 0 6px 18px var(--shadow);
+.input:focus{
+  outline-color:#fff;
+  background:#151f1b;
+  color:#e8e8e8;
+  box-shadow:5px 5px #0a0a0a;
 }
 
 input[type="text"],
@@ -99,50 +104,40 @@ input, textarea, select { font-size: 16px; }
 .shake{animation:shake .15s linear;}
 @media (prefers-reduced-motion: reduce){.shake{animation:none;}}
 
-/* Базовая кнопка */
-.btn {
-  -webkit-appearance: none;
-  appearance: none;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: .5rem;
-  min-height: 42px;
-  padding: 0 16px;
-  border-radius: 12px;
-  border: 0;
-  font-weight: 700;
-  letter-spacing: .2px;
-  cursor: pointer;
-  transition: transform .06s ease, background-color .2s ease, box-shadow .2s ease;
-  box-shadow: 0 8px 22px var(--shadow);
-  user-select: none;
+/* Универсальная кнопка */
+.btn{
+  -webkit-appearance:none; appearance:none;
+  display:inline-flex; align-items:center; justify-content:center;
+  gap:.5rem; padding:.7rem 1.1rem;
+  border:1px solid var(--border);
+  border-radius:12px;
+  background:var(--glass);
+  color:#e6f7ee; font-weight:600; line-height:1;
+  text-decoration:none; cursor:pointer;
+  transition:transform .06s ease, box-shadow .2s ease, background .2s ease, border-color .2s ease;
+  box-shadow:0 6px 18px rgba(0,0,0,.18);
 }
+.btn:hover{ transform:translateY(-1px); box-shadow:0 10px 24px rgba(0,0,0,.22);}
+.btn:active{ transform:translateY(0); box-shadow:0 4px 14px rgba(0,0,0,.18);}
+.btn:disabled{ opacity:.55; cursor:not-allowed; transform:none; }
+.btn:focus-visible{ outline:2px solid var(--brand-400); outline-offset:2px; }
 
-.btn--primary{
-  background: var(--brand);
-  color: #fff;
-}
-.btn--primary:hover{ background: var(--brand-600); }
-.btn--primary:active{ background: var(--brand-700); transform: translateY(1px); }
-.btn--primary:focus-visible{ outline: 2px solid var(--ring); outline-offset: 2px; }
+/* Вариации */
+.btn--primary{ background:linear-gradient(180deg,var(--brand-500),var(--brand-600)); border-color:var(--brand-500); color:var(--on-brand);}
+.btn--primary:hover{ background:linear-gradient(180deg,var(--brand-400),var(--brand-500));}
+.btn--secondary{ background:rgba(21,73,57,.45); border-color:var(--border);}
+.btn--ghost{ background:transparent; border-color:rgba(255,255,255,.18); }
+.btn--chip{ padding:.35rem .7rem; border-radius:999px; font-weight:700; }
+.btn--sm{ padding:.45rem .7rem; font-size:.9rem; }
+.btn--xl{ padding:1rem 1.25rem; font-size:1.05rem; }
+.btn.w-full{ width:100%; }
 
-.btn--ghost{
-  background: transparent;
-  color: var(--text);
-  border: 2px solid var(--brand-600);
-}
-.btn--ghost:hover{ background: rgba(46,125,97,.1); }
-.btn--ghost:active{ transform: translateY(1px); }
+/* Кнопка-ссылка тоже выглядит как кнопка */
+a.btn{ color:inherit; }
 
-.btn--danger{
-  background: #b93737;
-  color: #fff;
-}
-.btn--danger:hover{ background: #a12f2f; }
-
-.btn--sm{ min-height: 34px; padding: 0 12px; font-size: 14px; }
-.btn--lg{ min-height: 48px; padding: 0 18px; font-size: 16px; }
+/* Дополнительные вариации */
+.btn--danger{ background:#b93737; color:#fff; }
+.btn--danger:hover{ background:#a12f2f; }
 
 :focus-visible{
   outline:2px solid var(--ring);


### PR DESCRIPTION
## Summary
- use data-go navigation with delegated handler for menu, profile, create and join buttons
- restyle inputs and buttons with shared design tokens
- ensure showScreen toggles `hidden` and top bar uses button controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a69c60067c8332baaefce081906a2e