### PR TITLE
feat: add floating message clouds and settings redirect

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -2885,3 +2885,68 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 if (!document.body.dataset.screen) show('menu');
+
+// === FroggyHub: render soft message-clouds background ===
+(function () {
+  const MESSAGES = [
+    "давайте сегодня тусовку?",
+    "в FroggyHub удобнее, чем создавать группы)",
+    "а я знаю что я возьму на день рождение другу)",
+    "приходи к 19:00 ✨",
+    "беру настолки!",
+  ];
+
+  function rand(min, max) { return Math.random() * (max - min) + min; }
+
+  function renderMessageClouds() {
+    const host = document.getElementById("fh-message-clouds");
+    if (!host) return;
+
+    const count = Math.min(12, Math.max(6, Math.round(window.innerWidth / 150)));
+    host.innerHTML = "";
+
+    for (let i = 0; i < count; i++) {
+      const cloud = document.createElement("div");
+      cloud.className = "fh-cloud";
+      cloud.textContent = MESSAGES[i % MESSAGES.length];
+
+      const top = rand(8, 78);     // проценты
+      const left = rand(6, 82);
+      const rot = rand(-10, 10);   // градусов
+      const op = rand(0.12, 0.22); // мягкая прозрачность
+
+      cloud.style.top = top + "%";
+      cloud.style.left = left + "%";
+      cloud.style.transform = `rotate(${rot}deg)`;
+      cloud.style.opacity = String(op);
+
+      host.appendChild(cloud);
+    }
+  }
+
+  // первичный рендер и легкий дебаунс на ресайз
+  let t;
+  function schedule() { clearTimeout(t); t = setTimeout(renderMessageClouds, 120); }
+  document.addEventListener("DOMContentLoaded", renderMessageClouds);
+  window.addEventListener("resize", schedule);
+})();
+
+// === Fix: make "Настройки" button navigate to /settings ===
+(function () {
+  function goToSettings() { window.location.href = "/settings"; }
+
+  document.addEventListener("click", function (e) {
+    const t = e.target;
+    if (!(t instanceof Element)) return;
+    const el = t.closest("#settingsBtn, [data-role='settings']");
+    if (el) { e.preventDefault?.(); goToSettings(); }
+  });
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const btn = document.getElementById("settingsBtn") || document.querySelector("[data-role='settings']");
+    if (btn) {
+      btn.addEventListener("click", function (e) { e.preventDefault?.(); goToSettings(); });
+      if (!(btn instanceof HTMLAnchorElement)) btn.style.cursor = "pointer";
+    }
+  });
+})();

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -8,8 +8,37 @@
   <link rel="stylesheet" href="style.css">
   <link rel="icon"
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
+  <style>
+    /* Message clouds background */
+    #fh-message-clouds {
+      position: fixed; inset: 0;
+      z-index: 0;             /* ниже основного контента */
+      pointer-events: none;   /* не перехватываем клики */
+      overflow: hidden;
+    }
+    .fh-cloud {
+      position: absolute;
+      max-width: 44ch;
+      padding: 10px 14px;
+      border-radius: 16px;
+      background: rgba(255,255,255,0.08);
+      backdrop-filter: saturate(150%) blur(6px);
+      -webkit-backdrop-filter: saturate(150%) blur(6px);
+      border: 1px solid rgba(255,255,255,0.12);
+      color: rgba(255,255,255,0.85);
+      font-size: 14px;
+      line-height: 1.3;
+      box-shadow: 0 8px 20px rgba(0,0,0,0.25);
+      transform-origin: center;
+    }
+    /* на маленьких экранах делаем меньше, чтобы не мешало */
+    @media (max-width: 640px) {
+      .fh-cloud { font-size: 12px; max-width: 32ch; }
+    }
+  </style>
 </head>
 <body class="scene-intro">
+  <div id="fh-message-clouds" aria-hidden="true"></div>
   <!-- Шапка -->
   <nav class="topbar">
     <div class="topbar-left">
@@ -18,7 +47,7 @@
     <div class="topbar-right">
       <button id="nav-menu" class="btn btn-sm btn-ghost" data-go="menu" hidden>Меню</button>
       <button id="nav-profile" class="btn btn-sm btn-ghost" data-go="profile">Профиль</button>
-      <button id="nav-settings" class="btn btn-sm btn-ghost" data-go="settings">Настройки</button>
+      <button id="nav-settings" class="btn btn-sm btn-ghost" data-go="settings" data-role="settings">Настройки</button>
     </div>
   </nav>
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->


### PR DESCRIPTION
## Summary
- add decorative message cloud background to homepage
- ensure "Настройки" button navigates to /settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9a84f9508332ac32e1fa8064a565