### PR TITLE
feat: protect event codes for non-owners

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -19,7 +19,7 @@ const API = {
     return data.event; // { id, join_code, code }
   },
   async getEventByCode(code) {
-    const res = await fetch('/.netlify/functions/event-one?code=' + encodeURIComponent(code));
+    const res = await fetch('/.netlify/functions/event-one?code=' + encodeURIComponent(code), { headers: authHeader() });
     const data = await res.json();
     if (!res.ok || data.success === false) throw new Error(data.error || `HTTP ${res.status}`);
     return data.event; // объект события + wishlist
@@ -425,6 +425,8 @@ $('#form-create-final')?.addEventListener('submit', async (e) => {
 
 function populateFinal(ev){
   state.event = ev; state.code = ev.code;
+  const isOwner = !!(ev.host_user_id && window.auth?.user?.id === ev.host_user_id);
+  document.querySelectorAll('[data-owner-only]').forEach(el => { el.hidden = !isOwner; });
   $('#final-title').textContent = ev.title || 'Событие';
   $('#invite-title').textContent = ev.title || 'Событие';
   $('#final-code').textContent = ev.code || '—';
@@ -2642,7 +2644,7 @@ function renderLobbyContent(ev){
         <button class="btn btn--ghost" data-rsvp="maybe">Возможно</button>
         <button class="btn btn--danger" data-rsvp="no">Не иду</button>
       </div>
-      <button class="btn btn--ghost btn--sm" id="copy-invite">Скопировать приглашение</button>
+      <button class="btn btn--ghost btn--sm" id="copy-invite" data-owner-only>Скопировать приглашение</button>
     </section>
 
     <section class="final-stats">
@@ -2656,6 +2658,8 @@ function renderLobbyContent(ev){
       <div class="wl-list" id="wl-list"></div>
     </section>
   `;
+    const isOwner = !!(ev.host_user_id && window.auth?.user?.id === ev.host_user_id);
+    document.querySelectorAll('[data-owner-only]').forEach(el => { el.hidden = !isOwner; });
 
   document.getElementById('copy-invite').addEventListener('click', () => copyInvite(ev));
   wireRsvp(ev.id);

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -305,7 +305,7 @@
           <div class="bubble"><div class="bubble-head">Фрогги:</div><div class="bubble-body">Поделитесь кодом.</div></div>
           <div class="codeRow">
             <span id="eventCodeText">Код: <strong id="eventCode" data-code>—</strong></span>
-            <button class="btn btn--ghost btn--sm" id="copyInviteBtn">Скопировать приглашение</button>
+            <button class="btn btn--ghost btn--sm" id="copyInviteBtn" data-owner-only>Скопировать приглашение</button>
             <a id="analyticsLink" class="btn btn--ghost btn--sm" href="#" hidden>Аналитика события</a>
           </div>
           <p id="codeExpire" class="hint"></p>
@@ -359,7 +359,7 @@
           <h2 id="final-title">Событие</h2>
           <div class="final-code">
             <span>Код: <b id="final-code">—</b></span>
-            <button id="btn-copy-invite" class="btn btn-chip">Скопировать приглашение</button>
+            <button id="btn-copy-invite" class="btn btn-chip" data-owner-only>Скопировать приглашение</button>
           </div>
         </div>
 

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -32,7 +32,7 @@
     <section id="lobby-right" class="lobby-right card">
       <h2 data-title>Событие</h2>
       <div class="event-grid">
-        <div class="codeRow"><span id="eventCodeText">Код: <strong id="eventCode" data-code>—</strong></span> <button id="copyInviteBtn" class="btn btn--ghost btn--sm">Скопировать приглашение</button></div>
+        <div class="codeRow"><span id="eventCodeText">Код: <strong id="eventCode" data-code>—</strong></span> <button id="copyInviteBtn" class="btn btn--ghost btn--sm" data-owner-only>Скопировать приглашение</button></div>
         <div><strong>Когда:</strong> <span data-when></span></div>
         <div><strong>Адрес:</strong> <span data-address>—</span></div>
         <div><strong>Дресс-код:</strong> <span data-dress>—</span></div>

--- a/netlify/functions/event-create.js
+++ b/netlify/functions/event-create.js
@@ -1,6 +1,7 @@
 // netlify/functions/event-create.js
 import { supabaseAdmin } from './_lib/supabase.js';
 import { generateJoinCode } from './_utils.js';
+import jwt from 'jsonwebtoken';
 
 const json = (s, b) => ({
   statusCode: s,
@@ -54,7 +55,14 @@ export async function handler(event) {
       (typeof generateJoinCode === 'function' && generateJoinCode()) ||
       String(Math.floor(100000 + Math.random() * 900000));
     payload.code = code;
-    payload.join_code = code;
+      payload.join_code = code;
+        const auth = event.headers.authorization || event.headers.Authorization || '';
+    const token = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+
+    let hostUserId = null;
+    if (token && process.env.JWT_SECRET) {
+      try { hostUserId = Number(jwt.verify(token, process.env.JWT_SECRET).sub) || null; } catch {}
+    }
 
     // на всякий случай выкидываем лишние ключи
     const insertable = {
@@ -67,6 +75,7 @@ export async function handler(event) {
       comment: payload.comment,
       code: payload.code,
       join_code: payload.join_code,
+        host_user_id: hostUserId,
     };
 
     const { data, error } = await supa

--- a/netlify/functions/event-one.js
+++ b/netlify/functions/event-one.js
@@ -1,36 +1,67 @@
+import jwt from 'jsonwebtoken';
 import { supabaseAdmin } from './_lib/supabase.js';
 
-const json = (status, body) => ({
-  statusCode: status,
+const json = (s, b) => ({
+  statusCode: s,
   headers: { 'content-type': 'application/json' },
-  body: JSON.stringify(body),
+  body: JSON.stringify(b),
 });
 
 export async function handler(event) {
   try {
-    const qs = event.queryStringParameters || {};
-    const id = qs.id ? Number(qs.id) : null;
-    const code = qs.code ? String(qs.code).trim() : null;
-    if (!id && !code) return json(400, { success: false, error: 'id or code is required' });
+    const params = event.queryStringParameters || {};
+    const id = params.id ? Number(params.id) : null;
+    const code = params.code ? String(params.code) : null;
+    if (!id && !code) return json(400, { success: false, error: 'Provide id or code' });
 
+    // запрашиваем событие
     const supa = supabaseAdmin();
-    let query = supa
+    let q = supa
       .from('events')
-      .select(`
-        id, code, join_code, title, date, time,
-        address, dress_code, what_to_bring, comment,
-        wishlist:wishlist_items ( id, title, url, claimed_by )
-      `);
+      .select('id, code, join_code, title, date, time, address, dress_code, what_to_bring, comment, host_user_id, wishlist_items(*)')
+      .limit(1);
 
-    if (id)  query = query.eq('id', id);
-    if (code) query = query.eq('code', code);
+    if (id) q = q.eq('id', id); else q = q.eq('code', code);
 
-    const { data, error } = await query.single();
-    if (error || !data) return json(404, { success: false, error: 'Not found' });
+    const { data, error } = await q.single();
+    if (error) throw error;
 
-    return json(200, { success: true, event: data });
+    // кто запрашивает?
+    const auth = event.headers.authorization || event.headers.Authorization || '';
+    const token = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+
+    let requesterId = null;
+    if (token && process.env.JWT_SECRET) {
+      try { requesterId = Number(jwt.verify(token, process.env.JWT_SECRET).sub) || null; } catch {}
+    }
+
+    const isOwner = data.host_user_id && requesterId && Number(data.host_user_id) === requesterId;
+
+    // если не владелец — удаляем чувствительные поля
+    if (!isOwner) {
+      delete data.code;
+      delete data.join_code;
+    }
+
+    return json(200, {
+      success: true,
+      event: {
+        id: data.id,
+        code: data.code,
+        join_code: data.join_code,
+        title: data.title,
+        date: data.date,
+        time: data.time,
+        address: data.address,
+        dress_code: data.dress_code,
+        what_to_bring: data.what_to_bring,
+        comment: data.comment,
+        host_user_id: data.host_user_id,
+        wishlist: data.wishlist || data.wishlist_items || [],
+      },
+    });
   } catch (e) {
     console.error('event-one error', e);
-    return json(500, { success: false, error: String(e.message || e) });
+    return json(500, { success: false, error: e.message || String(e) });
   }
 }


### PR DESCRIPTION
## Summary
- hide sensitive join codes when requester isn't the event owner
- set `host_user_id` from JWT on event creation
- show copy-invite button only to event owner on frontend

## Testing
- `npm test`
- `git push` *(fails: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_68aa256baf588332b9bb0fca1fbf4920