### PR TITLE
fix: centralize logout handling

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -1,4 +1,4 @@
-import { nf, getToken, setToken, clearToken, logout } from './js/api.js';
+import { nf, getToken, setToken, clearToken } from './js/api.js';
 
 let __booted = false;
 window.addEventListener('DOMContentLoaded', () => {
@@ -109,8 +109,20 @@ async function boot(){
   }
 }
 
-window.logout = logout;
 boot();
+
+// ---- Logout wiring (single place) ----
+function wireLogout() {
+  document.querySelectorAll('[data-logout]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      if (typeof window.logout === 'function') {
+        window.logout();
+      }
+    });
+  });
+}
+wireLogout();
 
 if(!localStorage.getItem(COOKIE_KEY)) $('#cookie-banner').hidden = false;
 
@@ -904,7 +916,7 @@ async function sha256(pass){
   return toHex(buf);
 }
 
-async function logout(msg){
+async function doLogout(msg){
   const sb = await ensureSupabase();
   manualSignOut = true;
   try{ await sb.auth.signOut(); }catch(_){ }
@@ -1472,7 +1484,7 @@ ensureSupabase().then(async sb => {
         }catch(_){ }
         rebindTried = true;
       }
-      await logout('Сессия истекла, войдите снова');
+      await doLogout('Сессия истекла, войдите снова');
       return;
     }
     currentUser = session?.user || null;
@@ -1541,12 +1553,6 @@ ensureSupabase().then(async sb => {
     }
   });
 });
-/* ---------- ВЫХОД ---------- */
-document.getElementById('logoutBtn')?.addEventListener('click', async () => {
-  await logout();
-  currentUser = null;
-});
-
 $('#changePassBtn')?.addEventListener('click', async ()=>{
   clearFormError($('#changePassError'));
   const curr = $('#currPass').value;
@@ -1583,7 +1589,7 @@ $('#confirmDeleteBtn')?.addEventListener('click', async ()=>{
     const token = session?.access_token;
     await fetch('/.netlify/functions/delete-account', { method:'POST', headers:{ Authorization:`Bearer ${token}` } });
     dlg.close();
-    await logout();
+    await doLogout();
   }catch(_){
     dlg.close();
     toast('Не удалось удалить аккаунт');
@@ -2289,17 +2295,6 @@ async function signup(nickname, password){
   return { token };
 }
 
-['btn-logout','logoutBtn'].forEach(id=>{
-  const el = document.getElementById(id);
-  if(el) el.addEventListener('click', withBusy(el, async ()=>{
-    try{ await callFn('local-logout', {});}catch(e){ console.warn(e); }
-    clearToken();
-    setNickname('');
-    toast('Вы вышли');
-    safeRedirect('/');
-  }));
-});
-
 async function loadProfile(){
   try{
     const res = await fetch('/.netlify/functions/profile-get', {
@@ -2384,10 +2379,6 @@ async function initHubPage(){
     }
   }catch(e){ console.warn('hub profile load failed', e); }
   loadMyEvents();
-  $('#hub-logout')?.addEventListener('click', ()=>{
-    clearToken();
-    window.location.href = '/';
-  });
   $('[data-action="create"]')?.addEventListener('click', (e)=>{
     e.preventDefault();
     window.location.href = '/event-edit.html';

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -11,7 +11,7 @@
 <body>
   <div id="mini-profile" style="position:absolute;top:10px;right:10px;text-align:right;">
     Ник: <span id="mp-nick"></span>, Создан: <span id="mp-created"></span>
-    <button id="hub-logout" class="btn btn--ghost btn--sm">Выйти</button>
+    <button id="hub-logout" data-logout class="btn btn--ghost btn--sm">Выйти</button>
   </div>
   <main class="container" role="main">
     <div class="card" style="max-width:760px;margin:40px auto">

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -452,8 +452,7 @@
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
   </script>
   <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
-  <script src="js/api.js" type="module"></script>
-  <script src="/app.js" type="module"></script>
+  <script type="module" src="./app.js"></script>
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
   <dialog id="otpModal">
     <form method="dialog" class="grid">

--- a/FroggyHub/js/api.js
+++ b/FroggyHub/js/api.js
@@ -33,5 +33,8 @@ export function logout() {
   location.href = '/';
 }
 
+// сделать доступным везде
+window.logout = logout;
+
 // Для удобства в браузере:
 window.fhApi = { nf, getToken, setToken, clearToken, logout };

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -14,7 +14,7 @@
       <nav class="topbar">
         <a href="/" class="btn btn--ghost btn--sm">Меню</a>
         <a href="/profile.html" class="btn btn--ghost btn--sm">Профиль</a>
-        <button id="logoutBtn" class="btn btn--ghost btn--sm">Выйти</button>
+        <button id="logoutBtn" data-logout class="btn btn--ghost btn--sm">Выйти</button>
       </nav>
     </header>
 

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -15,7 +15,7 @@
       <h1>Профиль</h1>
       <p>Никнейм: <strong id="profile-nickname"></strong></p>
       <p>Создан: <span id="profile-created"></span></p>
-      <button type="button" class="btn btn--ghost" id="btn-logout">Выйти</button>
+      <button type="button" class="btn btn--ghost" id="btn-logout" data-logout>Выйти</button>
     </div>
   </main>
   <script>


### PR DESCRIPTION
## Summary
- rely on global `window.logout` exported from API helper
- wire `[data-logout]` buttons to call the global logout once
- remove extra `api.js` script tag so only `app.js` is the entry module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a81d81df188332a8cc109452693e94