### PR TITLE
feat: align menu layout and frog positioning

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -35,6 +35,8 @@ const clearToken = () => { try { localStorage.removeItem(TOKEN_KEY); } catch {} 
 function showScreen(name){
   $$('[id^="screen-"]').forEach(s => s.hidden = s.id !== `screen-${name}`);
   document.body.dataset.screen = name;
+  const navMenu = document.getElementById('nav-menu');
+  if (navMenu) navMenu.hidden = (name === 'menu');
   console.log('[screen] =>', name);
 }
 

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -82,12 +82,12 @@
 
   <!-- ЭКРАН МЕНЮ -->
   <section id="screen-menu" class="screen" role="main">
+    <img class="mascot-top" src="/assets/frog_idle.png" alt="" aria-hidden="true">
     <div class="decor-layer" aria-hidden="true">
-      <img class="decor frog"  src="/assets/frog_idle.png" alt="">
-      <img class="decor stump" src="/assets/stump.png"     alt="">
+      <img class="decor stump" src="/assets/stump.png" alt="">
     </div>
 
-    <div class="container">
+    <div class="menu-deck">
       <div class="panel">
         <div class="menu-grid">
           <button id="create-event" class="btn btn-primary" data-go="app" data-mode="create">

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -662,21 +662,19 @@ body.scene-intro .speech{display:block}
 }
 
 /* Menu */
-.menu-grid{ display:grid; gap:12px; grid-template-columns:1fr; }
-.join-row{ display:grid; gap:10px; grid-template-columns:1fr auto; }
-@media (min-width:760px){
-  .menu-grid{ grid-template-columns:1fr 1fr 1fr; align-items:center; }
+.menu-deck{position:fixed; left:50%; transform:translateX(-50%); bottom:8vh; width:min(880px,92vw);}
+.menu-grid{display:grid; grid-template-columns:1fr auto; gap:12px;}
+.join-row{display:grid; gap:12px; grid-template-columns:1fr auto;}
+@media (max-width:600px){
+  .menu-grid{grid-template-columns:1fr;}
 }
 
 /* Decor should not intercept clicks */
 .decor-layer{ position:relative; pointer-events:none; }
 .decor{ position:absolute; pointer-events:none; user-select:none; opacity:.95; }
-.decor.frog{ left:18px; top:160px; width:120px; }
 .decor.stump{ left:0; bottom:-20px; width:180px; opacity:.85; }
+.mascot-top{position:fixed; top:16px; left:24px; pointer-events:none;}
 
-/* Show Menu button on non-menu screens */
-body[data-screen="menu"] #nav-menu{ display:none !important; }
-body:not([data-screen="menu"]) #nav-menu{ display:inline-flex !important; }
 button:not([disabled]){ cursor:pointer; }
 
 /* Profile */


### PR DESCRIPTION
## Summary
- Fix menu header to render logo, hide Menu button on home, and keep Profile/Settings
- Move menu controls to centered bottom deck with responsive grid
- Pin frog mascot to top-left and toggle menu button visibility per screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6d9df772c83328e29d5adbcb46702