### PR TITLE
feat: add event creation wizard and mock join

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -136,33 +136,125 @@ document.addEventListener('click', (e)=>{
 
 $('#create-event')?.addEventListener('click', (e)=>{
   e.preventDefault();
-  showScreen('app');
+  $('#dlg-type')?.removeAttribute('hidden');
 });
 
-$('#join-form')?.addEventListener('submit', async (e)=>{
+$('#join-form')?.addEventListener('submit', (e)=>{
   e.preventDefault();
-  $('#join-open')?.setAttribute('disabled','');
-  try{
-    const code = ($('#join-code')?.value || '').trim();
-    if (code.length !== 6) throw new Error('Введите 6-значный код');
-    const { event } = await apiFetch(`events-get?code=${encodeURIComponent(code)}`);
-    if (typeof openFinal === 'function') {
-      await openFinal(event.code);
-    } else if (typeof openEvent === 'function') {
-      await openEvent(event);
-    } else {
-      const fc=$('#final-code'); if(fc) fc.textContent = event.code || '—';
-      const ft=$('#final-title'); if(ft) ft.textContent = event.title || '—';
-      const fw=$('#final-when'); if(fw) fw.textContent = `${event.date||''} ${event.time||''}`.trim();
-      const fa=$('#final-address'); if(fa) fa.textContent = event.address || '—';
-      const fd=$('#final-dress'); if(fd) fd.textContent   = event.dress || '—';
-      const fb=$('#final-bring'); if(fb) fb.textContent   = event.bring || '—';
-      const fcm=$('#final-comment'); if(fcm) fcm.textContent = event.comment || '—';
-      showScreen('app');
-    }
-  } catch(err){ alert(err.message || 'Код не найден'); }
-  finally{ $('#join-open')?.removeAttribute('disabled'); }
+  const code = ($('#join-code')?.value || '').trim();
+  if (code.length !== 6) { alert('Введите 6-значный код'); return; }
+  openFinal({
+    code,
+    details:{ title:'Событие', date:'2024-01-01', time:'18:00', place:'Пруд' },
+    req:{ dress:'Произвольный', bring:'Хорошее настроение', comment:'До встречи!' },
+    picks:['Подарок']
+  });
 });
+
+// --- Создание события: state-machine ---
+const flowState = {
+  flow: {
+    type: 'business',
+    details: {},
+    req: {},
+    wishlist: [],
+    picks: new Set(),
+  }
+};
+
+function showCreate(step){
+  showScreen('create-' + step);
+}
+
+onDelegated('#dlg-type [data-type]', 'click', (e, el)=>{
+  flowState.flow.type = el.dataset.type;
+  const isBiz = flowState.flow.type === 'business';
+  $('#lbl-title').textContent = isBiz ? 'Название встречи' : 'Название праздника';
+  $('#lbl-date').textContent  = isBiz ? 'Дата встречи' : 'Дата праздника';
+  $('#lbl-time').textContent  = 'Время';
+  $('#lbl-place').textContent = isBiz ? 'Место' : 'Место проведения';
+  $('#dlg-type').hidden = true;
+  showCreate('details');
+});
+
+$('#details-next')?.addEventListener('click', ()=>{
+  flowState.flow.details = {
+    title: $('#det-title').value.trim(),
+    date: $('#det-date').value,
+    time: $('#det-time').value,
+    place: $('#det-place').value.trim(),
+  };
+  showCreate('requirements');
+});
+
+$('#details-back')?.addEventListener('click', ()=>{
+  showScreen('menu');
+});
+
+$('#req-next')?.addEventListener('click', ()=>{
+  flowState.flow.req = {
+    dress: $('#req-dress').value.trim(),
+    bring: $('#req-bring').value.trim(),
+    comment: $('#req-comment').value.trim(),
+  };
+  showCreate('wishlist');
+});
+
+$('#req-back')?.addEventListener('click', ()=>{
+  showCreate('details');
+});
+
+function addWish(){
+  const input = $('#wish-input');
+  const text = input.value.trim();
+  if (!text) return;
+  const idx = flowState.flow.wishlist.push(text) - 1;
+  const div = document.createElement('div');
+  div.className = 'wish-item';
+  div.dataset.idx = idx;
+  div.innerHTML = `<span>${text}</span><button class="btn btn--sm" data-pick>Заберу</button>`;
+  $('#wish-list').appendChild(div);
+  input.value = '';
+}
+$('#wish-add')?.addEventListener('click', addWish);
+$('#wish-input')?.addEventListener('keydown', e=>{ if(e.key==='Enter'){ e.preventDefault(); addWish(); } });
+
+onDelegated('.wish-item [data-pick]', 'click', (e, btn)=>{
+  const item = btn.closest('.wish-item');
+  const idx = Number(item.dataset.idx);
+  if (flowState.flow.picks.has(idx)) {
+    flowState.flow.picks.delete(idx);
+    item.classList.remove('taken');
+    btn.textContent = 'Заберу';
+  } else {
+    flowState.flow.picks.add(idx);
+    item.classList.add('taken');
+    btn.textContent = 'занято';
+  }
+});
+
+$('#wish-back')?.addEventListener('click', ()=>{
+  showCreate('requirements');
+});
+
+$('#wish-next')?.addEventListener('click', ()=>{
+  const selected = flowState.flow.wishlist.filter((_,i)=> flowState.flow.picks.has(i));
+  openFinal({ code:'—', details:flowState.flow.details, req:flowState.flow.req, picks:selected });
+});
+
+function openFinal(data){
+  if (typeof data === 'string') data = { code:data };
+  data = data || {};
+  showScreen('app');
+  $('#event-code').textContent = data.code || '—';
+  const when = [data.details?.date, data.details?.time].filter(Boolean).join(' ');
+  $('#event-when').textContent = when || '—';
+  $('#event-address').textContent = data.details?.place || '—';
+  $('#event-dress').textContent = data.req?.dress || '—';
+  $('#event-bring').textContent = data.req?.bring || '—';
+  $('#event-comment').textContent = data.req?.comment || '—';
+  $('#event-picks').textContent = data.picks && data.picks.length ? data.picks.join(', ') : '—';
+}
 
 async function apiFetch(path, init={}){
   init.headers = Object.assign({'Content-Type':'application/json'}, authHeaders(), init.headers||{});

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -104,6 +104,79 @@
     </div>
   </section>
 
+  <!-- МОДАЛЬНОЕ ОКНО ВЫБОРА ТИПА -->
+  <div id="dlg-type" class="modal-backdrop" hidden>
+    <div class="modal">
+      <h3>Какой тип встречи вы планируете создать?</h3>
+      <div class="grid">
+        <button class="btn" data-type="business">Деловая</button>
+        <button class="btn" data-type="party">Праздничная</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ШАГ 1: ДЕТАЛИ -->
+  <section id="screen-create-details" class="screen" hidden>
+    <div class="container">
+      <form id="form-create-details" class="grid form-grid" autocomplete="off">
+        <label><span id="lbl-title">Название</span>
+          <input id="det-title" required />
+        </label>
+        <label><span id="lbl-date">Дата</span>
+          <input id="det-date" type="date" required />
+        </label>
+        <label><span id="lbl-time">Время</span>
+          <input id="det-time" type="time" />
+        </label>
+        <label><span id="lbl-place">Место</span>
+          <input id="det-place" />
+        </label>
+      </form>
+      <div class="row2 mt-4">
+        <button id="details-back" class="btn btn--secondary" type="button">Назад</button>
+        <button id="details-next" class="btn btn--primary" type="button">Далее</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- ШАГ 2: ТРЕБОВАНИЯ -->
+  <section id="screen-create-requirements" class="screen" hidden>
+    <div class="container">
+      <form id="form-create-req" class="grid form-grid" autocomplete="off">
+        <label>Дресс-код
+          <input id="req-dress" />
+        </label>
+        <label>Что взять
+          <input id="req-bring" />
+        </label>
+        <label>Комментарий
+          <textarea id="req-comment" rows="3"></textarea>
+        </label>
+      </form>
+      <div class="row2 mt-4">
+        <button id="req-back" class="btn btn--secondary" type="button">Назад</button>
+        <button id="req-next" class="btn btn--primary" type="button">Далее</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- ШАГ 3: WISHLIST -->
+  <section id="screen-wishlist" class="screen" hidden>
+    <div class="container">
+      <div class="grid form-grid">
+        <div id="wish-list" class="wish-grid"></div>
+        <div class="row2">
+          <input id="wish-input" class="input" placeholder="Добавить пункт" />
+          <button id="wish-add" class="btn btn--primary" type="button">Добавить</button>
+        </div>
+      </div>
+      <div class="row2 mt-4">
+        <button id="wish-back" class="btn btn--secondary" type="button">Назад</button>
+        <button id="wish-next" class="btn btn--primary" type="button">Далее</button>
+      </div>
+    </div>
+  </section>
+
   <!-- ЭКРАН 3: ПРУД + ФИНАЛ -->
   <div id="screen-app" class="container" hidden>
     <section class="card">
@@ -114,6 +187,7 @@
       <div>Дресс-код: <span id="event-dress">—</span></div>
       <div>Что взять: <span id="event-bring">—</span></div>
       <div>Комментарий: <span id="event-comment">—</span></div>
+      <div>Вы выбрали: <span id="event-picks">—</span></div>
       <div class="mt-4">
         <button id="back-to-menu" class="btn btn--secondary" data-go="menu" type="button">Вернуться в меню</button>
       </div>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -698,3 +698,39 @@ button:not([disabled]){ cursor:pointer; }
 .event-title{ font-weight:700; }
 .event-meta{ opacity:.8; font-size:12px; }
 .event-actions{ display:flex; gap:8px; }
+
+/* Модальные окна */
+.modal-backdrop{
+  position:fixed;
+  inset:0;
+  background:rgba(0,0,0,.6);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  z-index:1000;
+}
+
+.modal{
+  background:var(--card-dark);
+  border:1px solid var(--card-border);
+  border-radius:12px;
+  padding:20px;
+  box-shadow:0 10px 26px var(--shadow);
+  max-width:320px;
+}
+
+/* Сетки форм */
+.form-grid{ display:grid; gap:14px; }
+
+/* Wishlist */
+.wish-grid{ display:grid; gap:10px; }
+.wish-item{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding:8px 10px;
+  border:1px solid var(--border);
+  border-radius:8px;
+}
+.wish-item.taken{ opacity:.6; }
+.wish-item.taken button{ pointer-events:none; }


### PR DESCRIPTION
## Summary
- add event type modal and step-by-step creation screens
- style modal and wishlist grid
- implement client-side flow state with wishlist picks and mock join final screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6dd85c0688332af2d7c604da98ff3