### PR TITLE
Add Netlify API helper and token-based auth boot

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -1,3 +1,5 @@
+import { nf, getToken, setToken, clearToken, logout } from './js/api.js';
+
 let __booted = false;
 window.addEventListener('DOMContentLoaded', () => {
   if (__booted) return;
@@ -33,17 +35,10 @@ function onDelegated(selector, type, handler, options){
   }, options || false);
 }
 
-const TOKEN_KEY  = 'FH_JWT';
 const COOKIE_KEY = 'FH_COOKIE_OK';
-const saveToken  = t => { try { localStorage.setItem(TOKEN_KEY, t); } catch {} };
-const getToken   = () => { try { return localStorage.getItem(TOKEN_KEY); } catch { return null } };
-const clearToken = () => { try { localStorage.removeItem(TOKEN_KEY); } catch {} };
-
-const TOK = 'FH_JWT';
-const getTok = () => localStorage.getItem(TOK);
 
 function authHeader(){
-  const t = localStorage.getItem('FH_JWT');
+  const t = getToken();
   return t ? { Authorization: `Bearer ${t}` } : {};
 }
 const authHeaders = authHeader;
@@ -94,13 +89,30 @@ function show(name){
   }
 }
 
-(function boot(){
-  // ВСЕГДА сначала авторизация
-  show('auth');
+async function boot(){
+  const token = getToken();
+  if(!token){
+    document.documentElement.classList.add('auth-required');
+    show('auth');
+    return;
+  }
 
-  // cookie banner
-  if(!localStorage.getItem(COOKIE_KEY)) $('#cookie-banner').hidden = false;
-})();
+  const me = await nf('profile');
+  if(me?.success && me?.user){
+    window.__me = me.user;
+    document.documentElement.classList.remove('auth-required');
+    document.documentElement.classList.add('auth-ok');
+    show('menu');
+  }else{
+    document.documentElement.classList.add('auth-required');
+    show('auth');
+  }
+}
+
+window.logout = logout;
+boot();
+
+if(!localStorage.getItem(COOKIE_KEY)) $('#cookie-banner').hidden = false;
 
 $('#cookie-accept')?.addEventListener('click', ()=>{
   localStorage.setItem(COOKIE_KEY,'1');
@@ -134,7 +146,7 @@ document.querySelectorAll('input, textarea, select').forEach(el=>{
 
 async function fetchMyEvents() {
   const res = await fetch('/.netlify/functions/events-mine', {
-    headers: { Authorization: `Bearer ${localStorage.getItem('FH_JWT') || ''}` }
+    headers: { Authorization: `Bearer ${getToken() || ''}` }
   });
   const data = await res.json();
   if (!res.ok) throw new Error(data?.error || 'Не удалось загрузить события');
@@ -2264,7 +2276,7 @@ if(editForm){
 
 async function login(nickname, password){
   const { token } = await callFn('local-login', { nickname, password });
-  if(token){ saveToken(token); }
+  if(token){ setToken(token); }
   setNickname(nickname);
   return { token };
 }
@@ -2272,7 +2284,7 @@ async function login(nickname, password){
 async function signup(nickname, password){
   await callFn('local-signup', { nickname, password });
   const { token } = await callFn('local-login', { nickname, password });
-  if(token){ saveToken(token); }
+  if(token){ setToken(token); }
   setNickname(nickname);
   return { token };
 }
@@ -2423,7 +2435,6 @@ if(DEBUG_AUTH){
 }
 
 // ==== API helpers (не трогаем существующие экспорты, просто добавляем) ====
-const FH_TOKEN_KEY = 'FH_JWT';
 const API_BASE = '/.netlify/functions';
 
 async function apiGet(path) {
@@ -2515,7 +2526,7 @@ document.addEventListener('click', (e) => {
 
 async function onDeleteEventClick(eventId) {
   if (!confirm('Удалить событие? Это действие необратимо.')) return;
-  const token = localStorage.getItem('FH_JWT');
+  const token = getToken();
   const res = await fetch('/.netlify/functions/event-delete', {
     method: 'POST',
     headers: {
@@ -2824,7 +2835,7 @@ function wireAuthForms(){
       try{
         const data = await apiLogin(nickname, password);
         if (data?.token){
-          saveToken(data.token);
+          setToken(data.token);
           show('menu');        // ← показываем меню/лобби
           if (typeof loadLobby === 'function') loadLobby();
         } else {
@@ -2858,7 +2869,7 @@ function wireAuthForms(){
         if (data?.ok || data?.success){
           const lg = await apiLogin(nickname, password);
           if (lg?.token){
-            saveToken(lg.token);
+            setToken(lg.token);
             show('menu');
             if (typeof loadLobby === 'function') loadLobby();
             return;

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -452,7 +452,8 @@
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
   </script>
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
-  <script src="/app.js" defer></script>
+  <script src="js/api.js" type="module"></script>
+  <script src="/app.js" type="module"></script>
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
   <dialog id="otpModal">
     <form method="dialog" class="grid">

--- a/FroggyHub/js/api.js
+++ b/FroggyHub/js/api.js
@@ -1,0 +1,37 @@
+// Tiny client for Netlify functions + token helpers
+export const TOKEN_KEY = 'fh:token';
+
+export const getToken = () => localStorage.getItem(TOKEN_KEY);
+export const setToken = (t) => t ? localStorage.setItem(TOKEN_KEY, t) : localStorage.removeItem(TOKEN_KEY);
+export const clearToken = () => localStorage.removeItem(TOKEN_KEY);
+
+export async function nf(path, opts = {}) {
+  const token = getToken();
+  const res = await fetch(`/.netlify/functions/${path}`, {
+    ...opts,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(opts.headers || {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+
+  if (res.status === 401) {
+    clearToken();
+    // отправим на экран входа
+    if (location.pathname !== '/' && location.pathname !== '/index.html') {
+      location.href = '/';
+    }
+    return { success: false, error: 'unauthorized' };
+  }
+  return res.json();
+}
+
+// Глобальный logout удобен для кнопки в шапке
+export function logout() {
+  clearToken();
+  location.href = '/';
+}
+
+// Для удобства в браузере:
+window.fhApi = { nf, getToken, setToken, clearToken, logout };

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -12,17 +12,17 @@
   <div class="container" role="main">
     <div class="card" style="max-width:480px;margin:40px auto">
       <h1>Вход</h1>
-      <form id="login-form" class="grid" novalidate>
+      <form id="login-form" class="grid" novalidate onsubmit="handleLogin(event)">
         <label>Никнейм
-          <input id="login-nick" type="text" autocomplete="username" required />
+          <input id="login-nickname" type="text" autocomplete="username" required />
         </label>
         <label>Пароль
-          <input id="login-pass" type="password" autocomplete="current-password" required />
+          <input id="login-password" type="password" autocomplete="current-password" required />
         </label>
         <button class="btn btn--primary" type="submit">Войти</button>
       </form>
     </div>
   </div>
-  <script src="/login.js" defer></script>
+  <script src="/login.js" type="module"></script>
 </body>
 </html>

--- a/FroggyHub/login.js
+++ b/FroggyHub/login.js
@@ -1,33 +1,25 @@
-(() => {
-  const form = document.querySelector('#login-form');
-  const nick = document.querySelector('#login-nick');
-  const pass = document.querySelector('#login-pass');
+import { nf, setToken } from './js/api.js';
 
-  if (!form || !nick || !pass) { console.warn('login form not found'); return; }
+async function handleLogin(evt) {
+  evt?.preventDefault?.();
+  const nickname = document.querySelector('#login-nickname')?.value?.trim();
+  const password = document.querySelector('#login-password')?.value ?? '';
 
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    e.stopImmediatePropagation();
+  const res = await fetch('/.netlify/functions/local-login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ nickname, password }),
+  });
+  const data = await res.json();
 
-    const nickname = nick.value.trim();
-    const password = pass.value;
-
-    if (!nickname || !password) return;
-
-    const res = await fetch('/.netlify/functions/local-login', {
-      method: 'POST',
-      headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({ nickname, password })
-    });
-
-    const data = await res.json().catch(() => ({}));
-    if (res.ok && data?.token) {
-      localStorage.setItem('FH_JWT', data.token);
-      location.assign('/'); // на страницу выбора “создать / присоединиться”
-    } else {
-      alert(data?.error || 'Ошибка входа');
-    }
-  }, { once: true });
-
-  console.log('Login submit hooked');
-})();
+  if (data?.success && data?.token) {
+    setToken(data.token);
+    // вернёмся на главную/меню
+    location.href = '/';
+  } else {
+    // покажи ошибку в UI
+    console.warn('Login failed:', data);
+    alert(data?.error || 'Не удалось войти');
+  }
+}
+window.handleLogin = handleLogin;


### PR DESCRIPTION
## Summary
- add `js/api.js` to manage auth token and wrap Netlify function calls
- load API helper and convert scripts to modules
- save JWT on login and bootstrap profile on app start with logout helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a813eaeab483329263b410ac63a0f8