### PR TITLE
feat: ensure background message bubbles

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -9,69 +9,6 @@
   <link rel="icon"
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
   <style>
-    /* Message clouds background */
-    #fh-message-clouds {
-      position: fixed; inset: 0;
-      z-index: 0;             /* ниже основного контента */
-      pointer-events: none;   /* не перехватываем клики */
-      overflow: hidden;
-    }
-    .fh-cloud {
-      position: absolute;
-      max-width: 44ch;
-      padding: 10px 14px;
-      border-radius: 16px;
-      background: rgba(255,255,255,0.08);
-      backdrop-filter: saturate(150%) blur(6px);
-      -webkit-backdrop-filter: saturate(150%) blur(6px);
-      border: 1px solid rgba(255,255,255,0.12);
-      color: rgba(255,255,255,0.85);
-      font-size: 14px;
-      line-height: 1.3;
-      box-shadow: 0 8px 20px rgba(0,0,0,0.25);
-      transform-origin: center;
-    }
-    /* на маленьких экранах делаем меньше, чтобы не мешало */
-    @media (max-width: 640px) {
-      .fh-cloud { font-size: 12px; max-width: 32ch; }
-    }
-  </style>
-  <style>
-    /* Message clouds background */
-    #fh-message-clouds {
-      position: fixed; inset: 0;
-      z-index: 0;             /* ниже основного контента */
-      pointer-events: none;   /* не перехватываем клики */
-      overflow: hidden;
-    }
-    .fh-cloud {
-      position: absolute;
-      max-width: 44ch;
-      padding: 10px 14px;
-      border-radius: 16px;
-      background: rgba(255,255,255,0.08);
-      backdrop-filter: saturate(150%) blur(6px);
-      -webkit-backdrop-filter: saturate(150%) blur(6px);
-      border: 1px solid rgba(255,255,255,0.12);
-      color: rgba(255,255,255,0.85);
-      font-size: 14px;
-      line-height: 1.3;
-      box-shadow: 0 8px 20px rgba(0,0,0,0.25);
-      transform-origin: center;
-      animation: floaty 6s ease-in-out infinite;
-    }
-
-    @keyframes floaty {
-      0%   { transform: translateY(0) rotate(var(--rot, 0deg)); }
-      50%  { transform: translateY(-6px) rotate(calc(var(--rot, 0deg) * 1.1)); }
-      100% { transform: translateY(0) rotate(var(--rot, 0deg)); }
-    }
-
-    @media (max-width: 640px) {
-      .fh-cloud { font-size: 12px; max-width: 32ch; }
-    }
-  </style>
-  <style>
     .fh-bg {
       position: fixed; inset: 0; z-index: 0;
       background: #0b241b url("/assets/froggy_glass_bg.jpeg") center 45% / cover no-repeat;
@@ -80,21 +17,15 @@
       .fh-bg { background-position: center; }
     }
     .fh-bg::after { content:""; position:absolute; inset:0; background: rgba(11,36,27,.55); }
-    #fh-message-clouds { position: fixed; inset: 0; z-index: 0; pointer-events:none; }
     .fh-content { position: relative; z-index: 20; min-height: 100svh; padding-inline: 1rem; }
     #fh-cta { position: relative; z-index: 30; }
   </style>
 </head>
 <body class="scene-intro">
   <div class="fh-bg" aria-hidden="true"></div>
-  <div id="fh-message-clouds" class="fh-bubbles" aria-hidden="true">
-    <div class="fh-chip">Создавайте события</div>
-    <div class="fh-chip">Делитесь вишлистами</div>
-    <div class="fh-chip">Планируйте встречи</div>
-    <div class="fh-chip">Приглашайте друзей</div>
-    <div class="fh-chip">Следите за ответами</div>
-  </div>
-  <div class="fh-content">
+  <main id="app-root">
+    <div class="fh-bubbles" aria-hidden="true"></div>
+    <div class="fh-content">
   <!-- Шапка -->
   <nav class="topbar">
     <div class="topbar-left">
@@ -108,8 +39,8 @@
   </nav>
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <section id="screen-auth" class="screen container" role="main">
-    <div class="auth-card-wrap">
-      <div class="auth-card">
+    <div class="auth-card-wrap auth-wrapper">
+      <div class="auth-card fh-card">
         <div class="card auth-panel" id="authPanel" style="max-width:620px;margin:40px auto">
       <div class="auth-head">
         <div class="auth-avatar">
@@ -573,6 +504,7 @@
     </div>
   </div>
 </div>
+</main>
 <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -216,6 +216,49 @@ else {
     handle(signupForm, 'signup');
   })();
 
+  // Ensure bubbles layer exists and populated, then kick visibility
+  (function ensureBubbles() {
+    const stage = document.querySelector('.fh-bubbles');
+    if (!stage) return;
+
+    // если уже отрисованы > 20 — ничего не делаем
+    if (stage.querySelectorAll('.fh-bubble').length > 20) {
+      // На всякий случай: снимем «невидимость», если она зависла
+      stage.querySelectorAll('.fh-bubble').forEach(n => n.classList.add('is-in'));
+      return;
+    }
+
+    const messages = [
+      'Кто возьмёт колу? 🥤','Буду с +1 🙂','Зайду за напитками 🛒',
+      'Я купил шарики 🎈','Забронировал столик 🍽️','Приеду на час раньше ⏱️',
+      'Давайте играть в мафию 😎','Кто возьмёт гитару? 🎸','Нужны свечи 🕯️',
+      'Принесу проектор 📽️','Я на машине 🚗','Возьму пледы 🧣',
+      'Давайте сделаем фото 📸','Где паркуемся? 🅿️','Я за пиццу 🍕',
+      'Кто возьмёт посуду? 🍽️','Я за салатом 🥗','Кто на десерт? 🧁',
+      'Поделитесь адресом 🗺️','Скиньте код 🔐','У кого карты? 🃏'
+    ];
+
+    // Сколько хотим сразу
+    const COUNT = 60;
+    const frag = document.createDocumentFragment();
+    for (let i = 0; i < COUNT; i++) {
+      const b = document.createElement('div');
+      b.className = 'fh-bubble';
+      b.textContent = messages[Math.floor(Math.random() * messages.length)];
+      // временно за экран, чтобы не мигали
+      b.style.setProperty('--tx', '-9999px');
+      b.style.setProperty('--ty', '-9999px');
+      frag.appendChild(b);
+    }
+    stage.appendChild(frag);
+
+    // Дай браузеру вставить DOM, затем включи «видимость» — сразу,
+    // чтобы они не остались прозрачными
+    requestAnimationFrame(() => {
+      stage.querySelectorAll('.fh-bubble').forEach(n => n.classList.add('is-in'));
+    });
+  })();
+
   // ===== BUBBLES: grid + no-overlap + fade swap =====
   (function bubblesManager() {
     const stage = document.querySelector('.fh-bubbles');

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -49,11 +49,13 @@ body{
   font:16px/1.5 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial;
 }
 
+#app-root{ position:relative; min-height:100vh; }
+
 /* Контейнер для фона с пузырями */
 .fh-bubbles {
   position: absolute;
   inset: 0;
-  overflow: hidden;
+  z-index: 1;
   pointer-events: none;
 }
 
@@ -63,17 +65,27 @@ body{
   z-index: 1;
 }
 
+.auth-wrapper, .fh-card { z-index: 10; position: relative; }
+
 /* Базовое состояние пузыря */
 .fh-bubble {
   position: absolute;
   opacity: 0;
-  transform: translate3d(0,0,0) scale(0.98);
+  transform: translate3d(0,0,0) scale(.98);
   transition: opacity .45s ease, transform .45s ease;
   will-change: transform, opacity;
+  background: rgba(255,255,255,.08);
+  border: 1px solid rgba(255,255,255,.12);
+  backdrop-filter: blur(8px);
+  color: rgba(255,255,255,.9);
+  padding: 8px 14px;
+  border-radius: 999px;
+  box-shadow: 0 6px 16px rgba(0,0,0,.22);
+  font: 500 14px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
 }
 
 .fh-bubble.is-in {
-  opacity: 1;
+  opacity: .92;
   transform: translate3d(var(--tx,0), var(--ty,0), 0) scale(1);
 }
 


### PR DESCRIPTION
## Summary
- restore bubble layer and ensure it renders behind auth card but above background
- style bubbles for immediate visibility and correct layering
- auto-populate bubble stage with messages and make them visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6c7eaa3483328757dd25ec9311fc