### PR TITLE
style: polish auth and center final screen

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -50,6 +50,12 @@ function show(name){
   const navMenu = document.getElementById('nav-menu');
   if (navMenu) navMenu.hidden = (name === 'menu' || name === 'auth');
   console.log('[screen] =>', name);
+  if (name === 'final') {
+    const right = document.getElementById('final-right');
+    if (right) right.hidden = true;
+    const wrap = document.querySelector('.final-wrap');
+    if (wrap) document.body.dataset.final = 'single';
+  }
 }
 
 (function boot(){

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -23,7 +23,7 @@
   </nav>
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <section id="screen-auth" class="container" role="main">
-    <div class="card" id="authPanel" style="max-width:620px;margin:40px auto">
+    <div class="card auth-card" id="authPanel" style="max-width:620px;margin:40px auto">
       <div class="auth-hero">
         <div class="avatar frog-ava">🐸</div>
         <div class="hero-text">
@@ -48,7 +48,7 @@
           <label>Пароль
             <input id="login-password" name="password" type="password" placeholder="••••••••" minlength="4" required autocomplete="current-password">
           </label>
-            <button id="login-btn" class="btn btn--primary btn--xl w-full" type="submit">Войти</button>
+            <button id="login-btn" class="btn btn-primary btn-xl w-100" type="submit">Войти</button>
             <button id="showReset" class="btn btn--ghost w-full" type="button" data-forgot="false">Забыли пароль?</button>
           <div id="resetPassBlock" class="grid is-hidden">
             <label>Новый пароль
@@ -73,7 +73,7 @@
           <label>Повтор пароля
             <input id="signup-password2" name="password2" type="password" required minlength="4" autocomplete="new-password">
           </label>
-            <button id="signup-btn" class="btn btn--primary btn--xl w-full" type="submit">Зарегистрироваться</button>
+            <button id="signup-btn" class="btn btn-primary btn-xl w-100" type="submit">Зарегистрироваться</button>
           <div id="reg-status" aria-live="polite"></div>
         </form>
       </section>
@@ -350,70 +350,68 @@
 
   <section id="screen-final" class="screen" hidden>
     <div class="final-wrap">
-      <div class="final-grid">
-        <!-- ЛЕВАЯ КОЛОНКА: детали и шаринг -->
-        <div class="final-left card">
-          <div class="final-head">
-            <h2 id="final-title">Событие</h2>
-            <div class="final-code">
-              <span>Код: <b id="final-code">—</b></span>
-              <button id="btn-copy-invite" class="btn btn-chip">Скопировать приглашение</button>
-            </div>
-          </div>
-
-          <div class="final-details">
-            <div class="row">
-              <span class="label">Когда:</span>
-              <span id="final-when" class="value">—</span>
-            </div>
-            <div class="row">
-              <span class="label">Адрес:</span>
-              <span id="final-address" class="value">—</span>
-            </div>
-            <div class="row">
-              <span class="label">Дресс-код:</span>
-              <span id="final-dress" class="value">—</span>
-            </div>
-            <div class="row">
-              <span class="label">Что взять:</span>
-              <span id="final-bring" class="value">—</span>
-            </div>
-            <div class="row">
-              <span class="label">Комментарий:</span>
-              <span id="final-comment" class="value">—</span>
-            </div>
-            <div class="row" id="final-picked-row" hidden>
-              <span class="label">Вы выбрали:</span>
-              <span id="final-picked" class="value">—</span>
-            </div>
-          </div>
-
-          <div class="final-actions">
-            <button class="btn" data-go="menu">Вернуться в меню</button>
+      <!-- ЛЕВАЯ КОЛОНКА: детали и шаринг -->
+      <article id="final-left" class="final-card">
+        <div class="final-head">
+          <h2 id="final-title">Событие</h2>
+          <div class="final-code">
+            <span>Код: <b id="final-code">—</b></span>
+            <button id="btn-copy-invite" class="btn btn-chip">Скопировать приглашение</button>
           </div>
         </div>
 
-        <!-- ПРАВАЯ КОЛОНКА: превью приглашения + wishlist -->
-        <div class="final-right invite-card">
-          <div class="invite-title" id="invite-title">Событие</div>
-
-          <div class="invite-meta">
-            <span class="chip" id="chip-date">—</span>
-            <span class="chip" id="chip-time" hidden>—</span>
-            <span class="chip" id="chip-place" hidden>—</span>
+        <div class="final-details">
+          <div class="row">
+            <span class="label">Когда:</span>
+            <span id="final-when" class="value">—</span>
           </div>
-
-          <div class="invite-desc" id="invite-desc">Описание / детали.</div>
-
-          <div class="invite-subtitle">Wishlist</div>
-          <div id="invite-wishlist" class="chips"></div>
-
-          <div class="invite-legend">
-            <span class="dot free"></span> свободно
-            <span class="dot taken"></span> занято
+          <div class="row">
+            <span class="label">Адрес:</span>
+            <span id="final-address" class="value">—</span>
+          </div>
+          <div class="row">
+            <span class="label">Дресс-код:</span>
+            <span id="final-dress" class="value">—</span>
+          </div>
+          <div class="row">
+            <span class="label">Что взять:</span>
+            <span id="final-bring" class="value">—</span>
+          </div>
+          <div class="row">
+            <span class="label">Комментарий:</span>
+            <span id="final-comment" class="value">—</span>
+          </div>
+          <div class="row" id="final-picked-row" hidden>
+            <span class="label">Вы выбрали:</span>
+            <span id="final-picked" class="value">—</span>
           </div>
         </div>
-      </div>
+
+        <div class="final-actions">
+          <button class="btn" data-go="menu">Вернуться в меню</button>
+        </div>
+      </article>
+
+      <!-- ПРАВАЯ КОЛОНКА: превью приглашения + wishlist -->
+      <aside id="final-right" class="final-card" hidden>
+        <div class="invite-title" id="invite-title">Событие</div>
+
+        <div class="invite-meta">
+          <span class="chip" id="chip-date">—</span>
+          <span class="chip" id="chip-time" hidden>—</span>
+          <span class="chip" id="chip-place" hidden>—</span>
+        </div>
+
+        <div class="invite-desc" id="invite-desc">Описание / детали.</div>
+
+        <div class="invite-subtitle">Wishlist</div>
+        <div id="invite-wishlist" class="chips"></div>
+
+        <div class="invite-legend">
+          <span class="dot free"></span> свободно
+          <span class="dot taken"></span> занято
+        </div>
+      </aside>
     </div>
   </section>
 

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -755,3 +755,32 @@ button:not([disabled]){ cursor:pointer; }
 .invite-legend .dot{display:inline-block;width:10px;height:10px;border-radius:50%;margin-right:6px;border:1px solid rgba(0,0,0,.4)}
 .invite-legend .dot.free{background:#19c34a}
 .invite-legend .dot.taken{background:#c3a019}
+.w-100{width:100%}
+
+/* === Auth polish === */
+.auth-card{max-width:640px;margin:6vh auto;padding:20px 22px;border-radius:18px;
+  background:rgba(0,0,0,.22);border:1px solid rgba(255,255,255,.09);
+  box-shadow:0 18px 40px rgba(0,0,0,.35)}
+.auth-card h1,.auth-card h2{letter-spacing:.2px}
+.auth-card .tabs{margin:10px 0 14px}
+.auth-card .input, .auth-card input[type="text"], .auth-card input[type="password"]{
+  height:52px;font-size:16px;border-radius:12px;border:1px solid rgba(255,255,255,.18);
+  background:rgba(10,10,10,.55);padding:0 16px;color:#fff}
+.auth-card .input::placeholder{color:rgba(255,255,255,.55)}
+.btn-xl{height:52px;font-weight:600;border-radius:14px}
+.btn-primary{background:linear-gradient(180deg,#2e7a62,#1f5c49);border:1px solid rgba(255,255,255,.12)}
+.btn-primary:hover{filter:brightness(1.06)}
+@media (max-width:720px){
+  .auth-card{margin:3vh 12px;padding:16px}
+}
+
+/* === Final single-column === */
+.final-wrap{max-width:860px;margin:32px auto;padding:0 16px;display:block}
+.final-card{background:rgba(0,0,0,.22);border:1px solid rgba(255,255,255,.09);
+  border-radius:20px;padding:22px;box-shadow:0 18px 40px rgba(0,0,0,.35)}
+#final-left{transform:scale(1.03);transform-origin:center}
+#final-right[hidden]{display:none !important}
+@media (max-width:720px){
+  .final-wrap{margin:16px auto}
+  .final-card{padding:16px}
+}


### PR DESCRIPTION
## Summary
- refine login/register card with new button styling
- center final screen in single column and hide preview card
- ensure final view hides right column programmatically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a787adc24083329ab76f4f86db30dd