### PR TITLE
feat: add menu and profile screens with avatars

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -32,14 +32,10 @@ const saveToken  = t => { try { localStorage.setItem(TOKEN_KEY, t); } catch {} }
 const getToken   = () => { try { return localStorage.getItem(TOKEN_KEY); } catch { return null } };
 const clearToken = () => { try { localStorage.removeItem(TOKEN_KEY); } catch {} };
 
-function showScreen(id) {
-  const ids = ['auth','lobby','app','profile'];
-  ids.forEach(s => {
-    const el = document.getElementById('screen-' + s);
-    if (el) el.hidden = (s !== id);
-  });
-  document.body.dataset.screen = id;
-  console.log('[screen] =>', id);
+function showScreen(name){
+  $$('[id^="screen-"]').forEach(s => s.hidden = s.id !== `screen-${name}`);
+  document.body.dataset.screen = name;
+  console.log('[screen] =>', name);
 }
 
 async function apiPost(fnPath, payload) {
@@ -62,7 +58,7 @@ document.querySelectorAll('input, textarea, select').forEach(el=>{
   el.classList.add('input');
 });
 
-['create-event','join-event','login-btn','signup-btn','btn-logout'].forEach(id=>{
+['create-event','join-open','login-btn','signup-btn','btn-logout'].forEach(id=>{
   const el = document.getElementById(id);
   console.debug('[btn]', id, 'present=', !!el);
 });
@@ -121,25 +117,135 @@ async function renderProfile() {
 }
 
 // Навигация по атрибуту data-go
-document.addEventListener('click', (e) => {
-  const el = e.target.closest('[data-go]');
-  if (!el) return;
+document.addEventListener('click', (e)=>{
+  const go = e.target.closest('[data-go]');
+  if (!go) return;
   e.preventDefault();
-  const go = el.dataset.go;
-  const mode = el.dataset.mode || null;
-  showScreen(go);
-  if (go === 'app') {
+  const dest = go.getAttribute('data-go');
+  if (dest === 'settings') return;
+  showScreen(dest);
+  if (dest === 'profile') loadProfileAndEvents().catch(console.error);
+  if (dest === 'app') {
+    const mode = go.getAttribute('data-mode') || null;
     setWizardMode?.(mode || 'create');
     requestAnimationFrame(() => document.querySelector('#screen-app input, #screen-app textarea')?.focus());
   }
-  if (go === 'profile') { renderProfile(); }
 });
 
-// Не даём форме "join" перезагружать страницу
-document.querySelector('#join-form')?.addEventListener('submit', (e) => {
+$('#create-event')?.addEventListener('click', (e)=>{
   e.preventDefault();
-  document.querySelector('#join-event')?.click();
+  showScreen('app');
 });
+
+$('#join-form')?.addEventListener('submit', async (e)=>{
+  e.preventDefault();
+  $('#join-open')?.setAttribute('disabled','');
+  try{
+    const code = ($('#join-code')?.value || '').trim();
+    if (code.length !== 6) throw new Error('Введите 6-значный код');
+    const { event } = await apiFetch(`events-get?code=${encodeURIComponent(code)}`);
+    if (typeof openFinal === 'function') {
+      await openFinal(event.code);
+    } else if (typeof openEvent === 'function') {
+      await openEvent(event);
+    } else {
+      const fc=$('#final-code'); if(fc) fc.textContent = event.code || '—';
+      const ft=$('#final-title'); if(ft) ft.textContent = event.title || '—';
+      const fw=$('#final-when'); if(fw) fw.textContent = `${event.date||''} ${event.time||''}`.trim();
+      const fa=$('#final-address'); if(fa) fa.textContent = event.address || '—';
+      const fd=$('#final-dress'); if(fd) fd.textContent   = event.dress || '—';
+      const fb=$('#final-bring'); if(fb) fb.textContent   = event.bring || '—';
+      const fcm=$('#final-comment'); if(fcm) fcm.textContent = event.comment || '—';
+      showScreen('app');
+    }
+  } catch(err){ alert(err.message || 'Код не найден'); }
+  finally{ $('#join-open')?.removeAttribute('disabled'); }
+});
+
+async function apiFetch(path, init={}){
+  init.headers = Object.assign({'Content-Type':'application/json'}, authHeaders(), init.headers||{});
+  const res = await fetch(`/.netlify/functions/${path}`, init);
+  const data = await res.json().catch(()=>({}));
+  if (!res.ok || data?.success===false) throw new Error(data?.error || `HTTP ${res.status}`);
+  return data;
+}
+
+async function loadProfileAndEvents(){
+  const prof = await apiFetch('profile');
+  $('#profile-nick').textContent = prof.nickname || '—';
+  if (prof.avatar_url) $('#avatar-img').src = prof.avatar_url;
+
+  const { events } = await apiFetch('events-mine');
+  const { upcoming, past } = splitEvents(events);
+  renderEventsColumn('#profile-upcoming', upcoming);
+  renderEventsColumn('#profile-past', past);
+}
+
+function splitEvents(list){
+  const now = new Date();
+  const parse = (e)=>{
+    const dt = new Date(`${e.date || ''}T${(e.time||'00:00')}:00`);
+    return isFinite(dt) ? dt : new Date(8640000000000000);
+  };
+  const upcoming = [], past = [];
+  for (const e of list){
+    (parse(e) >= now ? upcoming : past).push(e);
+  }
+  upcoming.sort((a,b)=> new Date(`${a.date}T${a.time||'00:00'}`) - new Date(`${b.date}T${b.time||'00:00'}`));
+  past.sort((a,b)=> new Date(`${b.date}T${b.time||'00:00'}`) - new Date(`${a.date}T${a.time||'00:00'}`));
+  return { upcoming, past };
+}
+
+function renderEventsColumn(sel, items){
+  const box = $(sel); if (!box) return;
+  box.innerHTML = items.map(e => `
+    <div class="event-item" data-open-event="${e.code || e.id}">
+      <div>
+        <div class="event-title">${e.title || '—'}</div>
+        <div class="event-meta">${e.date || '—'} ${e.time || ''} · ${e.address || '—'}</div>
+      </div>
+      <div class="event-actions">
+        <button class="btn btn-sm" data-open-event="${e.code || e.id}">Открыть</button>
+      </div>
+    </div>
+  `).join('') || '<div style="opacity:.7">Пока пусто</div>';
+}
+
+document.addEventListener('click', async (e)=>{
+  const trg = e.target.closest('[data-open-event]');
+  if (!trg) return;
+  const key = trg.getAttribute('data-open-event');
+  try{
+    const q = isNaN(+key) ? `events-get?code=${encodeURIComponent(key)}` : `events-get?id=${key}`;
+    const { event } = await apiFetch(q);
+    if (typeof openFinal === 'function')      await openFinal(event.code);
+    else if (typeof openEvent === 'function')  await openEvent(event);
+    else {
+      const ft=$('#final-title'); if(ft) ft.textContent = event.title || '—';
+      showScreen('app');
+    }
+  }catch(err){ alert(err.message || 'Не удалось открыть событие'); }
+});
+
+$('#avatar-upload')?.addEventListener('click', ()=> $('#avatar-file')?.click());
+$('#avatar-file')?.addEventListener('change', async (e)=>{
+  const file = e.target.files?.[0]; if (!file) return;
+  const b64 = await fileToBase64Resized(file, 512);
+  try{
+    const { url } = await apiFetch('avatar-upload', { method:'POST', body: JSON.stringify({ image: b64 }) });
+    $('#avatar-img').src = url;
+  }catch(err){ alert(err.message || 'Не удалось загрузить аватар'); }
+});
+
+async function fileToBase64Resized(file, max){
+  const img = await new Promise(r => { const i=new Image(); i.onload=()=>r(i); i.src=URL.createObjectURL(file); });
+  const scale = Math.min(1, max/Math.max(img.width, img.height));
+  const w = Math.max(1, Math.round(img.width*scale));
+  const h = Math.max(1, Math.round(img.height*scale));
+  const c = document.createElement('canvas'); c.width=w; c.height=h;
+  c.getContext('2d').drawImage(img,0,0,w,h);
+  return c.toDataURL('image/jpeg', 0.9);
+}
 
 const state = window.__APP_STATE__ ?? (window.__APP_STATE__ = { currentEvent: null });
 
@@ -591,9 +697,9 @@ function trapFocus(node){
   return ()=>node.removeEventListener('keydown',handler);
 }
 function show(idToShow){
-  const map = {'#screen-auth':'auth', '#screen-lobby':'lobby', '#screen-app':'app'};
+  const map = {'#screen-auth':'auth', '#screen-menu':'menu', '#screen-app':'app', '#screen-profile':'profile'};
   if (map[idToShow]) return showScreen(map[idToShow]);
-  ['#screen-auth','#screen-lobby','#screen-app'].forEach(id=>{
+  ['#screen-auth','#screen-menu','#screen-app','#screen-profile'].forEach(id=>{
     const el=$(id); if(!el) return; el.hidden = (id!==idToShow);
   });
 }
@@ -762,7 +868,7 @@ function setStatus(zone,msg){
 }
 
 function goToLobby(){
-  show('#screen-lobby');
+  show('#screen-menu');
 }
 
 async function handleRegister(){
@@ -883,7 +989,7 @@ resetSetBtn?.addEventListener('click', async ()=>{
       setSession(emailSup);
       window.currentUserEmail = emailSup;
       renderUserBadge({ nickname: getNickname(), email: emailSup });
-      show('#screen-lobby');
+      show('#screen-menu');
       return;
     }
   }
@@ -891,7 +997,7 @@ resetSetBtn?.addEventListener('click', async ()=>{
   if (email && users[email]) {
     window.currentUserEmail = email;
     renderUserBadge({ nickname: getNickname(), email });
-    show('#screen-lobby');
+    show('#screen-menu');
   } else {
     localStorage.removeItem(SESSION_KEY);
     show('#screen-auth');
@@ -1045,7 +1151,7 @@ ensureSupabase().then(async sb => {
     if(currentUser){
       window.currentUserEmail = currentUser.email || '';
       renderUserBadge({ nickname: getNickname(), email: window.currentUserEmail });
-      show('#screen-lobby');
+      show('#screen-menu');
       const pending = sessionStorage.getItem('pendingCreate');
       if(pending){
         Object.assign(eventData, JSON.parse(pending));
@@ -1092,7 +1198,7 @@ ensureSupabase().then(async sb => {
       window.currentUserEmail = currentUser.email || '';
       renderUserBadge({ nickname: getNickname(), email: window.currentUserEmail });
       if(isHome){
-        show('#screen-lobby');
+        show('#screen-menu');
         const pendingProfile = sessionStorage.getItem('pendingProfileName');
         if(pendingProfile){
           try{ await sb.from('profiles').upsert({ id: currentUser.id, nickname: pendingProfile }); }catch(e){ console.warn('profile upsert', e); }
@@ -2451,7 +2557,7 @@ function wireAuthForms(){
         const data = await apiLogin(nickname, password);
         if (data?.token){
           saveToken(data.token);
-          showScreen('lobby');        // ← показываем меню/лобби
+          showScreen('menu');        // ← показываем меню/лобби
           if (typeof loadLobby === 'function') loadLobby();
         } else {
           alert(data?.error || 'Ошибка входа');
@@ -2485,7 +2591,7 @@ function wireAuthForms(){
           const lg = await apiLogin(nickname, password);
           if (lg?.token){
             saveToken(lg.token);
-            showScreen('lobby');
+            showScreen('menu');
             if (typeof loadLobby === 'function') loadLobby();
             return;
           }
@@ -2502,7 +2608,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
   wireAuthForms();
 
   // если уже залогинен — сразу меню
-  if (getToken()) showScreen('lobby');
+  if (getToken()) showScreen('menu');
   else            showScreen('auth');
 
   // Навешанные делегированные клики работают всегда, ничего больше не нужно
@@ -2520,3 +2626,5 @@ document.addEventListener('DOMContentLoaded', () => {
     if (typeof renderMainMenu === 'function') renderMainMenu(); // страница "Создать / Присоединиться"
   }
 });
+
+if (!document.body.dataset.screen) showScreen('menu');

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -11,11 +11,16 @@
 </head>
 <body class="scene-intro">
   <!-- Шапка -->
-  <header id="topbar" class="topbar">
-    <button id="nav-menu" class="btn btn--ghost btn--sm" data-go="lobby" type="button">Меню</button>
-    <button id="nav-profile" class="btn btn--ghost btn--sm" data-go="profile" type="button">Профиль</button>
-    <button id="btn-logout" class="btn btn--ghost btn--sm" type="button">Выйти</button>
-  </header>
+  <nav class="topbar">
+    <div class="topbar-left">
+      <a href="#" id="logo" class="logo" data-go="menu">FroggyHub</a>
+    </div>
+    <div class="topbar-right">
+      <button id="nav-menu" class="btn btn-sm btn-ghost" data-go="menu" hidden>Меню</button>
+      <button id="nav-profile" class="btn btn-sm btn-ghost" data-go="profile">Профиль</button>
+      <button id="nav-settings" class="btn btn-sm btn-ghost" data-go="settings">Настройки</button>
+    </div>
+  </nav>
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <div id="screen-auth" class="container" role="main">
     <div class="card" id="authPanel" style="max-width:620px;margin:40px auto">
@@ -75,32 +80,29 @@
     </div>
   </div>
 
-  <!-- ЭКРАН 2: ГЛАВНОЕ МЕНЮ -->
-  <div id="screen-lobby" class="container" hidden>
-    <div class="card" style="max-width:760px;margin:28px auto">
-      <div class="hero">
-        <div class="avatar frog-ava">🐸</div>
-        <div class="hero-text">
-          <h1>Главное меню</h1>
-          <div class="chips">
-            <span class="chip">Шаг 2</span>
-            <span class="pill" data-user-badge>гость</span>
-          </div>
-        </div>
-      </div>
+  <!-- ЭКРАН МЕНЮ -->
+  <section id="screen-menu" class="screen" role="main">
+    <div class="decor-layer" aria-hidden="true">
+      <img class="decor frog"  src="/assets/frog_idle.png" alt="">
+      <img class="decor stump" src="/assets/stump.png"     alt="">
+    </div>
 
-      <div class="grid">
-          <button id="create-event" class="btn btn--primary btn--xl w-full" data-go="app" data-mode="create" type="button">Создать событие</button>
-        <div class="card inner">
-          <h3>Присоединиться к ивенту</h3>
-          <form id="join-form" class="row2 join">
-            <input id="join-code" class="input" placeholder="Введите 6-значный код" inputmode="numeric" pattern="\d*" autocomplete="one-time-code" maxlength="6">
-            <button id="join-event" class="btn btn--ghost" data-go="app" data-mode="join" type="button" disabled>Присоединиться</button>
-            </form>
+    <div class="container">
+      <div class="panel">
+        <div class="menu-grid">
+          <button id="create-event" class="btn btn-primary" data-go="app" data-mode="create">
+            Создать событие
+          </button>
+
+          <form id="join-form" class="join-row" autocomplete="off">
+            <input id="join-code" class="input" inputmode="numeric" maxlength="6"
+                   placeholder="Введите 6-значный код">
+            <button id="join-open" class="btn">Присоединиться</button>
+          </form>
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
   <!-- ЭКРАН 3: ПРУД + ФИНАЛ -->
   <div id="screen-app" class="container" hidden>
@@ -113,7 +115,7 @@
       <div>Что взять: <span id="event-bring">—</span></div>
       <div>Комментарий: <span id="event-comment">—</span></div>
       <div class="mt-4">
-        <button id="back-to-menu" class="btn btn--secondary" data-go="lobby" type="button">Вернуться в меню</button>
+        <button id="back-to-menu" class="btn btn--secondary" data-go="menu" type="button">Вернуться в меню</button>
       </div>
     </section>
     <div class="wrap" id="root" hidden>
@@ -289,21 +291,33 @@
   </div>
 
   <!-- ЭКРАН: ПРОФИЛЬ -->
-  <div id="screen-profile" class="container" hidden>
-    <section class="card">
-      <h2>Профиль</h2>
-      <div class="profile-grid">
-        <div>
-          <h3>Ближайшие события</h3>
-          <div id="profile-upcoming" class="profile-list"></div>
+  <section id="screen-profile" class="screen" hidden>
+    <div class="container">
+      <div class="panel profile-card">
+        <div class="profile-head">
+          <div class="avatar-wrap">
+            <img id="avatar-img" class="avatar" src="/assets/frog_avatar_placeholder.png" alt="">
+            <input id="avatar-file" type="file" accept="image/*" hidden>
+            <button id="avatar-upload" class="btn btn-sm">Загрузить аватар</button>
+          </div>
+          <div class="profile-meta">
+            <div class="profile-nick" id="profile-nick">—</div>
+          </div>
         </div>
-        <div>
-          <h3>Прошедшие</h3>
-          <div id="profile-past" class="profile-list"></div>
+
+        <div class="profile-grid">
+          <div>
+            <h3>Скоро</h3>
+            <div id="profile-upcoming" class="events-col"></div>
+          </div>
+          <div>
+            <h3>Прошедшие события</h3>
+            <div id="profile-past" class="events-col"></div>
+          </div>
         </div>
       </div>
-    </section>
-  </div>
+    </div>
+  </section>
 
   <script>
     // TODO: заполнить для проды через переменные окружения Netlify

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -640,3 +640,64 @@ body.scene-intro .speech{display:block}
 .wl-free { background:#d7fbe8; color:#0b3d2a; }
 .wl-taken { background:#ffe3e3; color:#7a1c1c; }
 
+/* Top bar */
+.topbar{
+  position: sticky; top: 0; z-index: 50;
+  display:flex; align-items:center; justify-content:space-between;
+  padding:10px 16px;
+  background:rgba(0,0,0,.15); backdrop-filter:blur(6px);
+  border-bottom:1px solid rgba(255,255,255,.06);
+}
+.topbar .logo{ font-weight:800; letter-spacing:.3px; color:#cdeed9; text-decoration:none; }
+.topbar-right{ display:flex; gap:8px; }
+.btn-sm{ padding:6px 10px; font-size:12px; border-radius:12px; }
+.btn-ghost{ background:transparent; border:1px solid rgba(255,255,255,.18); }
+.btn-ghost:hover{ background:rgba(255,255,255,.06); }
+
+/* Layout helpers */
+.container{ max-width:980px; margin:32px auto; padding:0 16px; }
+.panel{
+  background:rgba(0,0,0,.18); border:1px solid rgba(255,255,255,.08);
+  border-radius:20px; box-shadow:0 10px 28px rgba(0,0,0,.3); padding:18px;
+}
+
+/* Menu */
+.menu-grid{ display:grid; gap:12px; grid-template-columns:1fr; }
+.join-row{ display:grid; gap:10px; grid-template-columns:1fr auto; }
+@media (min-width:760px){
+  .menu-grid{ grid-template-columns:1fr 1fr 1fr; align-items:center; }
+}
+
+/* Decor should not intercept clicks */
+.decor-layer{ position:relative; pointer-events:none; }
+.decor{ position:absolute; pointer-events:none; user-select:none; opacity:.95; }
+.decor.frog{ left:18px; top:160px; width:120px; }
+.decor.stump{ left:0; bottom:-20px; width:180px; opacity:.85; }
+
+/* Show Menu button on non-menu screens */
+body[data-screen="menu"] #nav-menu{ display:none !important; }
+body:not([data-screen="menu"]) #nav-menu{ display:inline-flex !important; }
+button:not([disabled]){ cursor:pointer; }
+
+/* Profile */
+.profile-card{ display:grid; gap:18px; }
+.profile-head{ display:flex; gap:18px; align-items:center; }
+.avatar-wrap{ display:flex; gap:10px; align-items:center; }
+.avatar{
+  width:84px; height:84px; border-radius:50%;
+  object-fit:cover; background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.18);
+}
+.profile-nick{ font-size:20px; font-weight:700; }
+.profile-grid{
+  display:grid; gap:18px; grid-template-columns:1fr; 
+}
+@media (min-width:860px){ .profile-grid{ grid-template-columns:1fr 1fr; } }
+.events-col{ display:grid; gap:10px; }
+.event-item{
+  display:flex; justify-content:space-between; align-items:center; gap:12px;
+  padding:10px 12px; border:1px solid rgba(255,255,255,.1); border-radius:12px;
+  background:rgba(0,0,0,.14);
+}
+.event-title{ font-weight:700; }
+.event-meta{ opacity:.8; font-size:12px; }
+.event-actions{ display:flex; gap:8px; }

--- a/migrations/add_avatar_url.sql
+++ b/migrations/add_avatar_url.sql
@@ -1,0 +1,4 @@
+alter table public.users_local
+  add column if not exists avatar_url text;
+
+create index if not exists guests_nickname_idx on public.guests(nickname);

--- a/netlify/functions/avatar-upload.js
+++ b/netlify/functions/avatar-upload.js
@@ -1,0 +1,27 @@
+import { getServiceClient } from './_supabase.js';
+import { requireAuth, ok, err, cors } from './_auth.js';
+
+function decodeDataURL(dataUrl){
+  const m = /^data:(.+);base64,(.+)$/.exec(dataUrl||''); if(!m) throw new Error('Bad image');
+  return Buffer.from(m[2],'base64');
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors() };
+  if (event.httpMethod !== 'POST') return err('Method not allowed', 405);
+  const auth = requireAuth(event);
+  if (!auth) return err('Unauthorized', 401);
+  try{
+    const { image } = JSON.parse(event.body || '{}');
+    const buf = decodeDataURL(image);
+    const sb = getServiceClient();
+    const path = `avatars/${auth.user.sub}.jpg`;
+    const { error:upErr } = await sb.storage.from('avatars').upload(path, buf, { upsert:true, contentType:'image/jpeg' });
+    if (upErr) throw upErr;
+    const { data:pub } = sb.storage.from('avatars').getPublicUrl(path);
+    await sb.from('users_local').update({ avatar_url: pub.publicUrl }).eq('id', auth.user.sub);
+    return ok({ url: pub.publicUrl });
+  }catch(e){
+    return err(e.message || 'Failed to upload', 400);
+  }
+};

--- a/netlify/functions/events-join.js
+++ b/netlify/functions/events-join.js
@@ -7,8 +7,8 @@ export async function handler(event) {
   if (event.httpMethod !== 'POST') return err('Method not allowed', 405);
 
   try {
-    const { code, name } = JSON.parse(event.body || '{}');
-    if (!code || !name) return err('Code and name required', 400);
+    const { code, nickname } = JSON.parse(event.body || '{}');
+    if (!code || !nickname) return err('Code and nickname required', 400);
 
     const sb = getServiceClient();
     const { data: evt, error } = await sb.from('events').select('id').eq('code', code.toUpperCase()).single();
@@ -16,7 +16,7 @@ export async function handler(event) {
 
     const { data: g, error: e2 } = await sb
       .from('guests')
-      .insert({ event_id: evt.id, name, rsvp: 'maybe' })
+      .insert({ event_id: evt.id, nickname, rsvp: 'maybe' })
       .select('id')
       .single();
     if (e2) throw e2;

--- a/netlify/functions/events-mine.js
+++ b/netlify/functions/events-mine.js
@@ -1,7 +1,6 @@
 import { getServiceClient } from './_supabase.js';
 import { requireAuth, ok, err, cors } from './_auth.js';
 
-// Returns events of current user (hosted by user for now)
 export const handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors() };
   if (event.httpMethod !== 'GET') return err('Method not allowed', 405);
@@ -10,22 +9,24 @@ export const handler = async (event) => {
   if (!ctx) return err('Unauthorized', 401);
 
   const sb = getServiceClient();
-  const { data: rows, error } = await sb
+
+  const { data: hosted = [] } = await sb
     .from('events')
-    .select('id, code, title, date, time')
-    .eq('host_user_id', ctx.user.sub)
-    .order('date', { ascending: true });
+    .select('id, code, title, date, time, address')
+    .eq('host_user_id', ctx.user.sub);
 
-  if (error) return err('Failed to load', 500);
+  const { data: guestRows = [] } = await sb
+    .from('guests')
+    .select('event_id')
+    .eq('nickname', ctx.user.nickname);
+  const guestIds = guestRows.map(g => g.event_id);
 
-  const items = (rows || []).map(r => ({
-    id: r.id,
-    code: r.code,
-    title: r.title,
-    date: r.date,
-    time: r.time,
-    is_host: true,
-  }));
+  const { data: joined = [] } = guestIds.length
+    ? await sb.from('events').select('id, code, title, date, time, address').in('id', guestIds)
+    : { data: [] };
 
-  return ok(items);
+  const uniq = {};
+  [...hosted, ...joined].forEach(e => { uniq[e.id] = e; });
+
+  return ok({ events: Object.values(uniq) });
 };

--- a/netlify/functions/profile.js
+++ b/netlify/functions/profile.js
@@ -7,10 +7,10 @@ export async function handler(event, context) {
     const sb = getServiceClient();
     const { data, error } = await sb
       .from('users_local')
-      .select('id, nickname, email, created_at')
+      .select('id, nickname, avatar_url')
       .eq('id', ctx.user.sub)
       .single();
     if (error || !data) return err('User not found', 404);
-    return ok({ success:true, profile: data });
+    return ok(data);
   })(event, context);
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "serve:functions": "netlify functions:serve",
     "test": "npm run test:syntax",
-    "test:syntax": "node --check FroggyHub/app.js && node --check FroggyHub/event-analytics.js && node --check FroggyHub/login.js && node --check netlify/functions/_auth.js && node --check netlify/functions/db-ping.js && node --check netlify/functions/local-login.js && node --check netlify/functions/local-signup.js && node --check netlify/functions/profile.js && node --check netlify/functions/events-create.js && node --check netlify/functions/events-get.js && node --check netlify/functions/events-join.js && node --check netlify/functions/events-rsvp.js && node --check netlify/functions/events-list.js"
+    "test:syntax": "node --check FroggyHub/app.js && node --check FroggyHub/event-analytics.js && node --check FroggyHub/login.js && node --check netlify/functions/_auth.js && node --check netlify/functions/db-ping.js && node --check netlify/functions/local-login.js && node --check netlify/functions/local-signup.js && node --check netlify/functions/profile.js && node --check netlify/functions/events-create.js && node --check netlify/functions/events-get.js && node --check netlify/functions/events-join.js && node --check netlify/functions/events-rsvp.js && node --check netlify/functions/events-list.js && node --check netlify/functions/events-mine.js && node --check netlify/functions/avatar-upload.js"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- add persistent top bar and new menu and profile sections
- support joining events by code and loading user events
- implement profile, events-mine and avatar upload functions with migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6d1481e9c833289f9ab9874589a3b