### PR TITLE
feat: glass auth card and calm background bubbles

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -88,11 +88,11 @@
 <body class="scene-intro">
   <div class="fh-bg" aria-hidden="true"></div>
   <div id="fh-message-clouds" class="fh-bubbles" aria-hidden="true">
-    <div class="bubble chip">Создавайте события</div>
-    <div class="bubble chip">Делитесь вишлистами</div>
-    <div class="bubble chip">Планируйте встречи</div>
-    <div class="bubble chip">Приглашайте друзей</div>
-    <div class="bubble chip">Следите за ответами</div>
+    <div class="fh-chip">Создавайте события</div>
+    <div class="fh-chip">Делитесь вишлистами</div>
+    <div class="fh-chip">Планируйте встречи</div>
+    <div class="fh-chip">Приглашайте друзей</div>
+    <div class="fh-chip">Следите за ответами</div>
   </div>
   <div class="fh-content">
   <!-- Шапка -->
@@ -108,7 +108,9 @@
   </nav>
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <section id="screen-auth" class="screen container" role="main">
-    <div class="card auth-card auth-panel" id="authPanel" style="max-width:620px;margin:40px auto">
+    <div class="auth-card-wrap">
+      <div class="auth-card">
+        <div class="card auth-panel" id="authPanel" style="max-width:620px;margin:40px auto">
       <div class="auth-head">
         <div class="auth-avatar">
           <img src="/assets/frog_idle.png" alt="Froggy" />
@@ -165,6 +167,8 @@
           <div id="reg-status" aria-live="polite"></div>
         </form>
       </section>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -82,7 +82,27 @@ const FH_MESSAGES = [
   'Я отпечатаю фото 📸',
   'Кто на десерт? 🍮',
   'Встречаемся у метро 🚉',
-  'Я возьму мороженое 🍦'
+  'Я возьму мороженое 🍦',
+  'Поставлю плейлист вечера 🎵',
+  'Привезу настольный хоккей 🏒',
+  'Я беру карты Таро 🃏',
+  'Прихвачу селфи-палку 🤳',
+  'Запасуся маршмеллоу 🍡',
+  'Буду на самокате 🛴',
+  'Захвачу настольный дартс 🎯',
+  'У кого есть мяч? 🏀',
+  'Привезу лампу лаву 🪔',
+  'Я с домашним лимонадом 🍹',
+  'Захвачу гитару-бас 🎸',
+  'Принесу плейстейшен 🎮',
+  'Кто возьмёт микрофон? 🎙️',
+  'Я куплю фейерверки 🎆',
+  'Привезу попкорн 🍿',
+  'Зайду за напитками 🍻',
+  'Подготовлю викторину ❓',
+  'Привезу селфи-зону 📸',
+  'Захвачу набор для рисования 🎨',
+  'Кто принесёт настольные игры? 🎲'
 ];
 
 const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -90,131 +110,146 @@ const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').mat
 function pickMessage() {
   return FH_MESSAGES[Math.floor(Math.random() * FH_MESSAGES.length)];
 }
-
-function rectAt(pos, el) {
-  const { width, height } = el.getBoundingClientRect();
-  return { left: pos.x, top: pos.y, right: pos.x + width, bottom: pos.y + height };
-}
-
-function rectsOverlap(a, b, pad = 0) {
-  return !(a.right + pad < b.left || a.left - pad > b.right || a.bottom + pad < b.top || a.top - pad > b.bottom);
-}
-
-function overlapsAny(pos, el) {
-  const r1 = rectAt(pos, el);
-  const nodes = document.querySelectorAll('.fh-bubble.fh-bubble--in');
-  for (const n of nodes) {
-    if (n === el) continue;
-    const r2 = n.getBoundingClientRect();
-    if (rectsOverlap(r1, r2, 6)) return true;
+function createJitteredGrid({ cols, rows, jitter, margin }) {
+  const anchors = [];
+  const w = window.innerWidth - margin * 2;
+  const h = window.innerHeight - margin * 2;
+  const cw = w / cols;
+  const ch = h / rows;
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      anchors.push({
+        x: margin + c * cw + cw / 2 + (Math.random() * 2 - 1) * jitter,
+        y: margin + r * ch + ch / 2 + (Math.random() * 2 - 1) * jitter,
+      });
+    }
   }
-  return false;
+  return anchors;
 }
 
-function clampToContainer(p, el) {
-  const c = el.parentElement.getBoundingClientRect();
-  const { width, height } = el.getBoundingClientRect();
-  return {
-    x: Math.max(8, Math.min(c.width - width - 8, p.x)),
-    y: Math.max(8, Math.min(c.height - height - 8, p.y)),
+let GRID = createJitteredGrid({
+  cols: 10, rows: 8, jitter: 18, margin: 48
+});
+
+const MAX = window.innerWidth >= 1200 ? 36 : window.innerWidth >= 900 ? 26 : 16;
+
+function spawnChips(root){
+  root.innerHTML='';
+  const chips=[];
+  for(let i=0;i<MAX;i++){
+    const anchor=GRID[Math.floor(Math.random()*GRID.length)];
+    chips.push(createChip(root, anchor));
+  }
+  requestAnimationFrame(()=>requestAnimationFrame(()=>updateChips(chips, root)));
+}
+
+function createChip(root, anchor){
+  const el=document.createElement('div');
+  el.className='fh-chip chip-enter';
+  el.textContent=pickMessage();
+  const offset=()=> (Math.random()<0.5?-1:1)*(12+Math.random()*12);
+  const sx=offset(), sy=offset();
+  el.style.transform=`translate(${anchor.x+sx}px, ${anchor.y+sy}px)`;
+  root.appendChild(el);
+  requestAnimationFrame(()=>{
+    el.classList.add('chip-enter-active');
+    el.style.transform=`translate(${anchor.x}px, ${anchor.y}px)`;
+  });
+  el.addEventListener('transitionend',()=>el.classList.remove('chip-enter','chip-enter-active'),{once:true});
+  return{
+    el,
+    anchor:{...anchor},
+    phase:Math.random()*Math.PI*2,
+    omega:prefersReduced?0:(0.08+Math.random()*0.10),
+    radius:6+Math.random()*8,
+    life:performance.now()+3500+Math.random()*1000,
+    leaving:false,
+    x:anchor.x,
+    y:anchor.y
   };
 }
 
-function lifeCycle(bubble, anchor) {
-  const el = bubble.el;
-  if (prefersReduced) {
-    bubble.timer = setInterval(() => {
-      el.textContent = pickMessage();
-    }, 10000 + Math.random() * 2000);
-    return;
-  }
+function updateChips(chips, root){
+  const now=performance.now();
+  const cellSize=80;
+  const hash=new Map();
 
-  const run = () => {
-    const visibleMs = 3000 + Math.random() * 1000;
-    bubble.timer = setTimeout(() => {
-      el.classList.remove('fh-bubble--in');
-      el.classList.add('fh-bubble--out');
+  chips.forEach(chip=>{
+    if(chip.leaving) return;
+    chip.phase+=chip.omega*(prefersReduced?0:(now-(chip.prev||now))/1000);
+    chip.prev=now;
+    chip.x=chip.anchor.x+chip.radius*Math.cos(chip.phase);
+    chip.y=chip.anchor.y+chip.radius*Math.sin(chip.phase);
+    const gx=Math.floor(chip.x/cellSize);
+    const gy=Math.floor(chip.y/cellSize);
+    const key=gx+','+gy;
+    if(!hash.has(key)) hash.set(key,[]);
+    hash.get(key).push(chip);
+  });
 
-      const onEnd = () => {
-        el.removeEventListener('transitionend', onEnd);
-        el.textContent = pickMessage();
-
-        const dx = Math.random() * 80 - 40;
-        const dy = Math.random() * 80 - 40;
-        const target = clampToContainer({ x: anchor.x + dx, y: anchor.y + dy }, el);
-
-        let tries = 0;
-        while (tries < 30 && overlapsAny(target, el)) {
-          target.x += Math.random() * 20 - 10;
-          target.y += Math.random() * 20 - 10;
-          tries++;
+  chips.forEach(chip=>{
+    if(chip.leaving) return;
+    const gx=Math.floor(chip.x/cellSize);
+    const gy=Math.floor(chip.y/cellSize);
+    for(let dx=-1;dx<=1;dx++){
+      for(let dy=-1;dy<=1;dy++){
+        const list=hash.get((gx+dx)+','+(gy+dy));
+        if(!list) continue;
+        for(const other of list){
+          if(other===chip || other.leaving) continue;
+          const dxv=chip.x-other.x;
+          const dyv=chip.y-other.y;
+          const dist=Math.hypot(dxv,dyv);
+          const minDist=24;
+          if(dist>0 && dist<minDist){
+            const push=(minDist-dist)/2;
+            const nx=dxv/dist;
+            const ny=dyv/dist;
+            chip.x+=nx*push;
+            chip.y+=ny*push;
+            other.x-=nx*push;
+            other.y-=ny*push;
+          }
         }
+      }
+    }
+  });
 
-        el.style.left = `${target.x}px`;
-        el.style.top = `${target.y}px`;
+  chips.forEach(chip=>{
+    chip.el.style.transform=`translate(${chip.x}px, ${chip.y}px)`;
+    if(Math.random()<0.1){
+      const mult=0.96+Math.random()*0.04;
+      chip.el.style.opacity=0.9*mult;
+    } else {
+      chip.el.style.opacity=0.9;
+    }
+    if(!chip.leaving && now>chip.life){
+      chip.leaving=true;
+      const offset=()=> (Math.random()<0.5?-1:1)*(12+Math.random()*12);
+      const sx=offset(), sy=offset();
+      chip.el.style.transform=`translate(${chip.x+sx}px, ${chip.y+sy}px)`;
+      chip.el.classList.add('chip-leave');
+      chip.el.offsetWidth;
+      chip.el.classList.add('chip-leave-active');
+      const t=350+Math.random()*150;
+      setTimeout(()=>{
+        root.removeChild(chip.el);
+        const anchor=GRID[Math.floor(Math.random()*GRID.length)];
+        const n=createChip(root, anchor);
+        chips.splice(chips.indexOf(chip),1,n);
+      },t);
+    }
+  });
 
-        el.classList.remove('fh-bubble--out');
-        requestAnimationFrame(() => el.classList.add('fh-bubble--in'));
-
-        run();
-      };
-
-      el.addEventListener('transitionend', onEnd, { once: true });
-    }, visibleMs);
-  };
-  run();
+  requestAnimationFrame(()=>updateChips(chips, root));
 }
 
-function findNonOverlappingPosition(container, el, placed) {
-  const c = container.getBoundingClientRect();
-  let tries = 0;
-  let x, y;
-  do {
-    x = 24 + Math.random() * (c.width - 160);
-    y = 24 + Math.random() * (c.height - 60);
-    el.style.left = `${x}px`;
-    el.style.top = `${y}px`;
-    const r1 = el.getBoundingClientRect();
-    const hit = placed.some(p => rectsOverlap(r1, p.el.getBoundingClientRect(), 8));
-    if (!hit) break;
-    tries++;
-  } while (tries < 60);
-  return { x, y };
+function desiredBubbleCount(){
+  return MAX;
 }
 
-function desiredBubbleCount() {
-  const area = window.innerWidth * window.innerHeight;
-  return Math.min(80, Math.max(20, Math.round(area / 12000)));
-}
-
-function debounce(fn, wait = 100) {
-  let t;
-  return (...args) => {
-    clearTimeout(t);
-    t = setTimeout(() => fn.apply(this, args), wait);
-  };
-}
-
-function spawnBubbles(container, count) {
-  const placed = [];
-  for (let i = 0; i < count; i++) {
-    const el = document.createElement('div');
-    el.className = 'fh-bubble';
-    el.textContent = pickMessage();
-    container.appendChild(el);
-
-    const pos = findNonOverlappingPosition(container, el, placed);
-    el.style.left = `${pos.x}px`;
-    el.style.top = `${pos.y}px`;
-    requestAnimationFrame(() => el.classList.add('fh-bubble--in'));
-
-    const bubble = { el };
-    const anchor = { x: pos.x, y: pos.y };
-    const delay = Math.random() * 400;
-    setTimeout(() => lifeCycle(bubble, anchor), delay);
-
-    placed.push({ el, x: pos.x, y: pos.y });
-  }
+function debounce(fn, wait=100){
+  let t; return (...args)=>{clearTimeout(t); t=setTimeout(()=>fn.apply(this,args),wait);};
 }
 
 // ---- BOOTSTRAP (один раз) -----------------------------------
@@ -238,14 +273,15 @@ else {
   };
 
   // --- Экраны
-  const $auth = document.querySelector('#screen-auth');
-  const $home = document.querySelector('#screen-home');
-
-  const show = ($el) => { [$auth,$home].forEach(x=>x&&x.classList.remove('visible')); $el && $el.classList.add('visible'); };
+  const screens = document.querySelectorAll('.screen');
+  function showScreen(name){
+    screens.forEach(s=>s.classList.remove('visible'));
+    const el=document.getElementById(`screen-${name}`);
+    if(el) el.classList.add('visible');
+  }
 
   // --- Простенький роутер
   async function route() {
-    const hash = (location.hash || '#auth').toLowerCase();
     const supa = getSupabase();
     let session = getSavedSession();
 
@@ -264,14 +300,11 @@ else {
     const authed = !!session;
 
     if (!authed) {
-      show($auth);
-      location.hash = '#auth';
+      showScreen('auth');
       return;
     }
 
-    // авторизованы
-    show($home);
-    if (hash !== '#home') location.hash = '#home';
+    showScreen('home');
   }
 
   // --- Навигационные кнопки (делегирование)
@@ -279,9 +312,9 @@ else {
     const btn = e.target.closest('[data-link]');
     if (!btn) return;
     const to = btn.getAttribute('data-link');
-    if (to === 'home') location.hash = '#home';
-    else if (to === 'profile') location.hash = '#profile';   // сейчас просто якорь, UI можно расширять
-    else if (to === 'settings') location.hash = '#settings'; // якорь
+    if (to === 'home') showScreen('home');
+    else if (to === 'profile') showScreen('profile');
+    else if (to === 'settings') showScreen('settings');
   });
 
   // --- Обработчики форм логина/регистрации
@@ -315,8 +348,7 @@ else {
 
           if (ok && session) {
             setSavedSession({ user: session.user, access_token: session.access_token });
-            location.hash = '#home'; // триггерит route()
-            await route();
+            showScreen('home');
           }
         } catch (err) { /* можно показать тост */ }
       });
@@ -330,18 +362,18 @@ else {
     const root = document.querySelector('.fh-bubbles');
     if (!root) return;
 
-    spawnBubbles(root, desiredBubbleCount());
+    spawnChips(root);
 
     window.addEventListener('resize', debounce(() => {
+      GRID = createJitteredGrid({ cols:10, rows:8, jitter:18, margin:48 });
       const box = document.querySelector('.fh-bubbles');
       if (!box) return;
       box.innerHTML = '';
-      spawnBubbles(box, desiredBubbleCount());
+      spawnChips(box);
     }, 200));
   })();
 
   // --- Старт
   document.addEventListener('DOMContentLoaded', route);
-  window.addEventListener('hashchange', route);
 }
 

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -50,14 +50,14 @@ body{
   position: fixed;
   inset: 0;
   pointer-events: none;
-  z-index: 1;
+  z-index: 0;
   overflow: hidden;
 }
 
 #screen-auth,
 #screen-home {
   position: relative;
-  z-index: 2;
+  z-index: 1;
 }
 
 /* Состояния пузыря */
@@ -106,9 +106,34 @@ body{
   will-change: transform;
 }
 
-/* При скрытии контейнера экрана */
-.screen{display:none;opacity:0;transition:opacity .25s ease}
-.screen.visible{display:block;opacity:1}
+/* фоновые «смс-пузырьки» нового типа */
+.fh-bubbles{ z-index:0; }
+
+.fh-chip{
+  position:absolute; max-width: 36ch;
+  background: linear-gradient(180deg, rgba(255,255,255,.14), rgba(255,255,255,.08));
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: 999px; padding: 8px 14px;
+  color: rgba(255,255,255,.92);
+  box-shadow: 0 6px 20px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.18);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  will-change: transform, opacity;
+  transition: opacity .45s ease, transform .45s ease;
+  opacity: .9;
+}
+.fh-chip.chip-enter{ opacity:0; transform: translateY(10px) scale(.98); }
+.fh-chip.chip-enter-active{ opacity:1; transform: translateY(0) scale(1); }
+.fh-chip.chip-leave{ opacity:1; }
+.fh-chip.chip-leave-active{ opacity:0; transform: translateY(12px) scale(.98); }
+
+@media (prefers-reduced-motion: reduce){
+  .fh-chip{ transition: opacity .25s ease; }
+}
+
+/* Плавные появление/исчезновение экранов */
+.screen{ opacity:0; pointer-events:none; transition: opacity .35s ease; }
+.screen.visible{ opacity:1; pointer-events:auto; }
 
 /* Карточка авторизации/регистрации */
 #screen-auth .card,
@@ -121,6 +146,24 @@ body{
   -webkit-backdrop-filter: blur(6px);
   border: 1px solid rgba(255,255,255,0.08);
   box-shadow: 0 12px 40px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.05);
+}
+
+/* стеклянная карточка авторизации */
+#screen-auth .auth-card{
+  position:relative;
+  z-index:2;
+  background: rgba(20, 45, 35, 0.45);
+  backdrop-filter: blur(14px) saturate(120%);
+  -webkit-backdrop-filter: blur(14px) saturate(120%);
+  border: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 0 12px 40px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.06);
+  border-radius: 18px;
+}
+/* стартовый экран — положение карточки чуть ниже центра */
+#screen-auth .auth-card-wrap{
+  display:grid; place-items:center;
+  min-height: calc(100dvh - 96px);
+  transform: translateY(18px);
 }
 
 .container{max-width:1100px;margin:32px auto;padding:0 20px}


### PR DESCRIPTION
## Summary
- Restyle auth form with glass card wrapper and smoother screen transitions
- Add tranquil SMS-like background bubbles with jittered grid animation
- Simplify routing to use `showScreen` after Supabase auth

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5f858c648332a458ec7d046809ce