### PR TITLE
feat: add profile screen with event management

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -20,6 +20,7 @@ const screens = {
   auth:  $('#screen-auth'),
   lobby: $('#screen-lobby'),
   app:   $('#screen-app'),
+  profile: $('#screen-profile'),
 };
 
 function showScreen(name){
@@ -51,31 +52,99 @@ document.querySelectorAll('input, textarea, select').forEach(el=>{
   el.classList.add('input');
 });
 
-['create-event','join-event','login-btn','signup-btn','logout-btn'].forEach(id=>{
+['create-event','join-event','login-btn','signup-btn','btn-logout'].forEach(id=>{
   const el = document.getElementById(id);
   console.debug('[btn]', id, 'present=', !!el);
 });
 
+async function fetchMyEvents() {
+  const res = await fetch('/.netlify/functions/events-mine', {
+    headers: { Authorization: `Bearer ${localStorage.getItem('FH_JWT') || ''}` }
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data?.error || 'Не удалось загрузить события');
+  return Array.isArray(data) ? data : (data.items || []);
+}
+
+function splitEventsByDate(items) {
+  const today = new Date(); today.setHours(0,0,0,0);
+  const upcoming = [], past = [];
+  for (const ev of items) {
+    const d = new Date(ev.date + 'T' + (ev.time || '00:00'));
+    (d >= today ? upcoming : past).push(ev);
+  }
+  upcoming.sort((a,b)=> (a.date + (a.time||'')).localeCompare(b.date + (b.time||'')));
+  past.sort((a,b)=> (b.date + (b.time||'')).localeCompare(a.date + (a.time||'')));
+  return { upcoming, past };
+}
+
+function eventRow(ev) {
+  const title = ev.title || 'Без названия';
+  const when  = ev.date ? (ev.time ? `${ev.date} · ${ev.time}` : ev.date) : '—';
+  return `
+    <div class="event-item" data-id="${ev.id}" data-code="${ev.code || ''}">
+      <div>
+        <div><strong>${title}</strong></div>
+        <div class="event-item__meta">${when}${ev.code ? ` · код: ${ev.code}` : ''}</div>
+      </div>
+      <div class="event-item__actions">
+        <button class="btn btn--sm" data-action="open">Открыть</button>
+        ${ev.is_host ? `<button class="btn btn--sm btn--danger" data-action="delete">Удалить</button>` : ''}
+      </div>
+    </div>
+  `;
+}
+
+async function renderProfile() {
+  const listUpcoming = $('#profile-upcoming');
+  const listPast = $('#profile-past');
+  if (!listUpcoming || !listPast) return;
+  listUpcoming.innerHTML = listPast.innerHTML = 'Загрузка...';
+  try {
+    const items = await fetchMyEvents();
+    const { upcoming, past } = splitEventsByDate(items);
+    listUpcoming.innerHTML = upcoming.length ? upcoming.map(eventRow).join('') : '<div class="muted">Нет ближайших</div>';
+    listPast.innerHTML = past.length ? past.map(eventRow).join('') : '<div class="muted">Нет прошедших</div>';
+  } catch (e) {
+    listUpcoming.innerHTML = listPast.innerHTML = `<div class="error">${e.message}</div>`;
+  }
+}
+
+onDelegated('#screen-profile .event-item [data-action="open"]', 'click', async (e, btn) => {
+  const row = btn.closest('.event-item');
+  if (!row) return;
+  await renderEvent(row.dataset.id);
+  showScreen('app');
+});
+
+onDelegated('#screen-profile .event-item [data-action="delete"]', 'click', async (e, btn) => {
+  const row = btn.closest('.event-item');
+  if (!row) return;
+  if (!confirm('Удалить событие?')) return;
+  try {
+    btn.disabled = true;
+    const res = await fetch('/.netlify/functions/event-delete?id=' + encodeURIComponent(row.dataset.id), {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${localStorage.getItem('FH_JWT') || ''}` }
+    });
+    const data = await res.json().catch(()=> ({}));
+    if (!res.ok) throw new Error(data?.error || 'Не удалось удалить');
+    await renderProfile();
+    toast('Удалено');
+  } catch (err) {
+    toast(err.message || 'Ошибка удаления');
+  } finally {
+    btn.disabled = false;
+  }
+});
+
 // Экранная навигация по data-go
-onDelegated('[data-go]', 'click', (e, el) => {
+onDelegated('[data-go]', 'click', async (e, el) => {
   if (el.tagName === 'A') e.preventDefault();
   const target = el.dataset.go;
-  if (target === 'app' || target === 'profile') {
-    console.debug('[nav] goto app from', el.id || el.className);
-    showScreen('app');
-    const first = document.querySelector('#screen-app input, #screen-app textarea, #screen-app button');
-    if (first) first.focus();
-    return;
-  }
-  if (target === 'menu') {
-    console.debug('[nav] goto menu');
-    showScreen('lobby');
-    return;
-  }
-  if (target === 'auth') {
-    console.debug('[nav] goto auth');
-    showScreen('auth');
-  }
+  if (!target) return;
+  showScreen(target);
+  if (target === 'profile') { renderProfile(); }
 });
 
 function toast(msg, type='info'){
@@ -1828,7 +1897,7 @@ async function signup(nickname, password){
   return { token };
 }
 
-['logout-btn','logoutBtn'].forEach(id=>{
+['btn-logout','logoutBtn'].forEach(id=>{
   const el = document.getElementById(id);
   if(el) el.addEventListener('click', withBusy(el, async ()=>{
     try{ await callFn('local-logout', {});}catch(e){ console.warn(e); }
@@ -1963,7 +2032,7 @@ async function uiSmoke(){
     ['join-event',   !!document.querySelector('[data-action="join-event"]')],
     ['login',        !!document.querySelector('#login-btn')],
     ['signup',       !!document.querySelector('#signup-btn')],
-    ['logout',       !!document.querySelector('#logout-btn')],
+    ['logout',       !!document.querySelector('#btn-logout')],
   ];
   need.forEach(([k, ok])=> report.push({button:k, present:ok}));
   console.table(report);

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -9,11 +9,11 @@
 </head>
 <body class="scene-intro">
   <!-- Шапка -->
-  <nav class="topbar">
-    <button id="nav-menu" class="btn btn--ghost btn--sm" data-go="menu" type="button">Меню</button>
+  <header id="topbar" class="topbar">
+    <button id="nav-menu" class="btn btn--ghost btn--sm" data-go="lobby" type="button">Меню</button>
     <button id="nav-profile" class="btn btn--ghost btn--sm" data-go="profile" type="button">Профиль</button>
-    <button id="logout-btn" class="btn btn--ghost btn--sm" type="button">Выйти</button>
-  </nav>
+    <button id="btn-logout" class="btn btn--ghost btn--sm" type="button">Выйти</button>
+  </header>
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <div id="screen-auth" class="container" role="main">
     <div class="card" id="authPanel" style="max-width:620px;margin:40px auto">
@@ -111,7 +111,7 @@
       <div>Что взять: <span id="event-bring">—</span></div>
       <div>Комментарий: <span id="event-comment">—</span></div>
       <div class="mt-4">
-        <button id="back-to-menu" class="btn btn--secondary" data-go="menu" type="button">Вернуться в меню</button>
+        <button id="back-to-menu" class="btn btn--secondary" data-go="lobby" type="button">Вернуться в меню</button>
       </div>
     </section>
     <div class="wrap" id="root" hidden>
@@ -284,6 +284,23 @@
         </section>
       </section>
     </div>
+  </div>
+
+  <!-- ЭКРАН: ПРОФИЛЬ -->
+  <div id="screen-profile" class="container" hidden>
+    <section class="card">
+      <h2>Профиль</h2>
+      <div class="profile-grid">
+        <div>
+          <h3>Ближайшие события</h3>
+          <div id="profile-upcoming" class="profile-list"></div>
+        </div>
+        <div>
+          <h3>Прошедшие</h3>
+          <div id="profile-past" class="profile-list"></div>
+        </div>
+      </div>
+    </section>
   </div>
 
   <script>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -13,7 +13,7 @@
       <h1>Профиль</h1>
       <p>Никнейм: <strong id="profile-nickname"></strong></p>
       <p>Создан: <span id="profile-created"></span></p>
-      <button type="button" class="btn btn--ghost" id="logout-btn">Выйти</button>
+      <button type="button" class="btn btn--ghost" id="btn-logout">Выйти</button>
     </div>
   </main>
   <script>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -114,12 +114,19 @@ input, textarea, select { font-size: 16px; }
   background:var(--glass);
   color:#e6f7ee; font-weight:600; line-height:1;
   text-decoration:none; cursor:pointer;
+  pointer-events:auto;
   transition:transform .06s ease, box-shadow .2s ease, background .2s ease, border-color .2s ease;
   box-shadow:0 6px 18px rgba(0,0,0,.18);
 }
 .btn:hover{ transform:translateY(-1px); box-shadow:0 10px 24px rgba(0,0,0,.22);}
 .btn:active{ transform:translateY(0); box-shadow:0 4px 14px rgba(0,0,0,.18);}
-.btn:disabled{ opacity:.55; cursor:not-allowed; transform:none; }
+.btn[disabled],
+.btn.is-busy,
+.btn:disabled{
+  cursor:not-allowed;
+  opacity:.6;
+  transform:none;
+}
 .btn:focus-visible{ outline:2px solid var(--brand-400); outline-offset:2px; }
 
 /* Вариации */
@@ -138,6 +145,31 @@ a.btn{ color:inherit; }
 /* Дополнительные вариации */
 .btn--danger{ background:#b93737; color:#fff; }
 .btn--danger:hover{ background:#a12f2f; }
+
+.card, .container, header, nav {
+  pointer-events:auto;
+}
+
+.profile-grid {
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:16px;
+}
+.profile-list {
+  display:grid;
+  gap:10px;
+}
+.event-item {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:10px 12px;
+  border-radius:10px;
+  background:rgba(0,0,0,.2);
+  backdrop-filter:blur(4px);
+}
+.event-item__meta { opacity:.9; font-size:.9rem; }
+.event-item__actions { display:flex; gap:8px; }
 
 :focus-visible{
   outline:2px solid var(--ring);

--- a/netlify/functions/_auth.js
+++ b/netlify/functions/_auth.js
@@ -8,7 +8,7 @@ export function cors(extra = {}) {
     'Access-Control-Allow-Origin': CORS_ORIGIN,
     'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
     ...extra
   };
 }

--- a/netlify/functions/event-delete.js
+++ b/netlify/functions/event-delete.js
@@ -4,11 +4,11 @@ import { requireAuth, cors, ok, err } from './_auth.js';
 
 export const handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors() };
-  if (event.httpMethod !== 'POST') return err('Method not allowed', 405);
+  if (event.httpMethod !== 'DELETE') return err('Method not allowed', 405);
 
   const ctx = requireAuth(event); // { user: { sub, nickname, ... } }
-  const { event_id } = JSON.parse(event.body || '{}');
-  if (!event_id) return err('event_id required', 400);
+  const event_id = event.queryStringParameters?.id;
+  if (!event_id) return err('id required', 400);
 
   const sb = getServiceClient();
 

--- a/netlify/functions/events-mine.js
+++ b/netlify/functions/events-mine.js
@@ -1,0 +1,31 @@
+import { getServiceClient } from './_supabase.js';
+import { requireAuth, ok, err, cors } from './_auth.js';
+
+// Returns events of current user (hosted by user for now)
+export const handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors() };
+  if (event.httpMethod !== 'GET') return err('Method not allowed', 405);
+
+  const ctx = requireAuth(event);
+  if (!ctx) return err('Unauthorized', 401);
+
+  const sb = getServiceClient();
+  const { data: rows, error } = await sb
+    .from('events')
+    .select('id, code, title, date, time')
+    .eq('host_user_id', ctx.user.sub)
+    .order('date', { ascending: true });
+
+  if (error) return err('Failed to load', 500);
+
+  const items = (rows || []).map(r => ({
+    id: r.id,
+    code: r.code,
+    title: r.title,
+    date: r.date,
+    time: r.time,
+    is_host: true,
+  }));
+
+  return ok(items);
+};


### PR DESCRIPTION
## Summary
- add profile screen with upcoming and past events
- fix button cursor and navigation semantics
- support deleting and listing user events via new Netlify functions

## Testing
- `npm test`
- `node --check netlify/functions/events-mine.js`
- `node --check netlify/functions/event-delete.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6a0a957c08332ad291f7f2f189188