### PR TITLE
feat: add floating message clouds and smooth settings link

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -2950,3 +2950,95 @@ if (!document.body.dataset.screen) show('menu');
     }
   });
 })();
+
+// === FroggyHub: render many floating message-clouds ===
+(function () {
+  const MESSAGES = [
+    "давайте сегодня тусовку?",
+    "в FroggyHub удобнее, чем создавать группы)",
+    "а я знаю что я возьму на день рождение другу)",
+    "приходи к 19:00 ✨",
+    "беру настолки!",
+    "кто возьмёт колу?",
+    "добавил плейлист 🎶",
+    "буду с +1 😉",
+    "кто захватит настолки?",
+    "хочу пиццу 🍕",
+    "друзья, до встречи 🐸",
+    "спойлер: будет торт 🎂",
+  ];
+
+  function rand(min, max) { return Math.random() * (max - min) + min; }
+
+  function renderMessageClouds() {
+    const host = document.getElementById("fh-message-clouds");
+    if (!host) return;
+
+    // Больше облачков: 18..36 (зависит от ширины)
+    const count = Math.min(36, Math.max(18, Math.round(window.innerWidth / 60)));
+    host.innerHTML = "";
+
+    for (let i = 0; i < count; i++) {
+      const cloud = document.createElement("div");
+      cloud.className = "fh-cloud";
+      cloud.textContent = MESSAGES[i % MESSAGES.length];
+
+      const top = rand(5, 90);
+      const left = rand(5, 90);
+      const rot = rand(-15, 15);
+      const op = rand(0.15, 0.28);
+      const dur = rand(5, 9);   // длительность анимации
+      const delay = rand(-dur, 0);
+
+      cloud.style.top = top + "%";
+      cloud.style.left = left + "%";
+      cloud.style.opacity = String(op);
+      cloud.style.setProperty("--rot", rot + "deg");
+      cloud.style.animationDuration = dur + "s";
+      cloud.style.animationDelay = delay + "s";
+
+      host.appendChild(cloud);
+    }
+  }
+
+  let t;
+  function schedule() { clearTimeout(t); t = setTimeout(renderMessageClouds, 120); }
+  document.addEventListener("DOMContentLoaded", renderMessageClouds);
+  window.addEventListener("resize", schedule);
+})();
+
+// === Fix: make "Настройки" navigate smoothly (no full reload) ===
+(function () {
+  function goToSettings() {
+    // Мягкая SPA-навигация: меняем URL без перезагрузки.
+    history.pushState({}, "", "/settings");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+
+  // Делегированный обработчик — работает для любых кнопок/иконок
+  document.addEventListener("click", function (e) {
+    const t = e.target;
+    if (!(t instanceof Element)) return;
+    const el = t.closest("#settingsBtn, [data-role='settings']");
+    if (el) {
+      e.preventDefault?.();
+      goToSettings();
+    }
+  });
+
+  // Прямое навешивание, если элемент уже есть в DOM
+  document.addEventListener("DOMContentLoaded", function () {
+    const btn =
+      document.getElementById("settingsBtn") ||
+      document.querySelector("[data-role='settings']");
+    if (btn) {
+      btn.addEventListener("click", function (e) {
+        e.preventDefault?.();
+        goToSettings();
+      });
+      if (!(btn instanceof HTMLAnchorElement)) {
+        btn.style.cursor = "pointer";
+      }
+    }
+  });
+})();

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -36,6 +36,41 @@
       .fh-cloud { font-size: 12px; max-width: 32ch; }
     }
   </style>
+  <style>
+    /* Message clouds background */
+    #fh-message-clouds {
+      position: fixed; inset: 0;
+      z-index: 0;             /* ниже основного контента */
+      pointer-events: none;   /* не перехватываем клики */
+      overflow: hidden;
+    }
+    .fh-cloud {
+      position: absolute;
+      max-width: 44ch;
+      padding: 10px 14px;
+      border-radius: 16px;
+      background: rgba(255,255,255,0.08);
+      backdrop-filter: saturate(150%) blur(6px);
+      -webkit-backdrop-filter: saturate(150%) blur(6px);
+      border: 1px solid rgba(255,255,255,0.12);
+      color: rgba(255,255,255,0.85);
+      font-size: 14px;
+      line-height: 1.3;
+      box-shadow: 0 8px 20px rgba(0,0,0,0.25);
+      transform-origin: center;
+      animation: floaty 6s ease-in-out infinite;
+    }
+
+    @keyframes floaty {
+      0%   { transform: translateY(0) rotate(var(--rot, 0deg)); }
+      50%  { transform: translateY(-6px) rotate(calc(var(--rot, 0deg) * 1.1)); }
+      100% { transform: translateY(0) rotate(var(--rot, 0deg)); }
+    }
+
+    @media (max-width: 640px) {
+      .fh-cloud { font-size: 12px; max-width: 32ch; }
+    }
+  </style>
 </head>
 <body class="scene-intro">
   <div id="fh-message-clouds" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- add float animation styles for message clouds
- render numerous floating message clouds
- navigate to settings via SPA-style URL update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa9e11335c8332b759b929488acc1f