### PR TITLE
fix: load app.js as module entry

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -73,16 +73,6 @@
     </div>
   </div>
   <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
-  <script>
-    window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
-    window.PROXY_SUPABASE_URL = location.origin + '/supabase';
-    window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
-  </script>
-  <script type="module">
-    import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm";
-    window.createSupabaseClient = createClient;
-  </script>
-  <script src="/app.js" defer></script>
-  <script type="module" src="event-analytics.js"></script>
+  <script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -39,16 +39,7 @@
     </form>
     <p id="editError" class="error" role="status" aria-live="polite"></p>
   </main>
-  <script>
-    window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
-    window.PROXY_SUPABASE_URL = location.origin + '/supabase';
-    window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
-  </script>
-  <script type="module">
-    import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm";
-    window.createSupabaseClient = createClient;
-  </script>
-  <script src="/app.js" defer></script>
+  <script type="module" src="js/app.js"></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -34,13 +34,7 @@
       </section>
     </div>
   </main>
-  <script>
-    window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
-    window.PROXY_SUPABASE_URL = location.origin + '/supabase';
-    window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
-  </script>
-  <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
-  <script src="/app.js" defer></script>
+  <script type="module" src="js/app.js"></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -563,8 +563,6 @@
     </div>
   </div>
 </div>
-<script src="https://unpkg.com/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
-<script src="/js/api.js"></script>
-<script src="/app.js" defer></script>
+<script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/js/api.js
+++ b/FroggyHub/js/api.js
@@ -1,8 +1,31 @@
-// Tiny client for Netlify functions + token helpers
-export const TOKEN_KEY = 'fh:token';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
+const SUPABASE_URL = 'https://smamhlfzserjkdfhthwhdv.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4';
+
+export const supa = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+    flowType: 'pkce',
+    storageKey: 'fh.auth',
+  },
+});
+
+export const getSession = () => supa.auth.getSession().then((r) => r.data.session);
+export const onAuthState = (cb) => supa.auth.onAuthStateChange((_evt, session) => cb(session));
+export const signIn = (email, password) => supa.auth.signInWithPassword({ email, password });
+export const signUp = (email, password) => supa.auth.signUp({ email, password });
+export const signOut = () => supa.auth.signOut();
+export async function getProfile() {
+  const { data } = await supa.from('profiles').select('*').single();
+  return data;
+}
+
+export const TOKEN_KEY = 'fh:token';
 export const getToken = () => localStorage.getItem(TOKEN_KEY);
-export const setToken = (t) => t ? localStorage.setItem(TOKEN_KEY, t) : localStorage.removeItem(TOKEN_KEY);
+export const setToken = (t) => (t ? localStorage.setItem(TOKEN_KEY, t) : localStorage.removeItem(TOKEN_KEY));
 export const clearToken = () => localStorage.removeItem(TOKEN_KEY);
 
 export async function nf(path, opts = {}) {
@@ -18,7 +41,6 @@ export async function nf(path, opts = {}) {
 
   if (res.status === 401) {
     clearToken();
-    // отправим на экран входа
     if (location.pathname !== '/' && location.pathname !== '/index.html') {
       location.href = '/';
     }
@@ -36,57 +58,8 @@ export async function joinEvent({ code, nickname }) {
   return res.json();
 }
 
-// Глобальный logout удобен для кнопки в шапке
 export function logout() {
   clearToken();
   location.href = '/';
 }
 
-// сделать доступным везде
-window.logout = logout;
-
-// Для удобства в браузере:
-window.fhApi = { nf, joinEvent, getToken, setToken, clearToken, logout };
-// --- FH Supabase singleton (append only) ---
-(function attachSupabaseSingleton() {
-  const SUPABASE_URL = 'https://smamhlfzerjkdfhtwhdv.supabase.co';
-  const SUPABASE_ANON_KEY = '<PUT_YOUR_ANON_KEY_HERE>'; // keep as is if already set elsewhere
-
-  if (window.supabase && !window.__fh_supabase) {
-    window.__fh_supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-      auth: {
-        persistSession: true,
-        autoRefreshToken: true,
-        detectSessionInUrl: true,
-        flowType: 'pkce',
-        storageKey: 'fh.auth',
-      },
-    });
-  }
-
-  if (!window.getSupabase) {
-    window.getSupabase = () => window.__fh_supabase;
-  }
-})();
-
-// --- FH auth routing hooks (append only) ---
-(function () {
-  if (!window.getSupabase) return;
-  const client = window.getSupabase();
-  if (!client) return;
-
-  // Avoid double binding
-  if (window.__fh_auth_bound) return;
-  window.__fh_auth_bound = true;
-
-  client.auth.onAuthStateChange(async (evt, session) => {
-    // If user logs in or signs up -> go to home (or hub)
-    if (session) {
-      // If you prefer hub after auth, change 'home' to 'hub'
-      window.fhRouter && window.fhRouter.go('home');
-    } else {
-      // logged out -> to auth
-      window.fhRouter && window.fhRouter.go('auth');
-    }
-  });
-})();

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -1,22 +1,22 @@
-import { nf, getToken, setToken, clearToken, joinEvent } from './js/api.js';
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
+import {
+  supa,
+  getSession,
+  onAuthState,
+  signIn,
+  signUp,
+  signOut,
+  getProfile,
+  nf,
+  getToken,
+  setToken,
+  clearToken,
+  joinEvent,
+} from './api.js';
 
-// expose Supabase client factory and config (was in index.html)
-window.createClient = createClient;
-window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
-window.PROXY_SUPABASE_URL = location.origin + '/supabase';
-window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
+window.FH = { supa, signIn, signUp, signOut, getSession, getProfile };
 
-// --- Supabase singleton ---
-let __supabase;
 function getSupabase() {
-  if (__supabase) return __supabase;
-  __supabase = createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY, {
-    auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: false },
-  });
-  window.supabase = __supabase;
-  window.__supabaseClient = __supabase;
-  return __supabase;
+  return supa;
 }
 
 const API = {
@@ -38,12 +38,28 @@ const API = {
   }
 };
 
-let __booted = false;
-window.addEventListener('DOMContentLoaded', () => {
-  if (__booted) return;
-  __booted = true;
-  init();
-});
+document.addEventListener('DOMContentLoaded', init);
+
+async function init() {
+  let session = null;
+  try {
+    session = await Promise.race([
+      getSession(),
+      new Promise((resolve) => setTimeout(() => resolve(null), 1500)),
+    ]);
+  } catch (_) { /* ignore */ }
+
+  const target = session ? 'home' : 'auth';
+  window.fhRouter && window.fhRouter.go(target);
+
+  document.querySelectorAll('[data-go]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      const t = btn.dataset.go;
+      if (t) window.fhRouter && window.fhRouter.go(t);
+    });
+  });
+}
 
 const toastEl = document.getElementById('toast');
 let toastTimer;
@@ -776,7 +792,6 @@ const DEBUG_EVENTS = !!window.DEBUG_EVENTS;
 async function ensureSupabase(){
   return getSupabase();
 }
-window.ensureSupabase = ensureSupabase;
 
 const clearNickname = () => setNickname('');
 

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -80,7 +80,7 @@
     </section>
   </main>
 
-  <script src="/app.js" defer></script>
+  <script type="module" src="js/app.js"></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -18,13 +18,7 @@
       <button type="button" class="btn btn--ghost" id="btn-logout" data-logout>Выйти</button>
     </div>
   </main>
-  <script>
-    window.SUPABASE_URL = "https://smamhlfzserjkdfhthwhdv.supabase.co";
-    window.PROXY_SUPABASE_URL = location.origin + '/supabase';
-    window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4";
-  </script>
-  <script defer type="module" src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm"></script>
-  <script src="/app.js" defer></script>
+  <script type="module" src="js/app.js"></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>


### PR DESCRIPTION
## Summary
- load a single `<script type="module" src="js/app.js">` on each page
- expose minimal FH globals and init flow from `js/app.js`
- convert `js/api.js` to a pure ESM supabase helper

## Testing
- `npm test`

## Sanity check
- Hard reload (empty cache). On first open (no session) → Auth screen visible; no console errors.
- After sign-in/sign-up → navigate to Home without page reload.
- Reload while logged in → stays on Home.
- Console has no Unexpected keyword 'export' and no import call errors.


------
https://chatgpt.com/codex/tasks/task_e_68ba1af36d00833297aed330550e46d7