### PR TITLE
feat: center hero section and balance message clouds

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply antialiased;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,8 +7,11 @@ export const metadata: Metadata = { title: "FroggyHub — события и ви
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ru">
+      <head>
+        <link rel="preload" href="/assets/frog_idle.png" as="image" />
+      </head>
       {/* предотвращаем «дрожание» при появлении скролла */}
-      <body className="min-h-screen text-white overflow-x-hidden">
+      <body className="min-h-screen text-white overflow-hidden">
         <GlassLogoBackground />
         {/* весь контент поверх фона */}
         <div className="relative z-20 min-h-screen">{children}</div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,17 @@
 import Link from "next/link";
+import FrogWithStump from "@/components/FrogWithStump";
 import MessageCloudsBackground from "@/components/MessageCloudsBackground";
 
 export default function HomePage() {
   return (
-    <main className="relative min-h-[100svh] flex flex-col items-center justify-center overflow-hidden px-4">
+    <main className="relative min-h-[100svh] flex items-center justify-center overflow-hidden px-4">
       {/* облачка ниже контента */}
       <div className="pointer-events-none fixed inset-0 -z-10">
         <MessageCloudsBackground />
       </div>
 
-      <div className="relative z-30 flex flex-col items-center gap-6 text-center">
+      <div className="relative z-20 flex flex-col items-center gap-6 text-center">
+        <FrogWithStump />
         <h1 className="text-4xl sm:text-5xl font-semibold">FroggyHub</h1>
 
         {/* CTA-панель */}

--- a/components/FrogWithStump.tsx
+++ b/components/FrogWithStump.tsx
@@ -8,14 +8,32 @@ export default function FrogWithStump({ frogWidth = 680 }: Props) {
   const stumpWidth = Math.round(frogWidth * 0.43);
   const stumpHeight = Math.round(frogHeight * 0.20);
 
-  return (
-    <div className="relative mx-auto" style={{ width: frogWidth, height: frogHeight }}>
-      <div className="absolute left-1/2 -translate-x-1/2"
-           style={{ bottom: Math.round(frogHeight * 0.06), width: stumpWidth, height: stumpHeight }}>
-        <Image src="/assets/stump.png" alt="\u041f\u0435\u043d\u044c" fill className="object-contain" sizes={`${stumpWidth}px`} />
+    return (
+      <div className="relative mx-auto" style={{ width: frogWidth, height: frogHeight }}>
+        <div
+          className="absolute left-1/2 -translate-x-1/2"
+          style={{ bottom: Math.round(frogHeight * 0.06), width: stumpWidth, height: stumpHeight }}
+        >
+          <Image
+            src="/assets/stump.png"
+            alt="\u041f\u0435\u043d\u044c"
+            fill
+            loading="eager"
+            priority
+            className="object-contain"
+            sizes={`${stumpWidth}px`}
+          />
+        </div>
+        <Image
+          src="/assets/frog_idle.png"
+          alt="\u041b\u044f\u0433\u0443\u0448\u043a\u0430"
+          fill
+          loading="eager"
+          priority
+          className="object-contain drop-shadow-[0_12px_40px_rgba(0,0,0,0.45)]"
+          sizes={`${frogWidth}px`}
+        />
       </div>
-      <Image src="/assets/frog_idle.png" alt="\u041b\u044f\u0433\u0443\u0448\u043a\u0430" fill className="object-contain drop-shadow-[0_12px_40px_rgba(0,0,0,0.45)]" sizes={`${frogWidth}px`} />
-    </div>
-  );
+    );
 }
 

--- a/components/GlassLogoBackground.tsx
+++ b/components/GlassLogoBackground.tsx
@@ -6,8 +6,8 @@ export default function GlassLogoBackground() {
   const pathname = usePathname();
   const isHero = pathname === "/" || pathname === "/final";
 
-  return (
-    <div aria-hidden className="fixed inset-0 -z-10 overflow-hidden">
+    return (
+      <div aria-hidden className="pointer-events-none fixed inset-0 -z-20 overflow-hidden">
       <Image
         src="/assets/froggy_glass_bg.jpeg"
         alt=""

--- a/components/MessageCloudsBackground.tsx
+++ b/components/MessageCloudsBackground.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useEffect, useRef, useState } from "react";
 
 const MESSAGES = [
   "давайте сегодня тусовку?",
@@ -8,20 +9,108 @@ const MESSAGES = [
   "беру настолки!",
 ];
 
+const PADDING = 48;
+const MIN_GAP = 16;
+const AMP_X = 12;
+const AMP_Y = 14;
+const ITERATIONS = 200;
+const RESIZE_DEBOUNCE = 250;
+
+interface LayoutState {
+  baseX: number;
+  baseY: number;
+  phase: number;
+}
+
 export default function MessageCloudsBackground() {
-  const spots = [
-    { top: "12%", left: "8%", r: -8 }, { top: "20%", left: "72%", r: 7 },
-    { top: "36%", left: "18%", r: 4 },  { top: "44%", left: "60%", r: -6 },
-    { top: "62%", left: "10%", r: 8 },  { top: "68%", left: "70%", r: -10 },
-  ];
+  const refs = useRef<HTMLDivElement[]>([]);
+  const [layout, setLayout] = useState<LayoutState[]>([]);
+
+  useEffect(() => {
+    let resizeTimeout: NodeJS.Timeout;
+
+    function computeLayout() {
+      const els = refs.current;
+      if (!els.length) return;
+
+      const sizes = els.map((el) => {
+        const rect = el.getBoundingClientRect();
+        return { w: rect.width, h: rect.height };
+      });
+
+      const bounds = {
+        left: PADDING,
+        top: PADDING,
+        width: window.innerWidth - PADDING * 2,
+        height: window.innerHeight - PADDING * 2,
+      };
+
+      let positions = initialRandomPositions(sizes, bounds);
+      positions = resolveOverlaps(positions, sizes, bounds);
+
+      const state = positions.map((p) => ({
+        baseX: p.x,
+        baseY: p.y,
+        phase: Math.random() * Math.PI * 2,
+      }));
+      setLayout(state);
+    }
+
+    const onResize = () => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(computeLayout, RESIZE_DEBOUNCE);
+    };
+
+    computeLayout();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  useEffect(() => {
+    if (!layout.length) return;
+    const els = refs.current;
+    const start = performance.now();
+    const bounds = {
+      left: PADDING,
+      top: PADDING,
+      right: window.innerWidth - PADDING,
+      bottom: window.innerHeight - PADDING,
+    };
+    let frame: number;
+
+    function animate(now: number) {
+      const t = (now - start) / 1000;
+      for (let i = 0; i < layout.length; i++) {
+        const s = layout[i];
+        const el = els[i];
+        const dx = Math.sin(t + s.phase) * AMP_X;
+        const dy = Math.sin((t + s.phase * 1.37)) * AMP_Y;
+        let x = s.baseX + dx;
+        let y = s.baseY + dy;
+        x = clamp(x, bounds.left, bounds.right - el.offsetWidth);
+        y = clamp(y, bounds.top, bounds.bottom - el.offsetHeight);
+        el.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+      }
+      frame = requestAnimationFrame(animate);
+    }
+
+    frame = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(frame);
+  }, [layout]);
 
   return (
-    <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden z-0">
-      {spots.map((s, i) => (
-        <div key={i} className="absolute"
-             style={{ top: s.top, left: s.left, transform:`rotate(${s.r}deg)`, opacity:0.18 }}>
+    <div aria-hidden className="pointer-events-none fixed inset-0 -z-10">
+      {MESSAGES.map((m, i) => (
+        <div
+          key={i}
+          ref={(el) => {
+            if (el) refs.current[i] = el;
+          }}
+          className="absolute will-change-transform opacity-20"
+          style={{ transform: "translate3d(-9999px,-9999px,0)" }}
+        >
           <div className="rounded-2xl bg-white/8 backdrop-blur-sm ring-1 ring-white/10 px-4 py-2 text-sm text-white/80 shadow">
-            {MESSAGES[i % MESSAGES.length]}
+            {m}
           </div>
         </div>
       ))}
@@ -29,3 +118,71 @@ export default function MessageCloudsBackground() {
   );
 }
 
+interface Size { w: number; h: number; }
+interface Position { x: number; y: number; }
+
+function initialRandomPositions(sizes: Size[], bounds: { left: number; top: number; width: number; height: number }): Position[] {
+  return sizes.map((s) => ({
+    x: bounds.left + Math.random() * (bounds.width - s.w),
+    y: bounds.top + Math.random() * (bounds.height - s.h),
+  }));
+}
+
+function resolveOverlaps(positions: Position[], sizes: Size[], bounds: { left: number; top: number; width: number; height: number }): Position[] {
+  const grid = createGridTargets(sizes, bounds);
+  for (let iter = 0; iter < ITERATIONS; iter++) {
+    for (let i = 0; i < positions.length; i++) {
+      for (let j = i + 1; j < positions.length; j++) {
+        const a = { ...positions[i], w: sizes[i].w, h: sizes[i].h };
+        const b = { ...positions[j], w: sizes[j].w, h: sizes[j].h };
+        const ax = a.x + a.w / 2;
+        const ay = a.y + a.h / 2;
+        const bx = b.x + b.w / 2;
+        const by = b.y + b.h / 2;
+        const dx = ax - bx;
+        const dy = ay - by;
+        const overlapX = (a.w + b.w) / 2 + MIN_GAP - Math.abs(dx);
+        const overlapY = (a.h + b.h) / 2 + MIN_GAP - Math.abs(dy);
+        if (overlapX > 0 && overlapY > 0) {
+          const overlap = Math.min(overlapX, overlapY) / 2;
+          const angle = Math.atan2(dy, dx);
+          const ox = Math.cos(angle) * overlap;
+          const oy = Math.sin(angle) * overlap;
+          positions[i].x += ox;
+          positions[i].y += oy;
+          positions[j].x -= ox;
+          positions[j].y -= oy;
+        }
+      }
+    }
+    for (let i = 0; i < positions.length; i++) {
+      positions[i].x += (grid[i].x - positions[i].x) * 0.05;
+      positions[i].y += (grid[i].y - positions[i].y) * 0.05;
+      positions[i].x = clamp(positions[i].x, bounds.left, bounds.left + bounds.width - sizes[i].w);
+      positions[i].y = clamp(positions[i].y, bounds.top, bounds.top + bounds.height - sizes[i].h);
+    }
+  }
+  return positions;
+}
+
+function createGridTargets(sizes: Size[], bounds: { left: number; top: number; width: number; height: number }): Position[] {
+  const n = sizes.length;
+  const cols = Math.ceil(Math.sqrt(n));
+  const rows = Math.ceil(n / cols);
+  const cellW = bounds.width / cols;
+  const cellH = bounds.height / rows;
+  const targets: Position[] = [];
+  for (let i = 0; i < n; i++) {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    targets.push({
+      x: bounds.left + col * cellW + cellW / 2 - sizes[i].w / 2,
+      y: bounds.top + row * cellH + cellH / 2 - sizes[i].h / 2,
+    });
+  }
+  return targets;
+}
+
+function clamp(v: number, min: number, max: number) {
+  return Math.min(Math.max(v, min), max);
+}


### PR DESCRIPTION
## Summary
- center hero content and preload frog image for immediate display
- push background layers behind hero and add eager frog image loading
- rewrite floating message background with collision-free relaxed layout and gentle animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8cd6e345483328149af4730000928