### PR TITLE
feat: add glass background and CTA layout

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -71,9 +71,24 @@
       .fh-cloud { font-size: 12px; max-width: 32ch; }
     }
   </style>
+  <style>
+    .fh-bg {
+      position: fixed; inset: 0; z-index: 0;
+      background: #0b241b url("/assets/froggy_glass_bg.jpeg") center 45% / cover no-repeat;
+    }
+    @media (min-width: 640px) {
+      .fh-bg { background-position: center; }
+    }
+    .fh-bg::after { content:""; position:absolute; inset:0; background: rgba(11,36,27,.55); }
+    #fh-message-clouds { position: fixed; inset: 0; z-index: 0; pointer-events:none; }
+    .fh-content { position: relative; z-index: 20; min-height: 100svh; padding-inline: 1rem; }
+    #fh-cta { position: relative; z-index: 30; }
+  </style>
 </head>
 <body class="scene-intro">
+  <div class="fh-bg" aria-hidden="true"></div>
   <div id="fh-message-clouds" aria-hidden="true"></div>
+  <div class="fh-content">
   <!-- Шапка -->
   <nav class="topbar">
     <div class="topbar-left">
@@ -548,5 +563,6 @@
       <button id="cookie-accept" class="btn btn-primary btn-sm">Принять</button>
     </div>
   </div>
+</div>
 </body>
 </html>

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -7,8 +7,24 @@
   <link rel="stylesheet" href="/style.css" />
   <link rel="icon"
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
+  <style>
+    .fh-bg {
+      position: fixed; inset: 0; z-index: 0;
+      background: #0b241b url("/assets/froggy_glass_bg.jpeg") center 45% / cover no-repeat;
+    }
+    @media (min-width: 640px) {
+      .fh-bg { background-position: center; }
+    }
+    .fh-bg::after { content:""; position:absolute; inset:0; background: rgba(11,36,27,.55); }
+    #fh-message-clouds { position: fixed; inset: 0; z-index: 0; pointer-events:none; }
+    .fh-content { position: relative; z-index: 20; min-height: 100svh; padding-inline: 1rem; }
+    #fh-cta { position: relative; z-index: 30; }
+  </style>
 </head>
 <body data-page="lobby">
+  <div class="fh-bg" aria-hidden="true"></div>
+  <div id="fh-message-clouds" aria-hidden="true"></div>
+  <div class="fh-content">
     <header class="fh-header">
       <a class="fh-logo" href="/">FroggyHub</a>
       <nav class="topbar">
@@ -78,5 +94,6 @@
       <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
     </div>
   </div>
+</div>
 </body>
 </html>

--- a/app/final/page.tsx
+++ b/app/final/page.tsx
@@ -1,0 +1,10 @@
+export default function FinalPage() {
+  return (
+    <main className="relative min-h-[100svh] flex items-center justify-center px-4">
+      <div className="relative z-30 text-center">
+        <h1 className="text-3xl sm:text-4xl font-semibold">Готово! 🎉</h1>
+        <p className="text-white/80 mt-2">Увидимся на событии 👋</p>
+      </div>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,18 @@
+import "./globals.css";
+import type { Metadata } from "next";
+import GlassLogoBackground from "@/components/GlassLogoBackground";
+
+export const metadata: Metadata = { title: "FroggyHub — события и вишлисты" };
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ru">
+      {/* предотвращаем «дрожание» при появлении скролла */}
+      <body className="min-h-screen text-white overflow-x-hidden">
+        <GlassLogoBackground />
+        {/* весь контент поверх фона */}
+        <div className="relative z-20 min-h-screen">{children}</div>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,52 @@
 import Link from "next/link";
-import FrogWithStump from "@/components/FrogWithStump";
 import MessageCloudsBackground from "@/components/MessageCloudsBackground";
 
 export default function HomePage() {
   return (
-    <main className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden bg-[#0b241b]">
-      <MessageCloudsBackground />
-      <div className="relative z-10 flex flex-col items-center">
-        <FrogWithStump frogWidth={680} />
-        <Link href="/settings" className="mt-8 rounded bg-green-600 px-6 py-3 text-white hover:bg-green-500">
-          Настройки
-        </Link>
+    <main className="relative min-h-[100svh] flex flex-col items-center justify-center overflow-hidden px-4">
+      {/* облачка ниже контента */}
+      <div className="pointer-events-none fixed inset-0 -z-10">
+        <MessageCloudsBackground />
+      </div>
+
+      <div className="relative z-30 flex flex-col items-center gap-6 text-center">
+        <h1 className="text-4xl sm:text-5xl font-semibold">FroggyHub</h1>
+
+        {/* CTA-панель */}
+        <div
+          id="fh-cta"
+          className="flex w-full max-w-3xl flex-col sm:flex-row items-stretch sm:items-center gap-3 bg-black/20 backdrop-blur-sm rounded-xl p-3"
+        >
+          <Link
+            href="/create"
+            className="rounded bg-green-600 px-4 py-2 text-white hover:bg-green-500 text-center"
+          >
+            Создать событие
+          </Link>
+
+          <input
+            id="joinCodeInput"
+            className="flex-1 rounded bg-white/10 px-3 py-2 text-white placeholder:text-white/40 outline-none"
+            placeholder="Введите 6-значный код"
+            maxLength={6}
+            inputMode="numeric"
+            pattern="[0-9]*"
+          />
+
+          <button
+            id="joinBtn"
+            className="rounded bg-white/10 px-4 py-2 text-white hover:bg-white/20"
+            onClick={() => {
+              const el = document.getElementById("joinCodeInput") as HTMLInputElement | null;
+              const code = (el?.value || "").trim();
+              if (/^\d{6}$/.test(code)) window.location.href = `/join?code=${code}`;
+              else el?.focus();
+            }}
+          >
+            Присоединиться
+          </button>
+        </div>
       </div>
     </main>
   );
 }
-

--- a/components/GlassLogoBackground.tsx
+++ b/components/GlassLogoBackground.tsx
@@ -1,0 +1,26 @@
+"use client";
+import Image from "next/image";
+import { usePathname } from "next/navigation";
+
+export default function GlassLogoBackground() {
+  const pathname = usePathname();
+  const isHero = pathname === "/" || pathname === "/final";
+
+  return (
+    <div aria-hidden className="fixed inset-0 -z-10 overflow-hidden">
+      <Image
+        src="/assets/froggy_glass_bg.jpeg"
+        alt=""
+        fill
+        priority
+        // На десктопе — cover; на мобилках — слегка отцентрован вверх, чтобы не обрезать «Froggy»
+        className={`object-cover transition-all will-change-transform ${
+          isHero ? "blur-0 scale-100" : "blur-[6px] scale-[1.03] opacity-90"
+        } bg-[#0b241b] [object-position:center_45%] sm:[object-position:center]`}
+        sizes="100vw"
+      />
+      {/* мягкое затемнение, чтобы CTA и текст читались */}
+      <div className="absolute inset-0 bg-[#0b241b]/55" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable glass logo background component
- overlay pages with frosted background and hero CTA
- update static lobby and index pages with full-screen glass background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaa4779af08332b97ea3e942eb403c