### PR TITLE
Auth-first, single frog, centered modals, cookies fixed

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -42,19 +42,6 @@ const clearToken = () => { try { localStorage.removeItem(TOKEN_KEY); } catch {} 
 const TOK = 'FH_JWT';
 const getTok = () => localStorage.getItem(TOK);
 
-function openModal(dlg){
-  if (typeof dlg === 'string') dlg = document.getElementById(dlg);
-  if (!dlg) return;
-  dlg.hidden = false;
-  if (dlg.showModal) dlg.showModal();
-}
-function closeModal(dlg){
-  if (typeof dlg === 'string') dlg = document.getElementById(dlg);
-  if (!dlg) return;
-  if (dlg.close) try { dlg.close(); } catch {}
-  dlg.hidden = true;
-}
-
 function show(name){
   document.querySelectorAll('section[id^="screen-"]').forEach(s => {
     s.hidden = s.id !== `screen-${name}`;
@@ -66,8 +53,10 @@ function show(name){
 }
 
 (function boot(){
-  const hasToken = !!localStorage.getItem(TOKEN_KEY);
-  show(hasToken ? 'menu' : 'auth');
+  // ВСЕГДА сначала авторизация
+  show('auth');
+
+  // cookie banner
   const cookie = document.getElementById('cookie');
   if (cookie && !localStorage.getItem(COOKIE_KEY)) cookie.hidden = false;
 })();
@@ -175,34 +164,34 @@ document.addEventListener('click', (e)=>{
 
 const dlgType = document.getElementById('dlg-type');
 
-function openDlg(el){ el.hidden = false; requestAnimationFrame(()=> el.classList.add('show')); }
-function closeDlg(el){ el.classList.remove('show'); setTimeout(()=>{ el.hidden = true; }, 150); }
+function openDlg(el){ if(!el) return; el.hidden = false; requestAnimationFrame(()=> el.classList.add('show')); }
+function closeDlg(el){ if(!el) return; el.classList.remove('show'); setTimeout(()=>{ el.hidden = true; }, 160); }
 
 document.getElementById('create-event')?.addEventListener('click', (e)=>{
   e.preventDefault();
-  if (dlgType) openDlg(dlgType);
+  openDlg(dlgType);
 });
 
-// Закрытие по «Отмена», клик по подложке, Esc и выбор типа
+// Делегирование: закрыть по “Отмена”, клик по подложке, или выбрать тип
 document.addEventListener('click', (e)=>{
-  const closeBtn = e.target.closest('[data-close="dlg-type"]');
-  if (closeBtn && dlgType && !dlgType.hidden) closeDlg(dlgType);
+  if (!dlgType) return;
 
-  if (e.target.classList?.contains('modal__backdrop') && dlgType && !dlgType.hidden){
+  if (e.target.closest('[data-close="dlg-type"]') || e.target.classList?.contains('modal__backdrop')){
     closeDlg(dlgType);
   }
 
   const typeBtn = e.target.closest('[data-type]');
   if (typeBtn){
-    const t = typeBtn.dataset.type;           // 'business' | 'party'
+    const t = typeBtn.dataset.type;  // 'business' | 'party'
     window.__FH__ = window.__FH__ || {};
     window.__FH__.createType = t;
-    if (dlgType && !dlgType.hidden) closeDlg(dlgType);
+    closeDlg(dlgType);
     if (typeof configureRequirementsForm === 'function') configureRequirementsForm(t);
     show('create-conditions');
   }
 });
 
+// Закрытие по клавише Esc
 document.addEventListener('keydown', (e)=>{
   if (e.key === 'Escape' && dlgType && !dlgType.hidden) closeDlg(dlgType);
 });
@@ -235,7 +224,6 @@ function showCreate(step){
 }
 
 // старый код модалки "type-modal" удалён
-document.addEventListener('keydown', (e)=>{ if (e.key === 'Escape' && !typeModal.hidden) closeModal(typeModal); });
 
 function configureCreateForm(type){
   const lTitle = document.querySelector('#eventTitle')?.closest('label');

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -82,14 +82,13 @@
 
   <!-- ЭКРАН МЕНЮ -->
   <section id="screen-menu" class="screen" role="main" hidden>
-    <img class="mascot-top" src="/assets/frog_idle.png" alt="" aria-hidden="true">
     <div class="decor-layer" aria-hidden="true">
       <img class="decor stump" src="/assets/stump.png" alt="">
     </div>
 
     <!-- Герой-лягушка (центр меню) -->
-    <div class="frog-hero" aria-hidden="true">
-      <img src="/assets/frog_idle.png" alt="" />
+    <div id="frog-hero" class="frog-hero" aria-hidden="true">
+      <img src="/assets/frog_idle.png" alt="">
     </div>
 
     <div class="menu-deck">
@@ -212,7 +211,7 @@
 
         <!-- Пень и лягушка -->
         <img id="stumpImg" class="stump" src="assets/stump.png" alt="Пень" />
-        <div id="frog"><img id="frogImg" src="assets/frog_idle.png" alt="Frog" /></div>
+        <div id="frog" class="frog-sticker"><img id="frogImg" src="assets/frog_idle.png" alt="Frog" /></div>
 
         <!-- ФИНАЛЬНАЯ РАСКЛАДКА: ДВЕ КОЛОНКИ -->
         <div id="finalLayout" class="final-layout" hidden>
@@ -406,31 +405,6 @@
   </script>
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
   <script src="/app.js" defer></script>
-  <!-- Cookie notice -->
-  <div id="cookie" class="cookie" hidden>
-    <div class="cookie__text">
-      Мы используем cookies, чтобы сайт работал стабильнее. Продолжая, вы принимаете использование cookies.
-    </div>
-    <div class="cookie__actions">
-      <button id="cookie-ok" class="btn btn-primary btn-sm">Принять</button>
-    </div>
-  </div>
-
-  <!-- Тип встречи (модалка) -->
-  <div id="dlg-type" class="modal" hidden>
-    <div class="modal__backdrop" data-close="dlg-type"></div>
-    <div class="modal__card">
-      <h3 class="modal__title">Какой тип встречи вы планируете создать?</h3>
-      <div class="modal__btns">
-        <button class="btn btn-secondary" data-type="business">Деловая</button>
-        <button class="btn btn-secondary" data-type="party">Праздничная</button>
-      </div>
-      <div class="modal__footer">
-        <button class="btn btn-ghost" data-close="dlg-type">Отмена</button>
-      </div>
-    </div>
-  </div>
-
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
   <dialog id="otpModal">
     <form method="dialog" class="grid">
@@ -445,19 +419,31 @@
       <p id="otpStatus" class="hint" aria-live="polite"></p>
     </form>
   </dialog>
-      <div id="cookieCard" class="card" style="display:none">
-        <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
-          <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
-        </svg>
-        <div class="cookieHeading">Cookies</div>
-        <div class="cookieDescription">
-          Мы используем файлы cookies, чтобы сайт работал быстрее и удобнее. Продолжая, вы соглашаетесь с их использованием.
-        </div>
-        <div class="buttonContainer">
-          <button class="btn btn--primary acceptButton" id="cookieAccept">Ок</button>
-          <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
-        </div>
+  <!-- Cookie notice -->
+  <div id="cookie" class="cookie" hidden>
+    <div class="cookie__text">
+      Мы используем cookies, чтобы сайт работал стабильнее. Продолжая, вы принимаете использование cookies.
+    </div>
+    <div class="cookie__actions">
+      <button id="cookie-ok" class="btn btn-primary btn-sm">Принять</button>
+    </div>
+  </div>
+
+  <!-- Тип встречи (модалка выбора) -->
+  <div id="dlg-type" class="modal" hidden>
+    <div class="modal__backdrop" data-close="dlg-type"></div>
+    <div class="modal__card">
+      <h3 class="modal__title">Какой тип встречи вы планируете создать?</h3>
+      <div class="modal__btns">
+        <button class="btn btn-secondary" data-type="business">Деловая</button>
+        <button class="btn btn-secondary" data-type="party">Праздничная</button>
       </div>
-      <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
-    </body>
-    </html>
+      <div class="modal__footer">
+        <button class="btn btn-ghost" data-close="dlg-type">Отмена</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+</body>
+</html>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -256,7 +256,7 @@ body.scene-final #frog{max-width:120px;transform:translate(-50%,-70%);}
 }
 @media (max-width:640px){
   body.scene-intro #frog, body.scene-pond #frog{width:clamp(64px,20vw,112px);}
-  body.scene-final #frog{max-width:95px;transform:translate(-50%,-65%);}
+body.scene-final #frog{max-width:95px;transform:translate(-50%,-65%);}
 }
 .lilypads img { max-width: 22vw; height: auto; }
 #frog.jump{animation:jump .55s ease}
@@ -673,7 +673,6 @@ body.scene-intro .speech{display:block}
 .decor-layer{ position:relative; pointer-events:none; }
 .decor{ position:absolute; pointer-events:none; user-select:none; opacity:.95; }
 .decor.stump{ left:0; bottom:-20px; width:180px; opacity:.85; }
-.mascot-top{position:fixed; top:16px; left:24px; pointer-events:none;}
 
 button:not([disabled]){ cursor:pointer; }
 
@@ -699,26 +698,6 @@ button:not([disabled]){ cursor:pointer; }
 .event-meta{ opacity:.8; font-size:12px; }
 .event-actions{ display:flex; gap:8px; }
 
-/* Модальные окна */
-.modal-backdrop{
-  position:fixed;
-  inset:0;
-  background:rgba(0,0,0,.6);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  z-index:1000;
-}
-
-.modal{
-  background:var(--card-dark);
-  border:1px solid var(--card-border);
-  border-radius:12px;
-  padding:20px;
-  box-shadow:0 10px 26px var(--shadow);
-  max-width:320px;
-}
-
 /* Сетки форм */
 .form-grid{ display:grid; gap:14px; }
 
@@ -735,92 +714,52 @@ button:not([disabled]){ cursor:pointer; }
 .wish-item.taken{ opacity:.6; }
 .wish-item.taken button{ pointer-events:none; }
 
-/* --- Menu mascot sizing & layering --- */
-#frog-mascot,
-.mascot-top{
-  position: fixed;
-  top: 56px;             /* было 18px — чуть ниже, чтобы не «давила» на блок */
-  left: 24px;
-  width: clamp(120px, 18vw, 220px);  /* адаптивный размер вместо гигантского */
-  height: auto;
-  z-index: 1;            /* под контролами */
-  pointer-events: none;  /* не перехватывает клики */
-  object-fit: contain;
-}
-
-.menu-deck{
-  z-index: 3;            /* гарантированно поверх маскота */
-}
-
-/* на очень узких экранах сделать ещё компактнее */
-@media (max-width: 520px){
-  #frog-mascot,
-  .mascot-top{
-    top: 44px;
-    width: clamp(110px, 26vw, 160px);
-  }
-}
-
-dialog[type-modal], #type-modal { border: none; background: transparent; }
-#type-modal::backdrop { background: rgba(0,0,0,.45); }
-#type-modal .panel {
-  background: rgba(0,0,0,.28);
-  border: 1px solid rgba(255,255,255,.08);
-  box-shadow: 0 10px 28px rgba(0,0,0,.4);
-  border-radius: 16px;
-  padding: 20px;
-  width: min(480px, 92vw);
-  margin: 0 auto;
-}
-
 .stack-md > * + * { margin-top: 12px; }
 .row-end { display: flex; justify-content: flex-end; }
 .gap-sm { gap: 10px; }
 
-/* Cookie banner */
+/* Важно: не даём странице “уезжать” по горизонтали */
+html, body { overflow-x: hidden; }
+
+/* Герой-лягушка — показываем только на меню */
+.frog-hero { display: none; position: fixed; left: 50%; top: 42%;
+  transform: translate(-50%,-50%); pointer-events: none; user-select: none; z-index: 1;
+}
+#screen-menu .frog-hero { display: block; }
+.frog-hero img { width: min(58vw, 680px); height: auto; filter: drop-shadow(0 8px 24px rgba(0,0,0,.35)); }
+@media (max-width: 900px){ .frog-hero img{ width: min(78vw, 560px); } }
+
+/* Любые другие лягушки-стикеры запрещаем вне финала (предотвращаем дубли) */
+.frog-sticker { display: none; }
+#screen-final .frog-sticker, #screen-app .frog-sticker { display: block; }
+
+/* Cookie banner — фиксируем по центру снизу и поверх контента, но ниже модалок */
 .cookie{
   position: fixed; left: 50%; bottom: 20px; transform: translateX(-50%);
   display: flex; gap: 12px; align-items: center;
-  background: rgba(9, 30, 18, 0.9);
+  background: rgba(9, 30, 18, 0.92);
   border: 1px solid rgba(255,255,255,0.08);
   border-radius: 14px; padding: 10px 14px; z-index: 1000;
   box-shadow: 0 10px 28px rgba(0,0,0,.35);
   max-width: min(92vw, 840px);
 }
-.cookie__text{ color: #dff9ea; line-height: 1.35; font-size: 14px; }
-.cookie__actions{ margin-left: auto; }
+.cookie__text{ color:#dff9ea; line-height:1.35; font-size:14px; }
+.cookie__actions{ margin-left:auto; }
 
-/* Modal */
-.modal{ position: fixed; inset: 0; z-index: 1001; }
+/* Модалки строго по центру вьюпорта и поверх всего */
+.modal { position: fixed; inset: 0; z-index: 1100; }
 .modal[hidden]{ display:none; }
-.modal.show .modal__card{ transform: translate(-50%,-50%) scale(1); opacity: 1; }
-.modal__backdrop{
-  position:absolute; inset:0; background: rgba(0,0,0,.45); backdrop-filter: blur(2px);
-}
+.modal__backdrop{ position: fixed; inset:0; background: rgba(0,0,0,.45); backdrop-filter: blur(2px); }
 .modal__card{
-  position:absolute; left:50%; top:50%; transform: translate(-50%,-50%) scale(.96);
-  width: min(92vw, 520px);
-  background: rgba(9, 30, 18, 0.96);
-  border: 1px solid rgba(255,255,255,.08);
+  position: fixed; left:50%; top:50%; transform: translate(-50%,-50%) scale(.965);
+  width: min(92vw, 520px); opacity:0;
+  background: rgba(9,30,18,0.98);
+  border: 1px solid rgba(255,255,255,.10);
   border-radius: 18px; padding: 18px;
-  box-shadow: 0 18px 48px rgba(0,0,0,.4);
-  transition: transform .15s ease, opacity .15s ease;
-  opacity: 0;
+  box-shadow: 0 18px 48px rgba(0,0,0,.45);
+  transition: transform .16s ease, opacity .16s ease;
 }
+.modal.show .modal__card{ transform: translate(-50%,-50%) scale(1); opacity:1; }
 .modal__title{ margin: 4px 2px 12px; font-size: 20px; color:#e8fff3; }
 .modal__btns{ display:flex; gap:10px; flex-wrap:wrap; }
 .modal__footer{ margin-top:10px; display:flex; justify-content:flex-end; }
-
-/* Центровка и размер лягушки на экране меню */
-#screen-menu .frog-hero{
-  position: absolute; left:50%; top: 42%;
-  transform: translate(-50%,-50%);
-  pointer-events: none; user-select: none;
-}
-#screen-menu .frog-hero img{
-  display:block; width: min(60vw, 720px); max-width: 780px; height: auto;
-  filter: drop-shadow(0 8px 24px rgba(0,0,0,.35));
-}
-@media (max-width: 800px){
-  #screen-menu .frog-hero img{ width: min(82vw, 560px); }
-}


### PR DESCRIPTION
## Summary
- show auth screen by default and wire up type-selection modal with ESC/backdrop handling
- display a single hero frog on menu and hide decorative frogs until the final screen
- center cookie banner and generic modals while preventing horizontal scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7737b16688332912706b16f3ddd21