### PR TITLE
feat: add login-first flow with cookies and modal

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -33,7 +33,8 @@ function onDelegated(selector, type, handler, options){
   }, options || false);
 }
 
-const TOKEN_KEY = 'FH_JWT';
+const TOKEN_KEY  = 'FH_JWT';
+const COOKIE_KEY = 'FH_COOKIE_OK';
 const saveToken  = t => { try { localStorage.setItem(TOKEN_KEY, t); } catch {} };
 const getToken   = () => { try { return localStorage.getItem(TOKEN_KEY); } catch { return null } };
 const clearToken = () => { try { localStorage.removeItem(TOKEN_KEY); } catch {} };
@@ -63,6 +64,19 @@ function show(name){
   if (navMenu) navMenu.hidden = (name === 'menu' || name === 'auth');
   console.log('[screen] =>', name);
 }
+
+(function boot(){
+  const hasToken = !!localStorage.getItem(TOKEN_KEY);
+  show(hasToken ? 'menu' : 'auth');
+  const cookie = document.getElementById('cookie');
+  if (cookie && !localStorage.getItem(COOKIE_KEY)) cookie.hidden = false;
+})();
+
+document.getElementById('cookie-ok')?.addEventListener('click', ()=>{
+  localStorage.setItem(COOKIE_KEY, '1');
+  const cookie = document.getElementById('cookie');
+  if (cookie) cookie.hidden = true;
+});
 
 async function apiPost(fnPath, payload) {
   const res = await fetch(`/.netlify/functions${fnPath}`, {
@@ -159,12 +173,38 @@ document.addEventListener('click', (e)=>{
   }
 });
 
+const dlgType = document.getElementById('dlg-type');
+
+function openDlg(el){ el.hidden = false; requestAnimationFrame(()=> el.classList.add('show')); }
+function closeDlg(el){ el.classList.remove('show'); setTimeout(()=>{ el.hidden = true; }, 150); }
+
+document.getElementById('create-event')?.addEventListener('click', (e)=>{
+  e.preventDefault();
+  if (dlgType) openDlg(dlgType);
+});
+
+// Закрытие по «Отмена», клик по подложке, Esc и выбор типа
 document.addEventListener('click', (e)=>{
-  const btnCreate = e.target.closest('#create-event, [data-go="app"][data-mode="create"]');
-  if (btnCreate){
-    e.preventDefault();
-    openModal('type-modal');
+  const closeBtn = e.target.closest('[data-close="dlg-type"]');
+  if (closeBtn && dlgType && !dlgType.hidden) closeDlg(dlgType);
+
+  if (e.target.classList?.contains('modal__backdrop') && dlgType && !dlgType.hidden){
+    closeDlg(dlgType);
   }
+
+  const typeBtn = e.target.closest('[data-type]');
+  if (typeBtn){
+    const t = typeBtn.dataset.type;           // 'business' | 'party'
+    window.__FH__ = window.__FH__ || {};
+    window.__FH__.createType = t;
+    if (dlgType && !dlgType.hidden) closeDlg(dlgType);
+    if (typeof configureRequirementsForm === 'function') configureRequirementsForm(t);
+    show('create-conditions');
+  }
+});
+
+document.addEventListener('keydown', (e)=>{
+  if (e.key === 'Escape' && dlgType && !dlgType.hidden) closeDlg(dlgType);
 });
 
 $('#join-form')?.addEventListener('submit', (e)=>{
@@ -194,30 +234,7 @@ function showCreate(step){
   show('create-' + step);
 }
 
-const typeModal = document.getElementById('type-modal');
-
-  document.addEventListener('click', (e)=>{
-    const pick = e.target.closest('#type-modal [data-type]');
-    if (pick){
-      const type = pick.dataset.type;
-      ST.createType = type;
-      flowState.flow.type = type;
-      configureCreateForm(type);
-      closeModal(typeModal);
-      setWizardMode?.('create');
-      show('create-details');
-    }
-
-  if (e.target.closest('#type-modal [data-close]')){
-    closeModal(typeModal);
-  }
-});
-
-typeModal?.addEventListener('click', (e)=>{
-  const form = e.target.closest('form');
-  if (!form) closeModal(typeModal);
-});
-typeModal?.addEventListener('cancel', (e)=>{ e.preventDefault(); closeModal(typeModal); });
+// старый код модалки "type-modal" удалён
 document.addEventListener('keydown', (e)=>{ if (e.key === 'Escape' && !typeModal.hidden) closeModal(typeModal); });
 
 function configureCreateForm(type){
@@ -2808,11 +2825,6 @@ function wireAuthForms(){
 
 document.addEventListener('DOMContentLoaded', ()=>{
   wireAuthForms();
-
-  // если уже залогинен — сразу меню
-  if (getTok()) show('menu');
-  else show('auth');
-
   // Навешанные делегированные клики работают всегда, ничего больше не нужно
 });
 

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -87,6 +87,11 @@
       <img class="decor stump" src="/assets/stump.png" alt="">
     </div>
 
+    <!-- Герой-лягушка (центр меню) -->
+    <div class="frog-hero" aria-hidden="true">
+      <img src="/assets/frog_idle.png" alt="" />
+    </div>
+
     <div class="menu-deck">
       <div class="panel">
         <div class="menu-grid">
@@ -401,17 +406,31 @@
   </script>
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
   <script src="/app.js" defer></script>
-  <!-- Модалка выбора типа встречи -->
-  <dialog id="type-modal" hidden>
-    <form method="dialog" class="type-modal panel">
-      <h3>Какой тип встречи вы планируете создать?</h3>
-      <div class="stack-sm">
-        <button type="button" class="btn" data-type="business">Деловая</button>
-        <button type="button" class="btn" data-type="party">Праздничная</button>
+  <!-- Cookie notice -->
+  <div id="cookie" class="cookie" hidden>
+    <div class="cookie__text">
+      Мы используем cookies, чтобы сайт работал стабильнее. Продолжая, вы принимаете использование cookies.
+    </div>
+    <div class="cookie__actions">
+      <button id="cookie-ok" class="btn btn-primary btn-sm">Принять</button>
+    </div>
+  </div>
+
+  <!-- Тип встречи (модалка) -->
+  <div id="dlg-type" class="modal" hidden>
+    <div class="modal__backdrop" data-close="dlg-type"></div>
+    <div class="modal__card">
+      <h3 class="modal__title">Какой тип встречи вы планируете создать?</h3>
+      <div class="modal__btns">
+        <button class="btn btn-secondary" data-type="business">Деловая</button>
+        <button class="btn btn-secondary" data-type="party">Праздничная</button>
       </div>
-      <button type="button" class="btn btn-ghost" data-close>Отмена</button>
-    </form>
-  </dialog>
+      <div class="modal__footer">
+        <button class="btn btn-ghost" data-close="dlg-type">Отмена</button>
+      </div>
+    </div>
+  </div>
+
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
   <dialog id="otpModal">
     <form method="dialog" class="grid">

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -776,3 +776,51 @@ dialog[type-modal], #type-modal { border: none; background: transparent; }
 .stack-md > * + * { margin-top: 12px; }
 .row-end { display: flex; justify-content: flex-end; }
 .gap-sm { gap: 10px; }
+
+/* Cookie banner */
+.cookie{
+  position: fixed; left: 50%; bottom: 20px; transform: translateX(-50%);
+  display: flex; gap: 12px; align-items: center;
+  background: rgba(9, 30, 18, 0.9);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 14px; padding: 10px 14px; z-index: 1000;
+  box-shadow: 0 10px 28px rgba(0,0,0,.35);
+  max-width: min(92vw, 840px);
+}
+.cookie__text{ color: #dff9ea; line-height: 1.35; font-size: 14px; }
+.cookie__actions{ margin-left: auto; }
+
+/* Modal */
+.modal{ position: fixed; inset: 0; z-index: 1001; }
+.modal[hidden]{ display:none; }
+.modal.show .modal__card{ transform: translate(-50%,-50%) scale(1); opacity: 1; }
+.modal__backdrop{
+  position:absolute; inset:0; background: rgba(0,0,0,.45); backdrop-filter: blur(2px);
+}
+.modal__card{
+  position:absolute; left:50%; top:50%; transform: translate(-50%,-50%) scale(.96);
+  width: min(92vw, 520px);
+  background: rgba(9, 30, 18, 0.96);
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 18px; padding: 18px;
+  box-shadow: 0 18px 48px rgba(0,0,0,.4);
+  transition: transform .15s ease, opacity .15s ease;
+  opacity: 0;
+}
+.modal__title{ margin: 4px 2px 12px; font-size: 20px; color:#e8fff3; }
+.modal__btns{ display:flex; gap:10px; flex-wrap:wrap; }
+.modal__footer{ margin-top:10px; display:flex; justify-content:flex-end; }
+
+/* Центровка и размер лягушки на экране меню */
+#screen-menu .frog-hero{
+  position: absolute; left:50%; top: 42%;
+  transform: translate(-50%,-50%);
+  pointer-events: none; user-select: none;
+}
+#screen-menu .frog-hero img{
+  display:block; width: min(60vw, 720px); max-width: 780px; height: auto;
+  filter: drop-shadow(0 8px 24px rgba(0,0,0,.35));
+}
+@media (max-width: 800px){
+  #screen-menu .frog-hero img{ width: min(82vw, 560px); }
+}


### PR DESCRIPTION
## Summary
- add login-first routing with cookie consent banner
- center hero frog on menu and wire improved meeting type modal
- implement modal styling and open/close logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77026c834833296bf4c7666048f6d