### PR TITLE
feat: redesign type modal and final screen

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -161,10 +161,10 @@ document.addEventListener('click', (e)=>{
 });
 
 $('#create-event')?.addEventListener('click', () => openTypeModal(true));
-function openTypeModal(open){ $('#modal-type').hidden = !open; }
+function openTypeModal(open){ $('#typeModal').hidden = !open; }
 document.addEventListener('keydown', e=>{ if(e.key==='Escape') openTypeModal(false); });
-$('#modal-type').addEventListener('click', e=>{
-  if(e.target.id==='modal-type' || e.target.closest('[data-close]')) openTypeModal(false);
+$('#typeModal').addEventListener('click', e=>{
+  if(e.target.classList.contains('modal-backdrop') || e.target.closest('[data-close]')) openTypeModal(false);
 });
 
 // --- Создание события: состояние и шаги ---
@@ -194,7 +194,7 @@ $('#form-join-name')?.addEventListener('submit', e=>{
   if(!guest.nickname) return;
   // подгружаем wishlist из созданного state.create, если код совпал (стаб)
   const wl = (state.create.code && guest.code===state.create.code) ? state.create.wishlist : [];
-  guest.event = { title: state.create.base.title, date: state.create.base.date, time: state.create.base.time, place: state.create.base.place,
+  guest.event = { title: state.create.base.title, date: state.create.base.date, time: state.create.base.time, address: state.create.base.place,
     dress: state.create.reqs.dress, bring: state.create.reqs.bring, comment: state.create.reqs.comment, wishlist: JSON.parse(JSON.stringify(wl)) };
   renderJoinWl(); show('join-wishlist');
 });
@@ -221,15 +221,9 @@ document.addEventListener('click', e=>{
 });
 
 $('#btn-join-final')?.addEventListener('click', ()=>{
-  // выводим ту же финальную карточку
-  $('#event-code').textContent   = guest.code;
-  $('#final-title').textContent  = guest.event.title || '—';
-  $('#event-when').textContent   = `${guest.event.date||''} ${guest.event.time||''}`;
-  $('#event-address').textContent= guest.event.place || '—';
-  $('#event-dress').textContent  = guest.event.dress || '—';
-  $('#event-bring').textContent  = guest.event.bring || '—';
-  $('#event-comment').textContent= guest.event.comment || '—';
-  show('app');
+  const ev = Object.assign({ code: guest.code }, guest.event);
+  populateFinal(ev);
+  show('final');
 });
 
 function setCreateType(t){
@@ -242,11 +236,13 @@ function setCreateType(t){
 function six(){ return String(Math.floor(100000 + Math.random()*900000)); }
 
 // модалка “тип встречи”
-$('#btn-type-business')?.addEventListener('click', ()=>{
-  setCreateType('business'); openTypeModal(false); show('create-conditions');
-});
-$('#btn-type-party')?.addEventListener('click', ()=>{
-  setCreateType('party'); openTypeModal(false); show('create-conditions');
+document.addEventListener('click', e=>{
+  const btnType = e.target.closest('#typeModal [data-type]');
+  if(!btnType) return;
+  const kind = btnType.getAttribute('data-type');
+  setCreateType(kind);
+  openTypeModal(false);
+  show('create-conditions');
 });
 
 // шаг 1 → шаг 2
@@ -299,34 +295,70 @@ document.addEventListener('click', e=>{
 // финал
 $('#btn-create-final')?.addEventListener('click', ()=>{
   state.create.code = six();
-  fillFinalFromState(state.create);
-  show('app');
+  const ev = {
+    code: state.create.code,
+    title: state.create.base.title,
+    date: state.create.base.date,
+    time: state.create.base.time,
+    address: state.create.base.place,
+    dress: state.create.reqs.dress,
+    bring: state.create.reqs.bring,
+    comment: state.create.reqs.comment,
+    wishlist: state.create.wishlist
+  };
+  populateFinal(ev);
+  show('final');
 });
 
-function fillFinalFromState(st){
-  $('#event-code').textContent   = st.code;
-  $('#final-title').textContent  = st.base.title || '—';
-  $('#event-when').textContent   = `${st.base.date} ${st.base.time||''}`;
-  $('#event-address').textContent= st.base.place || '—';
-  $('#event-dress').textContent  = st.reqs.dress || '—';
-  $('#event-bring').textContent  = st.reqs.bring || '—';
-  $('#event-comment').textContent= st.reqs.comment || '—';
+function populateFinal(ev){
+  state.event = ev; state.code = ev.code;
+  $('#final-title').textContent = ev.title || 'Событие';
+  $('#invite-title').textContent = ev.title || 'Событие';
+  $('#final-code').textContent = ev.code || '—';
+
+  const whenText = [ev.date, ev.time].filter(Boolean).join(' ');
+  $('#final-when').textContent = whenText || '—';
+  $('#final-address').textContent = ev.address || '—';
+  $('#final-dress').textContent = ev.dress || '—';
+  $('#final-bring').textContent = ev.bring || '—';
+  $('#final-comment').textContent = ev.comment || '—';
+
+  $('#chip-date').textContent = ev.date || '—';
+  const chipTime = $('#chip-time');
+  if(ev.time){ chipTime.textContent = ev.time; chipTime.hidden = false; } else { chipTime.hidden = true; }
+  const chipPlace = $('#chip-place');
+  if(ev.address){ chipPlace.textContent = ev.address; chipPlace.hidden = false; } else { chipPlace.hidden = true; }
+
+  $('#invite-desc').textContent = ev.comment || 'Описание / детали.';
+
+  const wlBox = $('#invite-wishlist');
+  wlBox.innerHTML = '';
+  (ev.wishlist || []).forEach(it=>{
+    const a = document.createElement('a');
+    a.className = 'chip' + (it.claimed_by ? ' taken' : '');
+    a.textContent = it.title || '—';
+    if(it.url){ a.href = it.url; a.target = '_blank'; a.rel = 'noopener'; }
+    wlBox.appendChild(a);
+  });
+
+  let picked = null;
+  const myNick = guest.nickname || null;
+  if(myNick && ev.wishlist){
+    const mine = ev.wishlist.find(w=> (w.claimed_by||'').toLowerCase() === myNick.toLowerCase());
+    if(mine){ picked = mine.title; }
+  }
+  const pickedRow = $('#final-picked-row');
+  if(picked){ $('#final-picked').textContent = picked; pickedRow.hidden = false; }
+  else { pickedRow.hidden = true; }
 }
 
-function openFinal(data){
-  if (typeof data === 'string') data = { code:data };
-  data = data || {};
-  show('app');
-  $('#final-title').textContent = data.details?.title || 'Событие';
-  $('#event-code').textContent = data.code || '—';
-  const when = [data.details?.date, data.details?.time].filter(Boolean).join(' ');
-  $('#event-when').textContent = when || '—';
-  $('#event-address').textContent = data.details?.place || '—';
-  $('#event-dress').textContent = data.req?.dress || '—';
-  $('#event-bring').textContent = data.req?.bring || '—';
-  $('#event-comment').textContent = data.req?.comment || '—';
-  $('#event-picks').textContent = data.picks && data.picks.length ? data.picks.join(', ') : '—';
+async function openFinal(code){
+  const { event } = await apiFetch('event-one-v2?code='+encodeURIComponent(code));
+  populateFinal(event);
+  show('final');
 }
+
+$('#btn-copy-invite')?.addEventListener('click', ()=>{ if(state.event) copyInvite(state.event); });
 
 async function apiFetch(path, init={}){
   init.headers = Object.assign({'Content-Type':'application/json'}, authHeaders(), init.headers||{});

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -176,19 +176,6 @@
 
   <!-- ЭКРАН 3: ПРУД + ФИНАЛ -->
   <section id="screen-app" class="container" hidden>
-    <section class="card">
-      <h2 id="final-title">Событие</h2>
-      <div>Код: <span id="event-code">—</span> <button id="copy-invite" class="btn btn--ghost btn--sm" type="button">Скопировать приглашение</button></div>
-      <div>Когда: <span id="event-when">—</span></div>
-      <div>Адрес: <span id="event-address">—</span></div>
-      <div>Дресс-код: <span id="event-dress">—</span></div>
-      <div>Что взять: <span id="event-bring">—</span></div>
-      <div>Комментарий: <span id="event-comment">—</span></div>
-      <div>Вы выбрали: <span id="event-picks">—</span></div>
-      <div class="mt-4">
-        <button id="back-to-menu" class="btn btn--secondary" data-go="menu" type="button">Вернуться в меню</button>
-      </div>
-    </section>
     <div class="wrap" id="root" hidden>
       <section class="pond" id="pond">
         <div class="ripples" aria-hidden="true"></div>
@@ -361,6 +348,75 @@
     </div>
   </section>
 
+  <section id="screen-final" class="screen" hidden>
+    <div class="final-wrap">
+      <div class="final-grid">
+        <!-- ЛЕВАЯ КОЛОНКА: детали и шаринг -->
+        <div class="final-left card">
+          <div class="final-head">
+            <h2 id="final-title">Событие</h2>
+            <div class="final-code">
+              <span>Код: <b id="final-code">—</b></span>
+              <button id="btn-copy-invite" class="btn btn-chip">Скопировать приглашение</button>
+            </div>
+          </div>
+
+          <div class="final-details">
+            <div class="row">
+              <span class="label">Когда:</span>
+              <span id="final-when" class="value">—</span>
+            </div>
+            <div class="row">
+              <span class="label">Адрес:</span>
+              <span id="final-address" class="value">—</span>
+            </div>
+            <div class="row">
+              <span class="label">Дресс-код:</span>
+              <span id="final-dress" class="value">—</span>
+            </div>
+            <div class="row">
+              <span class="label">Что взять:</span>
+              <span id="final-bring" class="value">—</span>
+            </div>
+            <div class="row">
+              <span class="label">Комментарий:</span>
+              <span id="final-comment" class="value">—</span>
+            </div>
+            <div class="row" id="final-picked-row" hidden>
+              <span class="label">Вы выбрали:</span>
+              <span id="final-picked" class="value">—</span>
+            </div>
+          </div>
+
+          <div class="final-actions">
+            <button class="btn" data-go="menu">Вернуться в меню</button>
+          </div>
+        </div>
+
+        <!-- ПРАВАЯ КОЛОНКА: превью приглашения + wishlist -->
+        <div class="final-right invite-card">
+          <div class="invite-title" id="invite-title">Событие</div>
+
+          <div class="invite-meta">
+            <span class="chip" id="chip-date">—</span>
+            <span class="chip" id="chip-time" hidden>—</span>
+            <span class="chip" id="chip-place" hidden>—</span>
+          </div>
+
+          <div class="invite-desc" id="invite-desc">Описание / детали.</div>
+
+          <div class="invite-subtitle">Wishlist</div>
+          <div id="invite-wishlist" class="chips"></div>
+
+          <div class="invite-legend">
+            <span class="dot free"></span> свободно
+            <span class="dot taken"></span> занято
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- ЭКРАН: ПРОФИЛЬ -->
   <section id="screen-profile" class="screen" hidden>
     <div class="container">
@@ -412,15 +468,16 @@
   </dialog>
   <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
 
-  <div id="modal-type" class="modal" hidden>
-    <div class="card">
-      <h3>Какой тип встречи вы планируете создать?</h3>
-      <div class="modal__btns">
-        <button id="btn-type-business" class="btn btn-secondary" data-type="business">Деловая</button>
-        <button id="btn-type-party" class="btn btn-secondary" data-type="party">Праздничная</button>
+  <div id="typeModal" class="modal" hidden>
+    <div class="modal-backdrop" data-close></div>
+    <div class="modal-box">
+      <h3 class="modal-title">Какой тип встречи вы планируете создать?</h3>
+      <div class="modal-actions row">
+        <button class="btn btn-primary" data-type="business">Деловая</button>
+        <button class="btn btn-primary" data-type="party">Праздничная</button>
       </div>
-      <div class="modal__footer">
-        <button class="btn btn-ghost" data-close>Отмена</button>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" data-close>Отмена</button>
       </div>
     </div>
   </div>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -720,3 +720,38 @@ button:not([disabled]){ cursor:pointer; }
 .cookie{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);z-index:40}
 .cookie__text{color:#dff9ea;line-height:1.35;font-size:14px}
 .cookie__actions{margin-left:auto}
+
+/* Type modal: horizontal buttons + footer cancel */
+.modal-actions.row{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-top:8px}
+.modal-footer{display:flex;justify-content:flex-end;margin-top:16px}
+
+/* Final screen layout */
+.final-wrap{max-width:1100px;margin:24px auto;padding:0 16px}
+.final-grid{display:grid;grid-template-columns:1.2fr 1fr;gap:18px}
+@media (max-width:900px){.final-grid{grid-template-columns:1fr}}
+
+.card{background:rgba(0,0,0,.16);border:1px solid rgba(255,255,255,.08);border-radius:18px;box-shadow:0 10px 28px rgba(0,0,0,.35);padding:18px}
+.invite-card{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.12);border-radius:18px;box-shadow:0 14px 32px rgba(0,0,0,.35);padding:18px}
+
+.final-head{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:8px}
+.final-code{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.btn-chip{padding:6px 10px;border-radius:999px}
+
+.final-details .row{display:grid;grid-template-columns:120px 1fr;gap:10px;align-items:start;margin:6px 0}
+.final-details .label{opacity:.8}
+.final-actions{margin-top:14px;display:flex;justify-content:flex-start}
+
+.invite-title{font-size:22px;font-weight:700;margin-bottom:8px}
+.invite-meta{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px}
+.chip{display:inline-flex;align-items:center;gap:6px;border:1px solid rgba(255,255,255,.18);padding:6px 10px;border-radius:999px;background:rgba(0,0,0,.18)}
+.invite-desc{opacity:.9;margin:8px 0 12px}
+.invite-subtitle{font-weight:700;margin:4px 0 6px}
+
+.chips{display:flex;flex-wrap:wrap;gap:8px}
+.chips .chip{cursor:default}
+.chips .chip.taken{opacity:.5;border-style:dashed}
+
+.invite-legend{display:flex;gap:12px;margin-top:10px;opacity:.8;font-size:.95em}
+.invite-legend .dot{display:inline-block;width:10px;height:10px;border-radius:50%;margin-right:6px;border:1px solid rgba(0,0,0,.4)}
+.invite-legend .dot.free{background:#19c34a}
+.invite-legend .dot.taken{background:#c3a019}


### PR DESCRIPTION
## Summary
- redesign type selection modal with horizontal buttons and footer cancel
- overhaul final screen into two-column layout with invitation preview and wishlist chips
- populate final view via new JS helper and API fetch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a783406cf88332b5ddc2ff7779b23e