### PR TITLE
feat: add requirements step and wishlist navigation

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -19,6 +19,12 @@ const $  = (s, r=document) => r.querySelector(s);
 const $$ = (s, r=document) => Array.from(r.querySelectorAll(s));
 const on = (el, ev, fn) => el && el.addEventListener(ev, fn);
 
+window.__FH__ = window.__FH__ || {};
+const ST = window.__FH__;
+ST.createType = ST.createType || null;     // 'business' | 'party'
+ST.createDraft = ST.createDraft || {};     // шаг 1: условия
+ST.createReqs  = ST.createReqs  || {};     // шаг 2: требования
+
 function onDelegated(selector, type, handler, options){
   document.addEventListener(type, (e)=>{
     const el = e.target.closest(selector);
@@ -190,18 +196,17 @@ function showCreate(step){
 
 const typeModal = document.getElementById('type-modal');
 
-document.addEventListener('click', (e)=>{
-  const pick = e.target.closest('#type-modal [data-type]');
-  if (pick){
-    const type = pick.dataset.type;
-    window.__FH__ = window.__FH__ || {};
-    window.__FH__.createType = type;
-    flowState.flow.type = type;
-    configureCreateForm(type);
-    closeModal(typeModal);
-    setWizardMode?.('create');
-    show('app');
-  }
+  document.addEventListener('click', (e)=>{
+    const pick = e.target.closest('#type-modal [data-type]');
+    if (pick){
+      const type = pick.dataset.type;
+      ST.createType = type;
+      flowState.flow.type = type;
+      configureCreateForm(type);
+      closeModal(typeModal);
+      setWizardMode?.('create');
+      show('create-details');
+    }
 
   if (e.target.closest('#type-modal [data-close]')){
     closeModal(typeModal);
@@ -239,33 +244,70 @@ function configureCreateForm(type){
   }
 }
 
+function configureRequirementsForm(type){
+  const elTitle = document.getElementById('reqs-title');
+  const lblDress = document.getElementById('lbl-dress');
+  const lblBring = document.getElementById('lbl-bring');
+  const lblComment = document.getElementById('lbl-comment');
+  const rDress = document.getElementById('r-dress');
+  const rBring = document.getElementById('r-bring');
+  const rComm  = document.getElementById('r-comment');
 
-$('#details-next')?.addEventListener('click', ()=>{
-  flowState.flow.details = {
-    title: $('#det-title').value.trim(),
-    date: $('#det-date').value,
-    time: $('#det-time').value,
-    place: $('#det-place').value.trim(),
-  };
-  showCreate('requirements');
-});
+  if (type === 'business'){
+    elTitle.textContent = 'Требования (деловая встреча)';
+    lblDress.firstChild.nodeValue = 'Дресс-код';
+    rDress.placeholder = 'Например: business casual';
+    lblBring.firstChild.nodeValue = 'Материалы/Что взять';
+    rBring.placeholder = 'Ноутбук, презентация, блокнот…';
+    lblComment.firstChild.nodeValue = 'Комментарий организатора';
+    rComm.placeholder = 'Например: приходите за 10 минут';
+  } else {
+    elTitle.textContent = 'Требования (праздничная встреча)';
+    lblDress.firstChild.nodeValue = 'Дресс-код/Тема';
+    rDress.placeholder = 'Например: зелёный, 90-е, маскарад';
+    lblBring.firstChild.nodeValue = 'Что принести';
+    rBring.placeholder = 'Торт, напитки, гирлянды…';
+    lblComment.firstChild.nodeValue = 'Комментарий';
+    rComm.placeholder = 'Например: будет фотозона 🎉';
+  }
+}
 
-$('#details-back')?.addEventListener('click', ()=>{
-  show('menu');
-});
 
-$('#req-next')?.addEventListener('click', ()=>{
-  flowState.flow.req = {
-    dress: $('#req-dress').value.trim(),
-    bring: $('#req-bring').value.trim(),
-    comment: $('#req-comment').value.trim(),
-  };
-  showCreate('wishlist');
-});
+  document.getElementById('details-next')?.addEventListener('click', (e)=>{
+    e.preventDefault();
+    const title = document.getElementById('det-title')?.value?.trim() || '';
+    const date  = document.getElementById('det-date')?.value || '';
+    const time  = document.getElementById('det-time')?.value || '';
+    const addr  = document.getElementById('det-place')?.value?.trim() || '';
+    ST.createDraft = { title, date, time, address: addr };
+    flowState.flow.details = { title, date, time, place: addr };
+    configureRequirementsForm(ST.createType || 'business');
+    show('create-reqs');
+  });
 
-$('#req-back')?.addEventListener('click', ()=>{
-  showCreate('details');
-});
+  document.getElementById('details-back')?.addEventListener('click', (e)=>{
+    e.preventDefault();
+    show('menu');
+  });
+
+  document.getElementById('form-reqs')?.addEventListener('submit', (e)=>{
+    e.preventDefault();
+  });
+
+  document.getElementById('btn-reqs-next')?.addEventListener('click', (e)=>{
+    e.preventDefault();
+    const dress = document.getElementById('r-dress')?.value?.trim() || '';
+    const bring = document.getElementById('r-bring')?.value?.trim() || '';
+    const comment = document.getElementById('r-comment')?.value?.trim() || '';
+    ST.createReqs = { dress, bring, comment };
+    flowState.flow.req = { dress, bring, comment };
+    show('wishlist');
+  });
+
+  document.getElementById('btn-reqs-back')?.addEventListener('click', (e)=>{
+    e.preventDefault();
+    show('create-details');
+  });
 
 function addWish(){
   const input = $('#wish-input');
@@ -296,14 +338,16 @@ onDelegated('.wish-item [data-pick]', 'click', (e, btn)=>{
   }
 });
 
-$('#wish-back')?.addEventListener('click', ()=>{
-  showCreate('requirements');
-});
+  document.getElementById('btn-wish-back')?.addEventListener('click', (e)=>{
+    e.preventDefault();
+    show('create-reqs');
+  });
 
-$('#wish-next')?.addEventListener('click', ()=>{
-  const selected = flowState.flow.wishlist.filter((_,i)=> flowState.flow.picks.has(i));
-  openFinal({ code:'—', details:flowState.flow.details, req:flowState.flow.req, picks:selected });
-});
+  document.getElementById('btn-wish-next')?.addEventListener('click', (e)=>{
+    e.preventDefault();
+    const selected = flowState.flow.wishlist.filter((_,i)=> flowState.flow.picks.has(i));
+    openFinal({ code:'—', details: ST.createDraft, req: ST.createReqs, picks: selected });
+  });
 
 function openFinal(data){
   if (typeof data === 'string') data = { code:data };

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -129,43 +129,55 @@
     </div>
   </section>
 
-  <!-- ШАГ 2: ТРЕБОВАНИЯ -->
-  <section id="screen-create-requirements" class="screen" hidden>
-    <div class="container">
-      <form id="form-create-req" class="grid form-grid" autocomplete="off">
-        <label>Дресс-код
-          <input id="req-dress" />
-        </label>
-        <label>Что взять
-          <input id="req-bring" />
-        </label>
-        <label>Комментарий
-          <textarea id="req-comment" rows="3"></textarea>
-        </label>
-      </form>
-      <div class="row2 mt-4">
-        <button id="req-back" class="btn btn--secondary" type="button">Назад</button>
-        <button id="req-next" class="btn btn--primary" type="button">Далее</button>
-      </div>
-    </div>
-  </section>
+    <!-- ЭКРАН: Шаг 2 — Требования (скрыт по умолчанию) -->
+    <section id="screen-create-reqs" class="screen" hidden>
+      <div class="container">
+        <div class="panel">
+          <h2 id="reqs-title">Требования</h2>
 
-  <!-- ШАГ 3: WISHLIST -->
-  <section id="screen-wishlist" class="screen" hidden>
-    <div class="container">
-      <div class="grid form-grid">
-        <div id="wish-list" class="wish-grid"></div>
-        <div class="row2">
-          <input id="wish-input" class="input" placeholder="Добавить пункт" />
-          <button id="wish-add" class="btn btn--primary" type="button">Добавить</button>
+          <form id="form-reqs" autocomplete="off" class="stack-md">
+            <label id="lbl-dress">Дресс-код
+              <input id="r-dress" class="input" placeholder="Например: casual">
+            </label>
+
+            <label id="lbl-bring">Что взять
+              <input id="r-bring" class="input" placeholder="Например: ноутбук, блокнот">
+            </label>
+
+            <label id="lbl-comment">Комментарий для гостей
+              <input id="r-comment" class="input" placeholder="Короткое сообщение для приглашённых">
+            </label>
+
+            <div class="row-end gap-sm">
+              <button type="button" class="btn" id="btn-reqs-back">Назад</button>
+              <button class="btn btn-primary" id="btn-reqs-next">Далее</button>
+            </div>
+          </form>
         </div>
       </div>
-      <div class="row2 mt-4">
-        <button id="wish-back" class="btn btn--secondary" type="button">Назад</button>
-        <button id="wish-next" class="btn btn--primary" type="button">Далее</button>
+    </section>
+
+    <!-- ЭКРАН: Wishlist (общий) -->
+    <section id="screen-wishlist" class="screen" hidden>
+      <div class="container">
+        <div class="panel">
+          <h2>Wishlist</h2>
+
+          <form id="form-add-wish" class="grid-2">
+            <input id="wish-title" class="input" placeholder="Название (тема/подарок)">
+            <input id="wish-url" class="input" placeholder="Ссылка (опционально)">
+            <button class="btn">Добавить</button>
+          </form>
+
+          <div id="wish-list" class="wish-grid" style="margin-top:12px">Пока пусто</div>
+
+          <div class="row-end gap-sm" style="margin-top:16px">
+            <button type="button" class="btn" id="btn-wish-back">Назад</button>
+            <button class="btn btn-primary" id="btn-wish-next">Далее</button>
+          </div>
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
 
   <!-- ЭКРАН 3: ПРУД + ФИНАЛ -->
   <section id="screen-app" class="container" hidden>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -772,3 +772,7 @@ dialog[type-modal], #type-modal { border: none; background: transparent; }
   width: min(480px, 92vw);
   margin: 0 auto;
 }
+
+.stack-md > * + * { margin-top: 12px; }
+.row-end { display: flex; justify-content: flex-end; }
+.gap-sm { gap: 10px; }


### PR DESCRIPTION
## Summary
- add hidden requirements screen with configurable labels for business and party events
- wire navigation between condition, requirements, and wishlist screens while saving draft state
- introduce lightweight CSS utilities for layout spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76cd4ae448332b8df4039def57739