### PR TITLE
feat: add floating chat bubbles

### DIFF
--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -1,5 +1,40 @@
 import { supa } from './api.js';
 
+const FH_MESSAGES = [
+  "Я возьму пиццу 🍕",
+  "Я приду в 9 ⏰",
+  "Ребят, постучите в дверь 🚪",
+  "Кто возьмет колу? 🥤",
+  "Буду с +1 😊",
+  "Спойлер: будет торт 🎂",
+  "Добавил плейлист 🎶",
+  "Беру настолки! 🎲",
+  "Давайте сегодня тусовку?",
+  "Приходи к 19:00 ✨",
+  "Я возьму чипсы",
+  "Друзья, до встречи 🐸",
+  "Я за пивом 🍺",
+  "Забронировал столик 🍽️",
+  "Принесу проектор 📽️",
+  "Закажем такси? 🚖",
+  "Я купил шарики 🎈",
+  "Кто возьмёт гитару? 🎸",
+  "Я буду позже 🙈",
+  "У кого карты? 🃏",
+  "Я за сладким 🍩",
+  "Давайте сделаем фото 📸"
+];
+
+function spawnBubbles(container, count = 40) {
+  for (let i = 0; i < count; i++) {
+    const msg = FH_MESSAGES[Math.floor(Math.random() * FH_MESSAGES.length)];
+    const bubble = document.createElement("div");
+    bubble.className = "fh-bubble";
+    bubble.textContent = msg;
+    container.appendChild(bubble);
+  }
+}
+
 // ---- BOOTSTRAP (один раз) -----------------------------------
 if (!window.FH) window.FH = {};
 if (window.FH.__booted) { /* уже проинициализировано */ }
@@ -112,7 +147,9 @@ else {
   (function bubbles() {
     const root = document.querySelector('.fh-bubbles');
     if (!root) return;
-    const items = Array.from(root.querySelectorAll('.bubble'));
+    root.innerHTML = '';
+    spawnBubbles(root, 40);
+    const items = Array.from(root.querySelectorAll('.fh-bubble'));
     if (!items.length) return;
 
     function layout() {

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -54,6 +54,16 @@ body{
   overflow: hidden;
 }
 
+.fh-bubble {
+  animation: floaty 6s ease-in-out infinite alternate;
+}
+
+@keyframes floaty {
+  0% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(4px, -6px) scale(1.05); }
+  100% { transform: translate(-3px, 3px) scale(0.95); }
+}
+
 /* Базовый вид «смс» в виде iOS-пилюли */
 .bubble.chip{
   display:inline-flex;align-items:center;gap:6px;


### PR DESCRIPTION
## Summary
- populate intro with dozens of random chat-style bubbles
- animate bubble drift with new `floaty` keyframes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba51b07fc08332b97e0d3eb2a0e4c5