### PR TITLE
Add event creation/join endpoints and final screen updates

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -6,6 +6,43 @@ window.__FROGGY_BOOTED__ = true;
 const $  = (sel, root=document) => root.querySelector(sel);
 const $$ = (sel, root=document) => [...root.querySelectorAll(sel)];
 
+// --- API helpers ---
+const API = {
+  async createEvent(payload){
+    const res = await fetch('/.netlify/functions/event-create', {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json', ...authHeader() },
+      body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error||'Ошибка создания');
+    return data.event;
+  },
+  async joinByCode(code){
+    const res = await fetch('/.netlify/functions/event-join', {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify({ code })
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error||'Код не найден');
+    return data.event;
+  },
+  async loadEventByCode(code){
+    const res = await fetch(`/.netlify/functions/event-one?code=${encodeURIComponent(code)}`);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error||'Не найдено');
+    return data.event;
+  }
+};
+
+function authHeader(){
+  const t = getToken();
+  return t ? { Authorization: `Bearer ${t}` } : {};
+}
+
+const toast = (msg)=>alert(msg);
+
 // токен
 const TOKEN_KEY = 'FH_JWT';
 const getToken = () => localStorage.getItem(TOKEN_KEY);
@@ -27,15 +64,19 @@ function showScreen(id){
   console.debug('[screen] ->', id);
 }
 
-// ===== Делегируем клики по кнопкам навигации =====
-document.addEventListener('click', (e)=>{
-  const go = e.target.closest('[data-go]');
-  if (!go) return;
+// ===== Состояние события и навигация =====
+const State = { currentEvent:null, mode:'create' };
+
+document.addEventListener('click', async (e)=>{
+  const btn = e.target.closest('[data-go]');
+  if (!btn) return;
   e.preventDefault();
   e.stopPropagation();
-  const to = go.dataset.go;
-  if (SCREENS.includes(to)) {
-    showScreen(to);
+  const go = btn.dataset.go;
+  const mode = btn.dataset.mode;
+  if (mode){ document.body.dataset.mode = mode; State.mode = mode; }
+  if (SCREENS.includes(go)) {
+    showScreen(go);
   }
 });
 
@@ -75,15 +116,92 @@ if (loginForm) {
 $('#btn-create')?.addEventListener('click', (e)=>{ e.preventDefault(); showScreen('app'); });
 
 const joinForm = $('#join-form');
-if (joinForm) {
-  joinForm.addEventListener('submit', async (e)=>{
-    e.preventDefault(); e.stopPropagation();
-    const code = ($('#join-code')?.value || '').trim();
-    if (!code) return;
-    // здесь вызов проверки кода/загрузки события
-    // после успешной проверки уходим на экран app (или сразу final — по вашей логике)
-    showScreen('app');
-  });
+if (joinForm) joinForm.addEventListener('submit', e=>e.preventDefault());
+
+// запуск «создать событие»
+const saveBtn = $('#btn-save-event') || $('[data-action="save-event"]') || $('[data-role="next"]');
+if (saveBtn) saveBtn.addEventListener('click', onSaveEvent);
+
+async function onSaveEvent(){
+  try{
+    const title = ($('#event-title')?.value || $('#title')?.value || 'Моё событие').trim();
+    const date  = ($('#event-date')?.value || $('#date')?.value || '').trim();
+    const time  = ($('#event-time')?.value || $('#time')?.value || '').trim();
+    const address = ($('#event-address')?.value || $('#address')?.value || '').trim();
+    const dress_code = ($('#event-dress')?.value || $('#dress')?.value || '').trim();
+    const bring = ($('#event-bring')?.value || $('#bring')?.value || '').trim();
+    const comment = ($('#event-comment')?.value || $('#comment')?.value || '').trim();
+    const wishlist = collectWishlist();
+
+    const ev = await API.createEvent({ title, date, time, address, dress_code, bring, comment, wishlist });
+    State.currentEvent = ev;
+    renderFinal(ev);
+    toast('Событие создано');
+    showScreen('final');
+  }catch(e){ alert(e.message||'Ошибка'); }
+}
+
+// присоединиться по коду
+const joinBtn = $('#btn-join');
+if (joinBtn) joinBtn.addEventListener('click', onJoinByCode);
+async function onJoinByCode(){
+  try{
+    const code = ($('#join-code')?.value||'').trim();
+    if (!/^\d{6}$/.test(code)) throw new Error('Введите 6-значный код');
+    const ev = await API.joinByCode(code);
+    State.currentEvent = ev;
+    renderFinal(ev);
+    toast('Подключено');
+    showScreen('final');
+  }catch(e){ alert(e.message||'Код не найден'); }
+}
+
+function collectWishlist(){
+  return $$('.wish-row').map(row=>{
+    const title = $('input[name="wish-title"]', row)?.value?.trim();
+    const url   = $('input[name="wish-url"]', row)?.value?.trim();
+    return title ? { title, url } : null;
+  }).filter(Boolean);
+}
+
+// итоговый экран
+function renderFinal(ev){
+  const codeEl = $('#final-code'); if (codeEl) codeEl.textContent = ev.code || '—';
+  setText('#final-when', formatWhen(ev));
+  setText('#final-address', ev.address || '—');
+  setText('#final-dress', ev.dress_code || '—');
+  setText('#final-bring', ev.bring || '—');
+  setText('#final-comment', ev.comment || '—');
+  startCountdown(ev.date, ev.time);
+  const copy = $('#btn-copy-invite');
+  if (copy) copy.onclick = ()=>copyInvite(ev);
+}
+function setText(sel,val){ const n=$(sel); if(n) n.textContent=val; }
+function formatWhen(ev){ if(!ev?.date||!ev?.time) return '—'; return `${ev.date} • ${ev.time}`; }
+
+function copyInvite(ev){
+  const text=`Привет! Приглашаю тебя на "${ev.title}" 👋\nКогда: ${formatWhen(ev)}\nАдрес: ${ev.address||'—'}\nДресс-код: ${ev.dress_code||'—'}\nЧто взять: ${ev.bring||'—'}\nКод для входа: ${ev.code}\nЗайди на FroggyHub и введи код.`;
+  navigator.clipboard.writeText(text).then(()=>toast('Приглашение скопировано'));
+}
+
+// таймер
+let timerId;
+function startCountdown(date, time){
+  if (!date || !time) return;
+  const target = new Date(`${date}T${time}:00`);
+  const outTime = $('#countdown-time');
+  const outMeta = $('#countdown-meta');
+  clearInterval(timerId);
+  const tick=()=>{
+    const diff = target - new Date();
+    if (diff<=0){ if(outTime) outTime.textContent='00:00'; if(outMeta) outMeta.textContent=''; clearInterval(timerId); return; }
+    const d = Math.floor(diff/86400000);
+    const h = Math.floor((diff%86400000)/3600000);
+    const m = Math.floor((diff%3600000)/60000);
+    if(outTime) outTime.textContent=`${String(h).padStart(2,'0')}:${String(m).padStart(2,'0')}`;
+    if(outMeta) outMeta.textContent = d>0 ? `${d} дн.` : '';
+  };
+  tick(); timerId=setInterval(tick,30000);
 }
 
 // ===== Выход (только на экране профиля виден) =====

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -46,10 +46,20 @@
   </section>
 
   <!-- ЭКРАН 4: ФИНАЛ С ИТОГОВОЙ ИНФОЙ -->
-  <section id="screen-final" class="screen container" hidden>
-    <div class="final-card">
-      <!-- итоговая информация события -->
+  <section id="screen-final" class="screen container" hidden aria-labelledby="final-title">
+    <h1 id="final-title" class="sr-focus" tabindex="-1">Итоги события</h1>
+    <!-- финальная инфа -->
+    <div class="final-head">
+      Код: <span id="final-code">—</span>
+      <button id="btn-copy-invite" type="button" class="btn btn-secondary">Скопировать приглашение</button>
     </div>
+    <ul class="final-list">
+      <li>Когда: <span id="final-when">—</span></li>
+      <li>Адрес: <span id="final-address">—</span></li>
+      <li>Дресс-код: <span id="final-dress">—</span></li>
+      <li>Что взять: <span id="final-bring">—</span></li>
+      <li>Комментарий: <span id="final-comment">—</span></li>
+    </ul>
     <button class="btn btn-ghost" data-go="lobby">Вернуться в меню</button>
   </section>
 

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -23,8 +23,8 @@
     <section id="lobby-left" class="lobby-left">
       <div class="frog-hero"></div>
       <div class="countdown">
-        <div class="countdown-big" data-countdown-big>00:00</div>
-        <div class="countdown-small" data-countdown-small>1 января</div>
+        <div id="countdown-time" class="countdown-big" data-countdown-big>00:00</div>
+        <div id="countdown-meta" class="countdown-small" data-countdown-small></div>
       </div>
     </section>
 

--- a/netlify/functions/event-create.js
+++ b/netlify/functions/event-create.js
@@ -1,0 +1,55 @@
+// ESM
+import jwt from 'jsonwebtoken';
+import { getServiceClient } from './_supabase.js';
+
+const ok = (body, status=200)=>({ statusCode: status, headers: hdr(), body: JSON.stringify(body) });
+const err = (message, status=400)=>({ statusCode: status, headers: hdr(), body: JSON.stringify({ error: message }) });
+const hdr = () => ({
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+});
+
+export async function handler(event) {
+  if (event.httpMethod === 'OPTIONS') return ok({});
+  if (event.httpMethod !== 'POST') return err('Method not allowed', 405);
+  try {
+    const auth = event.headers.authorization || '';
+    const token = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+    if (!token) return err('Unauthorized', 401);
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    const userId = payload.sub;
+
+    const { title, date, time, address, dress_code, bring, comment, wishlist=[] } = JSON.parse(event.body||'{}');
+    if (!title || !date || !time) return err('title, date, time required');
+
+    const sb = getServiceClient();
+
+    // уникальный 6-значный код
+    let code;
+    for (let i=0;i<5;i++) {
+      code = String(Math.floor(100000 + Math.random()*900000));
+      const { data:exists } = await sb.from('events').select('id').eq('code', code).maybeSingle();
+      if (!exists) break;
+      code = null;
+    }
+    if (!code) return err('Failed to generate code', 500);
+
+    const { data:ev, error } = await sb.from('events').insert({
+      code, host_user_id: userId, title, date, time, address, dress_code, bring, comment
+    }).select('*').single();
+    if (error) return err(error.message, 400);
+
+    // wishlist
+    if (Array.isArray(wishlist) && wishlist.length) {
+      const rows = wishlist
+        .filter(x=>x && x.title)
+        .map(x=>({ event_id: ev.id, title: x.title, url: x.url||null }));
+      if (rows.length) await sb.from('wishlist_items').insert(rows);
+    }
+    return ok({ success:true, event: ev });
+  } catch (e) {
+    return err(e.message || 'Server error', 500);
+  }
+}

--- a/netlify/functions/event-join.js
+++ b/netlify/functions/event-join.js
@@ -1,0 +1,23 @@
+import { getServiceClient } from './_supabase.js';
+
+const ok = (b,s=200)=>({ statusCode:s, headers:hdr(), body:JSON.stringify(b) });
+const err = (m,s=400)=>({ statusCode:s, headers:hdr(), body:JSON.stringify({ error:m }) });
+const hdr = ()=>({
+  'Content-Type':'application/json',
+  'Access-Control-Allow-Origin':'*',
+  'Access-Control-Allow-Methods':'GET,POST,OPTIONS',
+  'Access-Control-Allow-Headers':'Content-Type, Authorization',
+});
+
+export async function handler(event){
+  if (event.httpMethod==='OPTIONS') return ok({});
+  if (event.httpMethod!=='POST') return err('Method not allowed',405);
+  try{
+    const { code } = JSON.parse(event.body||'{}');
+    if (!code || String(code).length!==6) return err('Invalid code');
+    const sb = getServiceClient();
+    const { data:ev, error } = await sb.from('events').select('*').eq('code', String(code)).single();
+    if (error || !ev) return err('Код не найден',404);
+    return ok({ success:true, event: ev });
+  }catch(e){ return err(e.message||'Server error',500); }
+}

--- a/netlify/functions/event-one.js
+++ b/netlify/functions/event-one.js
@@ -1,0 +1,15 @@
+import { getServiceClient } from './_supabase.js';
+const ok=(b,s=200)=>({statusCode:s,headers:hdr(),body:JSON.stringify(b)});
+const err=(m,s=400)=>({statusCode:s,headers:hdr(),body:JSON.stringify({error:m})});
+const hdr=()=>({'Content-Type':'application/json','Access-Control-Allow-Origin':'*'});
+export async function handler(event){
+  const id = event.queryStringParameters?.id;
+  const code = event.queryStringParameters?.code;
+  if (!id && !code) return err('id or code required',400);
+  const sb=getServiceClient();
+  let q = sb.from('events').select('*, wishlist_items(*)').limit(1);
+  if (id) q = q.eq('id', id); else q = q.eq('code', code);
+  const { data, error } = await q.single();
+  if (error || !data) return err('Not found',404);
+  return ok({ event: data });
+}


### PR DESCRIPTION
## Summary
- add Netlify functions for creating events, joining by code, and fetching a single event
- wire frontend to new APIs with copyable invites and countdown timer
- mark up final screen and countdown elements with IDs for dynamic updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6af1cce808332b45a1e2f4bb24d30