### PR TITLE
Add Supabase singleton and bootstrap enhancements

### DIFF
--- a/FroggyHub/app.js
+++ b/FroggyHub/app.js
@@ -3285,3 +3285,91 @@ if (!document.body.dataset.screen) show('home');
 })();
 
 document.addEventListener('DOMContentLoaded', bootstrap);
+
+// --- FH bootstrap append (do not remove existing code) ---
+(function () {
+  const $ = (sel) => document.querySelector(sel);
+
+  // By default show home; show auth overlay only if no session
+  function showHome() {
+    const el = $('#screen-home');
+    if (el) el.classList.remove('hidden');
+  }
+  function showAuth() {
+    const el = $('#screen-auth');
+    if (el) el.classList.remove('hidden');
+  }
+
+  async function getSessionWithTimeout(ms = 2000) {
+    try {
+      const client = window.getSupabase && window.getSupabase();
+      if (!client) return null;
+      const timeout = new Promise((r) => setTimeout(() => r({ data: { session: null } }), ms));
+      const req = client.auth.getSession();
+      const { data } = await Promise.race([req, timeout]);
+      return data?.session ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function fhBootstrap() {
+    // Always render home immediately
+    showHome();
+
+    // Check session without blocking UI
+    const session = await getSessionWithTimeout();
+    if (!session) {
+      // no session → reveal auth overlay (login/signup buttons)
+      showAuth();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', fhBootstrap);
+  } else {
+    fhBootstrap();
+  }
+})();
+
+// --- FH bubbles placement constraints (append only) ---
+(function () {
+  const SAFE_ZONES = [
+    // center frog approx region (tune if needed)
+    { x: 0.25, y: 0.18, w: 0.5, h: 0.35 },
+    // CTA band near bottom
+    { x: 0.05, y: 0.72, w: 0.90, h: 0.18 },
+  ];
+
+  function rectsOverlap(a, b) {
+    return !(a.x + a.w < b.x || b.x + b.w < a.x || a.y + a.h < b.y || b.y + b.h < a.y);
+  }
+
+  // given viewport size and bubble size, generate non-overlapping jittered grid positions
+  window.__fh_placeBubbles = function placeBubbles(count, vw, vh, bw, bh) {
+    const cells = Math.ceil(Math.sqrt(count));
+    const gx = vw / cells;
+    const gy = vh / cells;
+
+    const avoidRects = SAFE_ZONES.map(z => ({ x: vw*z.x, y: vh*z.y, w: vw*z.w, h: vh*z.h }));
+    const placed = [];
+
+    for (let i = 0; i < count * 3 && placed.length < count; i++) {
+      const cx = Math.floor(Math.random() * cells);
+      const cy = Math.floor(Math.random() * cells);
+      const jitterX = (Math.random() - 0.5) * gx * 0.6;
+      const jitterY = (Math.random() - 0.5) * gy * 0.6;
+
+      const x = Math.max(8, cx * gx + jitterX);
+      const y = Math.max(8, cy * gy + jitterY);
+      const rect = { x, y, w: bw, h: bh };
+
+      // avoid frog/CTA & previously placed
+      if (avoidRects.some(r => rectsOverlap(rect, r))) continue;
+      if (placed.some(r => rectsOverlap(rect, r))) continue;
+
+      placed.push(rect);
+    }
+    return placed; // [{x,y,w,h}]
+  };
+})();

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -524,7 +524,6 @@
     </div>
   </section>
 
-  <script type="module" src="./app.js"></script>
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
   <dialog id="otpModal">
     <form method="dialog" class="grid">
@@ -564,5 +563,8 @@
     </div>
   </div>
 </div>
+<script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
+<script src="/js/api.js"></script>
+<script src="/app.js" defer></script>
 </body>
 </html>

--- a/FroggyHub/js/api.js
+++ b/FroggyHub/js/api.js
@@ -47,3 +47,24 @@ window.logout = logout;
 
 // Для удобства в браузере:
 window.fhApi = { nf, joinEvent, getToken, setToken, clearToken, logout };
+// --- FH Supabase singleton (append only) ---
+(function attachSupabaseSingleton() {
+  const SUPABASE_URL = 'https://smamhlfzerjkdfhtwhdv.supabase.co';
+  const SUPABASE_ANON_KEY = '<PUT_YOUR_ANON_KEY_HERE>'; // keep as is if already set elsewhere
+
+  if (window.supabase && !window.__fh_supabase) {
+    window.__fh_supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        detectSessionInUrl: true,
+        flowType: 'pkce',
+        storageKey: 'fh.auth',
+      },
+    });
+  }
+
+  if (!window.getSupabase) {
+    window.getSupabase = () => window.__fh_supabase;
+  }
+})();

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -819,3 +819,7 @@ button:not([disabled]){ cursor:pointer; }
   .final-wrap{margin:16px auto}
   .final-card{padding:16px}
 }
+
+/* FH visibility defaults (append only) */
+#screen-home { display: block; }
+#screen-auth.hidden { display: none; }


### PR DESCRIPTION
## Summary
- set up Supabase singleton client and expose `getSupabase`
- reorder scripts and bootstrap UI without blocking
- add bubble placement constraints and visibility defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8edcfa83c83329111352b071e23c3