### PR TITLE
feat: bootstrap home screen and animate bubbles

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -3057,3 +3057,219 @@ if (!document.body.dataset.screen) show('home');
     }
   });
 })();
+/* ---------- FroggyHub bootstrap + bubbles layout/animation ---------- */
+(function () {
+  const $  = (sel, root = document) => root.querySelector(sel);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+  const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+  const now = () => performance.now();
+
+  const _selectScreen =
+    window.selectScreen ||
+    function selectScreen(name) {
+      const targetId = `#screen-${name}`;
+      $$(".fh-screen").forEach((el) => (el.style.display = "none"));
+      const tgt = $(targetId);
+      if (tgt) tgt.style.display = "";
+      if (location.hash !== `#${name}`) {
+        history.replaceState(null, "", `#${name}`);
+      }
+    };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const hashName = (location.hash || "").replace(/^#/, "");
+    if (!hashName) {
+      _selectScreen("home");
+    } else {
+      const hasScreen = !!document.getElementById(`screen-${hashName}`);
+      _selectScreen(hasScreen ? hashName : "home");
+    }
+
+    const bind = (sel, handler) => {
+      const el = $(sel);
+      if (el) el.addEventListener("click", handler, { passive: true });
+    };
+
+    bind('[data-action="open-menu"]', () => _selectScreen("home"));
+    bind('[data-action="create-event"]', () => _selectScreen("auth"));
+    bind('[data-action="join-event"]', () => _selectScreen("auth"));
+    bind('[data-action="login"]', () => _selectScreen("auth"));
+    bind('[data-action="signup"]', () => _selectScreen("auth"));
+    bind('[data-action="logout"]', () => {
+      try { window.localStorage.removeItem("fh_token"); } catch {}
+      _selectScreen("home");
+    });
+
+    initFloatingBubbles();
+  });
+
+  function initFloatingBubbles() {
+    const root =
+      document.getElementById("fh-clouds") ||
+      document.querySelector(".fh-clouds") ||
+      null;
+    if (!root) return;
+
+    const bubbles =
+      $$(".fh-cloud", root) || $$(".msg-cloud", root);
+    if (!bubbles.length) return;
+
+    const avoidRects = [];
+    const frog = document.getElementById("fh-frog");
+    const cta = document.getElementById("fh-cta");
+    if (frog) avoidRects.push(frog.getBoundingClientRect());
+    if (cta) avoidRects.push(cta.getBoundingClientRect());
+
+    root.style.position = "absolute";
+    root.style.inset = "0";
+    root.style.pointerEvents = "none";
+
+    const state = bubbles.map((el) => ({
+      el, x: 0, y: 0, w: 0, h: 0, vx: 0, vy: 0,
+    }));
+
+    function layout() {
+      const rect = root.getBoundingClientRect();
+      const W = rect.width;
+      const H = rect.height;
+
+      const cell = Math.max(200, Math.min(260, Math.floor(W / 6)));
+      const cols = Math.max(3, Math.floor(W / cell));
+      const rows = Math.max(3, Math.floor(H / cell));
+      const cellW = W / cols;
+      const cellH = H / rows;
+
+      const placed = [];
+
+      state.forEach((s, i) => {
+        const el = s.el;
+        el.style.position = "absolute";
+        el.style.willChange = "transform";
+        el.style.transform = "translate3d(-10000px,-10000px,0)";
+      });
+
+      requestAnimationFrame(() => {
+        state.forEach((s) => {
+          const r = s.el.getBoundingClientRect();
+          s.w = r.width; s.h = r.height;
+        });
+
+        const margin = 16;
+        let idx = 0;
+
+        for (let r = 0; r < rows && idx < state.length; r++) {
+          for (let c = 0; c < cols && idx < state.length; c++) {
+            const s = state[idx];
+            const baseX = c * cellW;
+            const baseY = r * cellH;
+            const jitterX = (Math.random() * 0.5 + 0.25) * (cellW - s.w);
+            const jitterY = (Math.random() * 0.5 + 0.25) * (cellH - s.h);
+
+            let x = clamp(baseX + jitterX, margin, W - s.w - margin);
+            let y = clamp(baseY + jitterY, margin, H - s.h - margin);
+
+            const triesMax = 12;
+            let tries = 0;
+            const overlapsAvoid = () =>
+              avoidRects.some((ar) => isOverlapXYWH(x, y, s.w, s.h, ar));
+            const overlapsBubbles = () =>
+              placed.some((p) => isOverlap(s, { x, y, w: s.w, h: s.h }, p));
+
+            while ((overlapsAvoid() || overlapsBubbles()) && tries < triesMax) {
+              x = clamp(x + (Math.random() - 0.5) * 40, margin, W - s.w - margin);
+              y = clamp(y + (Math.random() - 0.5) * 40, margin, H - s.h - margin);
+              tries++;
+            }
+
+            s.x = x; s.y = y;
+            s.vx = (Math.random() - 0.5) * 0.05;
+            s.vy = (Math.random() - 0.5) * 0.05;
+
+            s.el.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+            placed.push({ x, y, w: s.w, h: s.h });
+
+            idx++;
+          }
+        }
+      });
+    }
+
+    function isOverlap(a, pos, b) {
+      return !(
+        pos.x + pos.w <= b.x ||
+        pos.x >= b.x + b.w ||
+        pos.y + pos.h <= b.y ||
+        pos.y >= b.y + b.h
+      );
+    }
+
+    function isOverlapXYWH(x, y, w, h, rect) {
+      const rx = rect.left, ry = rect.top, rw = rect.width, rh = rect.height;
+      return !(x + w <= rx || x >= rx + rw || y + h <= ry || y >= ry + rh);
+    }
+
+    let raf = 0;
+    let last = now();
+    function tick() {
+      const t = now();
+      const dt = (t - last) / 16.7;
+      last = t;
+
+      const rect = root.getBoundingClientRect();
+      const W = rect.width;
+      const H = rect.height;
+      const margin = 12;
+
+      for (let i = 0; i < state.length; i++) {
+        const s = state[i];
+        s.vx += (Math.random() - 0.5) * 0.002;
+        s.vy += (Math.random() - 0.5) * 0.002;
+        s.vx = clamp(s.vx, -0.12, 0.12);
+        s.vy = clamp(s.vy, -0.12, 0.12);
+        s.x += s.vx * dt;
+        s.y += s.vy * dt;
+
+        if (s.x < margin) { s.x = margin; s.vx = Math.abs(s.vx); }
+        else if (s.x + s.w > W - margin) { s.x = W - margin - s.w; s.vx = -Math.abs(s.vx); }
+        if (s.y < margin) { s.y = margin; s.vy = Math.abs(s.vy); }
+        else if (s.y + s.h > H - margin) { s.y = H - margin - s.h; s.vy = -Math.abs(s.vy); }
+
+        for (const ar of avoidRects) {
+          const cx = clamp(s.x + s.w / 2, ar.left, ar.right);
+          const cy = clamp(s.y + s.h / 2, ar.top, ar.bottom);
+          const dx = s.x + s.w / 2 - cx;
+          const dy = s.y + s.h / 2 - cy;
+          const d2 = dx * dx + dy * dy;
+          if (d2 < 40000) {
+            s.vx += (dx / Math.max(80, Math.sqrt(d2))) * 0.06;
+            s.vy += (dy / Math.max(80, Math.sqrt(d2))) * 0.06;
+          }
+        }
+
+        s.el.style.transform = `translate3d(${s.x}px, ${s.y}px, 0)`;
+      }
+
+      raf = requestAnimationFrame(tick);
+    }
+
+    const relayout = debounce(() => {
+      cancelAnimationFrame(raf);
+      layout();
+      last = now();
+      raf = requestAnimationFrame(tick);
+    }, 120);
+    window.addEventListener("resize", relayout, { passive: true });
+    window.addEventListener("orientationchange", relayout, { passive: true });
+
+    layout();
+    raf = requestAnimationFrame(tick);
+  }
+
+  function debounce(fn, ms) {
+    let id = 0;
+    return (...args) => {
+      clearTimeout(id);
+      id = setTimeout(() => fn.apply(null, args), ms);
+    };
+  }
+})();


### PR DESCRIPTION
## Summary
- Automatically select the home screen on initial load and safely bind action buttons
- Add floating message bubbles with jittered-grid layout, drift animation, and collision avoidance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8dc7c7fa4833291f7328647f70f6d