### PR TITLE
feat: wrap screens with container panels

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -16,43 +16,57 @@
 
   <!-- 1) Меню — выбор действия после авторизации -->
   <section id="screen-menu" class="screen">
-    <div class="container stack-md">
-      <button id="create-event" class="btn btn-primary" data-go="app" data-mode="create">Создать событие</button>
-      <form id="join-form" class="row gap-sm" autocomplete="off">
-        <input id="join-code" class="input" inputmode="numeric" maxlength="6" placeholder="Введите 6-значный код" />
-        <button id="join-event" class="btn btn-secondary" data-go="app" data-mode="join">Присоединиться</button>
-      </form>
+    <div class="container">
+      <div class="panel">
+        <div class="lobby-grid">
+          <button id="create-event" class="btn btn-primary" data-go="app">Создать событие</button>
+          <form id="join-form" class="join-row" autocomplete="off">
+            <input id="join-code" class="input" placeholder="Введите 6-значный код" inputmode="numeric" maxlength="6" />
+            <button id="join-btn" class="btn">Присоединиться</button>
+          </form>
+        </div>
+      </div>
     </div>
   </section>
 
   <!-- 2) Мастер создания/подключения (контент уже есть в проекте) -->
   <section id="screen-app" class="screen" hidden>
-    <!-- существующая разметка мастера; никакой финальной карточки здесь -->
+    <div class="container">
+      <div class="panel">
+        <!-- существующая разметка мастера; никакой финальной карточки здесь -->
+      </div>
+    </div>
   </section>
 
   <!-- 3) Финальная информация (только этот экран показывает итоговую карточку) -->
   <section id="screen-final" class="screen" hidden>
-    <div id="final-card" class="final-card container">
-      <!-- здесь отрисовывается итог события -->
-    </div>
-    <div class="actions">
-      <button class="btn" data-go="menu">Вернуться в меню</button>
+    <div class="container">
+      <div class="panel">
+        <div id="final-card" class="final-card">
+          <!-- здесь отрисовывается итог события -->
+        </div>
+        <div class="actions">
+          <button class="btn" data-go="menu">Вернуться в меню</button>
+        </div>
+      </div>
     </div>
   </section>
 
   <!-- 4) Профиль — список моих событий -->
   <section id="screen-profile" class="screen" hidden>
     <div class="container">
-      <h2>Профиль</h2>
-      <div class="profile-grid">
-        <section>
-          <h3>Скоро</h3>
-          <div id="profile-upcoming" class="event-grid"></div>
-        </section>
-        <section>
-          <h3>Прошедшие</h3>
-          <div id="profile-past" class="event-grid"></div>
-        </section>
+      <div class="panel">
+        <h2>Профиль</h2>
+        <div class="profile-grid">
+          <section>
+            <h3>Скоро</h3>
+            <div id="profile-upcoming" class="event-grid"></div>
+          </section>
+          <section>
+            <h3>Прошедшие</h3>
+            <div id="profile-past" class="event-grid"></div>
+          </section>
+        </div>
       </div>
     </div>
   </section>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -197,7 +197,8 @@ a.btn{ color:inherit; }
 }
 
 .hint{color:var(--muted);font-size:.92rem}
- .hero{display:flex;gap:16px;align-items:center;margin-bottom:10px}
+.hero{display:flex;gap:16px;align-items:center;margin-bottom:10px}
+
  .hero, .header-pond { position: relative; overflow: hidden; }
 .avatar{width:64px;height:64px;border-radius:50%;display:grid;place-items:center;font-size:28px;background:var(--accent)}
 .hero-text h1{margin:0 0 6px}
@@ -642,4 +643,106 @@ body.scene-intro .speech{display:block}
 .wl-tag { display:inline-block; padding:4px 8px; border-radius:999px; font-size:12px; }
 .wl-free { background:#d7fbe8; color:#0b3d2a; }
 .wl-taken { background:#ffe3e3; color:#7a1c1c; }
+
+/* ====== Каркас страницы ====== */
+:root{
+  --topbar-h: 56px;
+  --page-pad: 16px;
+  --content-w: 980px;
+  --gap: 14px;
+}
+
+/* Тело как двумерный каркас: шапка + контент */
+body.scene-intro{
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: var(--topbar-h) 1fr;
+}
+
+/* Верхняя панель (твои кнопки "Меню / Профиль / Выйти") */
+.topbar{
+  position: sticky;
+  top: 0;
+  height: var(--topbar-h);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 var(--page-pad);
+  z-index: 5;
+}
+
+/* Центровщик контента экрана */
+.container{
+  width: min(100%, var(--content-w));
+  margin: 32px auto 48px;
+  padding: 0 var(--page-pad);
+}
+
+/* Универсальная карточка-«окно» */
+.panel{
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.25);
+  padding: 20px;
+}
+
+/* Служебное: невидимые экраны не занимают место */
+[hidden]{ display: none !important; }
+
+/* Декор не перехватывает клики и не сдвигает сетку */
+.decoration, .bg-layer, .lilies, .frog, .stump{
+  pointer-events: none !important;
+}
+
+/* ====== Меню (первый экран после входа) ====== */
+.lobby-grid{
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--gap);
+}
+
+/* На широкой — кнопка «Создать событие» растягивается,
+   справа — строка присоединения */
+@media (min-width: 720px){
+  .lobby-grid{
+    grid-template-columns: 1fr auto;
+    align-items: center;
+  }
+}
+
+/* Ряд с кодом + кнопкой присоединения */
+.join-row{
+  display: flex;
+  align-items: center;
+  gap: var(--gap);
+  margin: 0;
+}
+
+/* Инпут с кодом — фикс. ширина, но ужимается на мобильных */
+#join-code.input{
+  width: 260px;
+  max-width: 48vw;
+  text-align: center;
+}
+
+/* Кнопки всегда выглядят кликабельно (кроме disabled) */
+button, .btn{
+  cursor: pointer;
+}
+button[disabled], .btn[disabled]{
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* ====== Общие отступы внутри карточек ====== */
+.panel > * + *{ margin-top: var(--gap); }
+
+/* На остальных экранах карточки также центрируются той же шириной */
+#screen-app .panel,
+#screen-final .panel,
+#screen-profile .panel,
+#screen-auth .panel{
+  /* можно кастомизировать при желании */
+}
 


### PR DESCRIPTION
## Summary
- center screen content in `index.html` with `.container` and `.panel` wrappers
- add responsive layout styles and lobby grid helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6b2e6d6548332a6caea5af175a14c