### PR TITLE
feat: center frog hero and modal

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -57,14 +57,12 @@ function show(name){
   show('auth');
 
   // cookie banner
-  const cookie = document.getElementById('cookie');
-  if (cookie && !localStorage.getItem(COOKIE_KEY)) cookie.hidden = false;
+  if(!localStorage.getItem(COOKIE_KEY)) $('#cookie-banner').hidden = false;
 })();
 
-document.getElementById('cookie-ok')?.addEventListener('click', ()=>{
-  localStorage.setItem(COOKIE_KEY, '1');
-  const cookie = document.getElementById('cookie');
-  if (cookie) cookie.hidden = true;
+$('#cookie-accept')?.addEventListener('click', ()=>{
+  localStorage.setItem(COOKIE_KEY,'1');
+  $('#cookie-banner').hidden = true;
 });
 
 async function apiPost(fnPath, payload) {
@@ -162,38 +160,20 @@ document.addEventListener('click', (e)=>{
   }
 });
 
-const dlgType = document.getElementById('dlg-type');
-
-function openDlg(el){ if(!el) return; el.hidden = false; requestAnimationFrame(()=> el.classList.add('show')); }
-function closeDlg(el){ if(!el) return; el.classList.remove('show'); setTimeout(()=>{ el.hidden = true; }, 160); }
-
-document.getElementById('create-event')?.addEventListener('click', (e)=>{
-  e.preventDefault();
-  openDlg(dlgType);
-});
-
-// Делегирование: закрыть по “Отмена”, клик по подложке, или выбрать тип
-document.addEventListener('click', (e)=>{
-  if (!dlgType) return;
-
-  if (e.target.closest('[data-close="dlg-type"]') || e.target.classList?.contains('modal__backdrop')){
-    closeDlg(dlgType);
-  }
-
-  const typeBtn = e.target.closest('[data-type]');
-  if (typeBtn){
-    const t = typeBtn.dataset.type;  // 'business' | 'party'
-    window.__FH__ = window.__FH__ || {};
-    window.__FH__.createType = t;
-    closeDlg(dlgType);
+$('#create-event')?.addEventListener('click', () => openTypeModal(true));
+function openTypeModal(open){ $('#modal-type').hidden = !open; }
+document.addEventListener('keydown', e=>{ if(e.key==='Escape') openTypeModal(false); });
+$('#modal-type').addEventListener('click', e=>{
+  const btn = e.target.closest('[data-type]');
+  if(btn){
+    const t = btn.dataset.type;
+    ST.createType = t;
     if (typeof configureRequirementsForm === 'function') configureRequirementsForm(t);
-    show('create-conditions');
+    openTypeModal(false);
+    show('create-details');
+    return;
   }
-});
-
-// Закрытие по клавише Esc
-document.addEventListener('keydown', (e)=>{
-  if (e.key === 'Escape' && dlgType && !dlgType.hidden) closeDlg(dlgType);
+  if(e.target.id==='modal-type' || e.target.closest('[data-close]')) openTypeModal(false);
 });
 
 $('#join-form')?.addEventListener('submit', (e)=>{

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -24,7 +24,7 @@
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <section id="screen-auth" class="container" role="main">
     <div class="card" id="authPanel" style="max-width:620px;margin:40px auto">
-      <div class="hero">
+      <div class="auth-hero">
         <div class="avatar frog-ava">🐸</div>
         <div class="hero-text">
           <h1>Вход / Регистрация</h1>
@@ -82,13 +82,9 @@
 
   <!-- ЭКРАН МЕНЮ -->
   <section id="screen-menu" class="screen" role="main" hidden>
-    <div class="decor-layer" aria-hidden="true">
-      <img class="decor stump" src="/assets/stump.png" alt="">
-    </div>
-
-    <!-- Герой-лягушка (центр меню) -->
-    <div id="frog-hero" class="frog-hero" aria-hidden="true">
-      <img src="/assets/frog_idle.png" alt="">
+    <div id="hero" class="hero">
+      <img class="frog" src="/assets/frog_idle.png" alt="Froggy" />
+      <img class="stump" src="/assets/stump.png" alt="" aria-hidden="true" />
     </div>
 
     <div class="menu-deck">
@@ -419,31 +415,28 @@
       <p id="otpStatus" class="hint" aria-live="polite"></p>
     </form>
   </dialog>
-  <!-- Cookie notice -->
-  <div id="cookie" class="cookie" hidden>
-    <div class="cookie__text">
-      Мы используем cookies, чтобы сайт работал стабильнее. Продолжая, вы принимаете использование cookies.
-    </div>
-    <div class="cookie__actions">
-      <button id="cookie-ok" class="btn btn-primary btn-sm">Принять</button>
-    </div>
-  </div>
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
 
-  <!-- Тип встречи (модалка выбора) -->
-  <div id="dlg-type" class="modal" hidden>
-    <div class="modal__backdrop" data-close="dlg-type"></div>
-    <div class="modal__card">
-      <h3 class="modal__title">Какой тип встречи вы планируете создать?</h3>
+  <div id="modal-type" class="modal" hidden>
+    <div class="card">
+      <h3>Какой тип встречи вы планируете создать?</h3>
       <div class="modal__btns">
         <button class="btn btn-secondary" data-type="business">Деловая</button>
         <button class="btn btn-secondary" data-type="party">Праздничная</button>
       </div>
       <div class="modal__footer">
-        <button class="btn btn-ghost" data-close="dlg-type">Отмена</button>
+        <button class="btn btn-ghost" data-close>Отмена</button>
       </div>
     </div>
   </div>
 
-  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+  <div id="cookie-banner" class="cookie" hidden>
+    <div class="cookie__text">
+      Мы используем cookies, чтобы сайт работал стабильнее. Продолжая, вы принимаете использование cookies.
+    </div>
+    <div class="cookie__actions">
+      <button id="cookie-accept" class="btn btn-primary btn-sm">Принять</button>
+    </div>
+  </div>
 </body>
 </html>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -35,7 +35,7 @@
 }
 
 *{box-sizing:border-box}
-html,body{height:100%}
+html,body{height:100%;overflow-x:hidden}
 body{
   margin:0;
   background:radial-gradient(120% 120% at 50% 30%, var(--bg-dark2), var(--bg-dark));
@@ -194,8 +194,8 @@ a.btn{ color:inherit; }
 }
 
 .hint{color:var(--muted);font-size:.92rem}
- .hero{display:flex;gap:16px;align-items:center;margin-bottom:10px}
- .hero, .header-pond { position: relative; overflow: hidden; }
+  .auth-hero{display:flex;gap:16px;align-items:center;margin-bottom:10px}
+  .auth-hero, .header-pond { position: relative; overflow: hidden; }
 .avatar{width:64px;height:64px;border-radius:50%;display:grid;place-items:center;font-size:28px;background:var(--accent)}
 .hero-text h1{margin:0 0 6px}
 .chips{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
@@ -247,7 +247,7 @@ body.scene-intro .wrap, body.scene-final .wrap{grid-template-rows:100vh 0}
 #frog{position:absolute;left:50%;top:42%;transform:translate(-50%,-50%);transition:left .45s ease,top .45s ease,transform .2s ease;z-index:3}
 #frog img{width:100%;height:auto;display:block}
 /* Шапка с иллюстрациями: не даём им вылезать и менять ширину контейнера */
-.frog-hero, #frog { max-width: clamp(140px, 45vw, 360px); height: auto; }
+#frog { max-width: clamp(140px, 45vw, 360px); height: auto; }
 body.scene-intro #frog, body.scene-pond #frog{width:clamp(80px,14vw,140px);max-width:none;}
 body.scene-final #frog{max-width:120px;transform:translate(-50%,-70%);}
 @media (max-width:960px){
@@ -498,13 +498,6 @@ body.scene-intro .speech{display:block}
   justify-content: center;
 }
 
-.frog-hero {
-  width: 100%;
-  min-height: 360px;
-  background: url('/img/frog-stump.svg') center/contain no-repeat;
-  filter: drop-shadow(0 8px 16px rgba(0,0,0,.25));
-}
-
 .countdown {
   position: absolute;
   top: 24px;
@@ -718,48 +711,13 @@ button:not([disabled]){ cursor:pointer; }
 .row-end { display: flex; justify-content: flex-end; }
 .gap-sm { gap: 10px; }
 
-/* Важно: не даём странице “уезжать” по горизонтали */
-html, body { overflow-x: hidden; }
-
-/* Герой-лягушка — показываем только на меню */
-.frog-hero { display: none; position: fixed; left: 50%; top: 42%;
-  transform: translate(-50%,-50%); pointer-events: none; user-select: none; z-index: 1;
-}
-#screen-menu .frog-hero { display: block; }
-.frog-hero img { width: min(58vw, 680px); height: auto; filter: drop-shadow(0 8px 24px rgba(0,0,0,.35)); }
-@media (max-width: 900px){ .frog-hero img{ width: min(78vw, 560px); } }
-
-/* Любые другие лягушки-стикеры запрещаем вне финала (предотвращаем дубли) */
-.frog-sticker { display: none; }
-#screen-final .frog-sticker, #screen-app .frog-sticker { display: block; }
-
-/* Cookie banner — фиксируем по центру снизу и поверх контента, но ниже модалок */
-.cookie{
-  position: fixed; left: 50%; bottom: 20px; transform: translateX(-50%);
-  display: flex; gap: 12px; align-items: center;
-  background: rgba(9, 30, 18, 0.92);
-  border: 1px solid rgba(255,255,255,0.08);
-  border-radius: 14px; padding: 10px 14px; z-index: 1000;
-  box-shadow: 0 10px 28px rgba(0,0,0,.35);
-  max-width: min(92vw, 840px);
-}
-.cookie__text{ color:#dff9ea; line-height:1.35; font-size:14px; }
-.cookie__actions{ margin-left:auto; }
-
-/* Модалки строго по центру вьюпорта и поверх всего */
-.modal { position: fixed; inset: 0; z-index: 1100; }
-.modal[hidden]{ display:none; }
-.modal__backdrop{ position: fixed; inset:0; background: rgba(0,0,0,.45); backdrop-filter: blur(2px); }
-.modal__card{
-  position: fixed; left:50%; top:50%; transform: translate(-50%,-50%) scale(.965);
-  width: min(92vw, 520px); opacity:0;
-  background: rgba(9,30,18,0.98);
-  border: 1px solid rgba(255,255,255,.10);
-  border-radius: 18px; padding: 18px;
-  box-shadow: 0 18px 48px rgba(0,0,0,.45);
-  transition: transform .16s ease, opacity .16s ease;
-}
-.modal.show .modal__card{ transform: translate(-50%,-50%) scale(1); opacity:1; }
-.modal__title{ margin: 4px 2px 12px; font-size: 20px; color:#e8fff3; }
-.modal__btns{ display:flex; gap:10px; flex-wrap:wrap; }
-.modal__footer{ margin-top:10px; display:flex; justify-content:flex-end; }
+/* Центровка лягушки, модалок и куки */
+.hero{position:relative;display:flex;justify-content:center;align-items:flex-end;margin:40px 0 0}
+.hero .stump{position:absolute;bottom:-8px;left:50%;transform:translateX(-50%);width:min(220px,35vw);z-index:1;pointer-events:none}
+.hero .frog{position:relative;z-index:2;width:min(520px,72vw);max-width:90vw;height:auto;pointer-events:none}
+.modal{position:fixed;inset:0;display:grid;place-items:center;background:rgba(0,0,0,.45);backdrop-filter:saturate(1.2) blur(6px);z-index:50}
+.modal[hidden]{display:none}
+.modal .card{background:rgba(0,0,0,.35);border:1px solid rgba(255,255,255,.08);border-radius:16px;padding:18px 20px;min-width:min(560px,92vw);color:#fff}
+.cookie{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);z-index:40}
+.cookie__text{color:#dff9ea;line-height:1.35;font-size:14px}
+.cookie__actions{margin-left:auto}


### PR DESCRIPTION
## Summary
- show a single centered frog with stump on menu
- keep modals/cookie centered and closeable
- start app from auth screen and save cookie consent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a777baf0048332932ed267d8fea747