### PR TITLE
Reconnect event flows to Supabase backend

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -42,6 +42,42 @@ const clearToken = () => { try { localStorage.removeItem(TOKEN_KEY); } catch {} 
 const TOK = 'FH_JWT';
 const getTok = () => localStorage.getItem(TOK);
 
+function authHeader(){
+  const t = localStorage.getItem('FH_JWT');
+  return t ? { Authorization: `Bearer ${t}` } : {};
+}
+const authHeaders = authHeader;
+
+async function api(path, init={}){
+  init.headers = Object.assign({'Content-Type':'application/json'}, authHeader(), init.headers||{});
+  const res = await fetch(`/.netlify/functions/${path}`, init);
+  const data = await res.json().catch(()=>({}));
+  if (!res.ok || data?.success===false) throw new Error(data?.error || `HTTP ${res.status}`);
+  return data;
+}
+
+async function createEventFromDraft(draft){
+  const { event } = await api('event-create', { method:'POST', body: JSON.stringify(draft) });
+  return event; // {id, code, ...}
+}
+
+async function loadEventByCode(code){
+  const { event } = await api('event-one?code='+encodeURIComponent(code));
+  return event;
+}
+
+async function joinEvent(code, nickname){
+  await api('event-join', { method:'POST', body: JSON.stringify({ code, nickname }) });
+}
+
+async function addWish(code, title, url){
+  await api('wishlist-add', { method:'POST', body: JSON.stringify({ code, title, url }) });
+}
+
+async function claimWish(id, nickname){
+  await api('wishlist-claim', { method:'POST', body: JSON.stringify({ id, nickname }) });
+}
+
 function show(name){
   document.querySelectorAll('section[id^="screen-"]').forEach(s => {
     s.hidden = s.id !== `screen-${name}`;
@@ -186,23 +222,29 @@ const state = {
 
 const guest = { code:null, nickname:null, event:null };
 
-$('#join-btn')?.addEventListener('click', ()=>{
+$('#join-btn')?.addEventListener('click', async ()=>{
   const code = ($('#join-code')?.value||'').trim();
   if(code.length!==6){ toast?.('Введите корректный код'); return; }
-  // пока делаем “валидным” любой код, чтобы пройти UX
-  guest.code = code;
-  show('join-name');
+  try {
+    const ev = await loadEventByCode(code);
+    guest.code = code;
+    guest.event = ev;
+    show('join-name');
+  } catch (e) {
+    toast?.('Событие не найдено');
+  }
 });
 
-$('#form-join-name')?.addEventListener('submit', e=>{
+$('#form-join-name')?.addEventListener('submit', async e=>{
   e.preventDefault();
   guest.nickname = $('#jnick').value.trim();
   if(!guest.nickname) return;
-  // подгружаем wishlist из созданного state.create, если код совпал (стаб)
-  const wl = (state.create.code && guest.code===state.create.code) ? state.create.wishlist : [];
-  guest.event = { title: state.create.base.title, date: state.create.base.date, time: state.create.base.time, address: state.create.base.place,
-    dress: state.create.reqs.dress, bring: state.create.reqs.bring, comment: state.create.reqs.comment, wishlist: JSON.parse(JSON.stringify(wl)) };
-  renderJoinWl(); show('join-wishlist');
+  try {
+    await joinEvent(guest.code, guest.nickname);
+    renderJoinWl(); show('join-wishlist');
+  } catch (err) {
+    toast?.(err.message || 'Ошибка');
+  }
 });
 
 function renderJoinWl(){
@@ -219,11 +261,18 @@ function renderJoinWl(){
   `).join('') || '<div style="opacity:.7">Список пуст</div>';
 }
 
-document.addEventListener('click', e=>{
+document.addEventListener('click', async e=>{
   const c = e.target.closest('[data-claim]'); if(!c) return;
   const id = +c.dataset.claim;
   const item = guest.event.wishlist.find(x=>x.id===id);
-  if(item && !item.claimed_by){ item.claimed_by = guest.nickname; renderJoinWl(); }
+  if(item && !item.claimed_by){
+    try {
+      await claimWish(id, guest.nickname);
+      item.claimed_by = guest.nickname; renderJoinWl();
+    } catch (err) {
+      toast?.(err.message || 'Не удалось');
+    }
+  }
 });
 
 $('#btn-join-final')?.addEventListener('click', ()=>{
@@ -299,21 +348,29 @@ document.addEventListener('click', e=>{
 });
 
 // финал
-$('#btn-create-final')?.addEventListener('click', ()=>{
-  state.create.code = six();
-  const ev = {
-    code: state.create.code,
-    title: state.create.base.title,
-    date: state.create.base.date,
-    time: state.create.base.time,
-    address: state.create.base.place,
-    dress: state.create.reqs.dress,
-    bring: state.create.reqs.bring,
-    comment: state.create.reqs.comment,
-    wishlist: state.create.wishlist
-  };
-  populateFinal(ev);
-  show('final');
+$('#btn-create-final')?.addEventListener('click', async ()=>{
+  try {
+    const draft = {
+      type: state.create.type,
+      title: state.create.base.title,
+      date: state.create.base.date,
+      time: state.create.base.time,
+      address: state.create.base.place,
+      dress: state.create.reqs.dress,
+      bring: state.create.reqs.bring,
+      comment: state.create.reqs.comment
+    };
+    const ev = await createEventFromDraft(draft);
+    state.create.code = ev.code;
+    for (const w of state.create.wishlist) {
+      try { await addWish(ev.code, w.title, w.url); } catch {}
+    }
+    const full = await loadEventByCode(ev.code);
+    populateFinal(full);
+    show('final');
+  } catch (err) {
+    toast?.(err.message || 'Не удалось создать');
+  }
 });
 
 function populateFinal(ev){
@@ -359,7 +416,7 @@ function populateFinal(ev){
 }
 
 async function openFinal(code){
-  const { event } = await apiFetch('event-one-v2?code='+encodeURIComponent(code));
+  const event = await loadEventByCode(code);
   populateFinal(event);
   show('final');
 }
@@ -456,11 +513,6 @@ document.addEventListener('click', async (e)=>{
 
   const appState = window.__APP_STATE__ ?? (window.__APP_STATE__ = { currentEvent: null });
 
-function authHeaders() {
-  const t = localStorage.getItem('FH_JWT');
-  return t ? { Authorization: `Bearer ${t}` } : {};
-}
-
 function init() {
   document.addEventListener('click', async (e) => {
     const delBtn = e.target.closest('[data-delete-id]');
@@ -498,7 +550,7 @@ function init() {
 }
 
 // --- API: события ---
-const api = {
+const apiLegacy = {
   events: {
     async create() {
       // сервер создаёт код, даты и т.п. из текущего драфта/формы; при необходимости передай поля
@@ -531,7 +583,7 @@ const api = {
 };
 
 async function renderEvent(eventIdOrObj) {
-  const ev = typeof eventIdOrObj === 'object' ? eventIdOrObj : await api.events.load(eventIdOrObj);
+  const ev = typeof eventIdOrObj === 'object' ? eventIdOrObj : await apiLegacy.events.load(eventIdOrObj);
   appState.currentEvent = ev;
   // заполни поля экрана события
   $('#event-code')?.replaceChildren(document.createTextNode(ev.code ?? '—'));
@@ -1856,16 +1908,6 @@ $('#finishCreate')?.addEventListener('click',()=>withTransition(()=>toFinalScene
 
 
 /* ПРИСОЕДИНЕНИЕ ПО КОДУ */
-async function authHeader(){
-  const sb = await ensureSupabase();
-  if(sb){
-    const { data } = await sb.auth.getSession();
-    const t = data?.session?.access_token;
-    return t ? { Authorization: 'Bearer '+t } : {};
-  }
-  return {};
-}
-
 async function joinByCode(code){
   const announce = document.getElementById('joinCodeError');
   announce.textContent='';

--- a/migrations/2025-08-22_soft_migration.sql
+++ b/migrations/2025-08-22_soft_migration.sql
@@ -1,0 +1,36 @@
+-- 1) Уникальность только по code
+create unique index if not exists events_code_key on public.events(code);
+
+-- 2) Связи wishlist_items → events
+alter table public.wishlist_items
+  add column if not exists event_id bigint;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'wishlist_items_event_id_fkey'
+  ) then
+    alter table public.wishlist_items
+      add constraint wishlist_items_event_id_fkey
+      foreign key (event_id) references public.events(id) on delete cascade;
+  end if;
+end$$;
+
+-- 3) Связи guests → events и доп. поля
+alter table public.guests
+  add column if not exists event_id bigint,
+  add column if not exists nickname text,
+  add column if not exists rsvp text check (rsvp in ('yes','maybe','no'));
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'guests_event_id_fkey'
+  ) then
+    alter table public.guests
+      add constraint guests_event_id_fkey
+      foreign key (event_id) references public.events(id) on delete cascade;
+  end if;
+end$$;

--- a/netlify/functions/_utils.js
+++ b/netlify/functions/_utils.js
@@ -1,0 +1,37 @@
+import { createClient } from '@supabase/supabase-js';
+import jwt from 'jsonwebtoken';
+
+const { SUPABASE_URL, SUPABASE_SERVICE_KEY, JWT_SECRET } = process.env;
+
+export const db = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+export const ok = (body) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'authorization, content-type',
+      'Access-Control-Allow-Methods': 'GET, POST, PATCH, PUT, DELETE, OPTIONS',
+    },
+  });
+
+export const bad = (status, error) => ok({ success: false, error, status });
+
+export const preflight = (req) => {
+  if (req.method === 'OPTIONS')
+    return ok({ success: true });
+  return null;
+};
+
+export function authUser(request) {
+  const auth = request.headers.get('authorization') || '';
+  if (!auth.startsWith('Bearer ')) return null;
+  try {
+    const token = auth.slice(7);
+    const payload = jwt.verify(token, JWT_SECRET);
+    return { id: payload.sub, nickname: payload.nickname };
+  } catch (e) { return null; }
+}
+
+export const genCode = () => String(Math.floor(100000 + Math.random() * 900000));

--- a/netlify/functions/event-create.js
+++ b/netlify/functions/event-create.js
@@ -1,0 +1,28 @@
+import { db, ok, bad, preflight, authUser, genCode } from './_utils.js';
+
+export async function onRequestOptions(ctx){ const r = preflight(ctx.request); return r || ok({}); }
+
+export async function onRequestPost({ request }) {
+  const who = authUser(request);
+  if (!who) return bad(401, 'Unauthorized');
+
+  try {
+    const body = await request.json();
+    const payload = {
+      code: genCode(),
+      host_user_id: who.id,
+      type: (body.type || 'party'),             // 'business' | 'party'
+      title: body.title?.trim() || 'Событие',
+      date: body.date || null,
+      time: body.time || null,
+      address: body.address || null,
+      dress: body.dress || null,
+      bring: body.bring || null,
+      comment: body.comment || null
+    };
+
+    const { data, error } = await db.from('events').insert(payload).select().single();
+    if (error) return bad(500, error.message);
+    return ok({ success: true, event: data });
+  } catch (e) { return bad(400, e.message); }
+}

--- a/netlify/functions/event-join.js
+++ b/netlify/functions/event-join.js
@@ -1,0 +1,18 @@
+import { db, ok, bad, preflight } from './_utils.js';
+
+export async function onRequestOptions(ctx){ const r = preflight(ctx.request); return r || ok({}); }
+
+export async function onRequestPost({ request }) {
+  try {
+    const { code, nickname } = await request.json();
+    if (!code || !nickname) return bad(400, 'code and nickname required');
+
+    const { data: ev, error: e1 } = await db.from('events').select('id').eq('code', code).single();
+    if (e1 || !ev) return bad(404, 'Event not found');
+
+    const { error: e2 } = await db.from('guests').insert({ event_id: ev.id, nickname });
+    if (e2) return bad(500, e2.message);
+
+    return ok({ success: true });
+  } catch (e) { return bad(400, e.message); }
+}

--- a/netlify/functions/event-one.js
+++ b/netlify/functions/event-one.js
@@ -1,0 +1,21 @@
+import { db, ok, bad, preflight } from './_utils.js';
+
+export async function onRequestOptions(ctx){ const r = preflight(ctx.request); return r || ok({}); }
+
+export async function onRequestGet({ request }) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const id   = url.searchParams.get('id');
+
+  let q = db.from('events')
+    .select('id,code,type,title,date,time,address,dress,bring,comment,wishlist:wishlist_items(id,title,url,claimed_by)')
+    .limit(1);
+
+  if (code) q = q.eq('code', code);
+  else if (id) q = q.eq('id', id);
+  else return bad(400, 'code or id required');
+
+  const { data, error } = await q.single();
+  if (error || !data) return bad(404, 'Not found');
+  return ok({ success: true, event: data });
+}

--- a/netlify/functions/wishlist-add.js
+++ b/netlify/functions/wishlist-add.js
@@ -1,0 +1,18 @@
+import { db, ok, bad, preflight } from './_utils.js';
+
+export async function onRequestOptions(ctx){ const r = preflight(ctx.request); return r || ok({}); }
+
+export async function onRequestPost({ request }) {
+  try {
+    const { code, title, url } = await request.json();
+    if (!code || !title) return bad(400, 'code and title required');
+
+    const { data: ev, error: e1 } = await db.from('events').select('id').eq('code', code).single();
+    if (e1 || !ev) return bad(404, 'Event not found');
+
+    const { error: e2 } = await db.from('wishlist_items').insert({ event_id: ev.id, title, url });
+    if (e2) return bad(500, e2.message);
+
+    return ok({ success: true });
+  } catch (e) { return bad(400, e.message); }
+}

--- a/netlify/functions/wishlist-claim.js
+++ b/netlify/functions/wishlist-claim.js
@@ -1,0 +1,15 @@
+import { db, ok, bad, preflight } from './_utils.js';
+
+export async function onRequestOptions(ctx){ const r = preflight(ctx.request); return r || ok({}); }
+
+export async function onRequestPost({ request }) {
+  try {
+    const { id, nickname } = await request.json();
+    if (!id || !nickname) return bad(400, 'id and nickname required');
+
+    const { error } = await db.from('wishlist_items').update({ claimed_by: nickname }).eq('id', id);
+    if (error) return bad(500, error.message);
+
+    return ok({ success: true });
+  } catch (e) { return bad(400, e.message); }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "froggyhub",
       "dependencies": {
         "@netlify/neon": "^0.1.0",
-        "@supabase/supabase-js": "^2.42.5",
+        "@supabase/supabase-js": "^2.43.0",
         "axios": "^1.7.2",
         "bcryptjs": "^2.4.3",
         "jsonwebtoken": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "preview": "vite preview",
     "serve:functions": "netlify functions:serve",
     "test": "npm run test:syntax",
-    "test:syntax": "node --check FroggyHub/app.js && node --check FroggyHub/event-analytics.js && node --check FroggyHub/login.js && node --check netlify/functions/_auth.js && node --check netlify/functions/db-ping.js && node --check netlify/functions/local-login.js && node --check netlify/functions/local-signup.js && node --check netlify/functions/profile.js && node --check netlify/functions/profile-get.js && node --check netlify/functions/events-create.js && node --check netlify/functions/events-get.js && node --check netlify/functions/events-join.js && node --check netlify/functions/events-rsvp.js && node --check netlify/functions/events-list.js && node --check netlify/functions/events-mine.js && node --check netlify/functions/avatar-upload.js && node --check netlify/functions/event-create-v2.js && node --check netlify/functions/event-one-v2.js && node --check netlify/functions/event-join-v2.js && node --check netlify/functions/wishlist-add-v2.js && node --check netlify/functions/wishlist-claim-v2.js"
+    "test:syntax": "node --check FroggyHub/app.js && node --check FroggyHub/event-analytics.js && node --check FroggyHub/login.js && node --check netlify/functions/_auth.js && node --check netlify/functions/db-ping.js && node --check netlify/functions/local-login.js && node --check netlify/functions/local-signup.js && node --check netlify/functions/profile.js && node --check netlify/functions/profile-get.js && node --check netlify/functions/events-create.js && node --check netlify/functions/events-get.js && node --check netlify/functions/events-join.js && node --check netlify/functions/events-rsvp.js && node --check netlify/functions/events-list.js && node --check netlify/functions/events-mine.js && node --check netlify/functions/avatar-upload.js && node --check netlify/functions/event-create-v2.js && node --check netlify/functions/event-one-v2.js && node --check netlify/functions/event-join-v2.js && node --check netlify/functions/wishlist-add-v2.js && node --check netlify/functions/wishlist-claim-v2.js && node --check netlify/functions/_utils.js && node --check netlify/functions/event-create.js && node --check netlify/functions/event-one.js && node --check netlify/functions/event-join.js && node --check netlify/functions/wishlist-add.js && node --check netlify/functions/wishlist-claim.js"
   },
   "engines": {
     "node": ">=18"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.42.5",
+    "@supabase/supabase-js": "^2.43.0",
     "axios": "^1.7.2",
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
## Summary
- add Netlify helper and new Supabase-backed functions for events and wishlist
- wire frontend create/join/claim flows to call API client with JWT
- add soft migration for wishlist and guests relations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7a301e2c08332a45110d825e4ecc9