### PR TITLE
feat: add simple hash router

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -178,21 +178,21 @@
     <div class="menu-deck">
       <div class="panel">
         <div class="menu-grid">
-          <button id="create-event" class="btn btn-primary" data-go="app" data-mode="create">
+          <button id="btn-create" class="btn btn-primary" data-link="create" data-go="app" data-mode="create">
             Создать событие
           </button>
 
           <form id="join-form" class="join-row" autocomplete="off">
             <input id="join-code" class="input" inputmode="numeric" maxlength="6"
                    placeholder="Введите 6-значный код">
-            <button id="join-btn" type="button" class="btn">Присоединиться</button>
+            <button id="btn-join" type="button" class="btn" data-link="join">Присоединиться</button>
           </form>
         </div>
       </div>
     </div>
   </section>
 
-  <section id="screen-join-name" class="screen" hidden>
+  <section id="screen-join" class="screen">
     <div class="panel">
       <h2>Как к вам обращаться?</h2>
       <form id="form-join-name" class="row">
@@ -215,7 +215,7 @@
 
   <!-- ЭКРАНЫ СОЗДАНИЯ СОБЫТИЯ -->
 
-<section id="screen-create-conditions" class="screen" hidden>
+<section id="screen-create" class="screen">
   <div class="panel">
     <h2 id="create-title">Параметры встречи</h2>
     <form id="form-create-1" class="stack">
@@ -263,7 +263,7 @@
 </section>
 
   <!-- ЭКРАН 3: ПРУД + ФИНАЛ -->
-  <section id="screen-app" class="container" hidden>
+  <section id="screen-lobby" class="screen container">
     <div class="wrap" id="root" hidden>
       <section class="pond" id="pond">
         <div class="ripples" aria-hidden="true"></div>
@@ -504,7 +504,7 @@
   </section>
 
   <!-- ЭКРАН: ПРОФИЛЬ -->
-  <section id="screen-profile" class="screen" hidden>
+  <section id="screen-profile" class="screen">
     <div class="container">
       <div class="panel profile-card">
         <div class="profile-head">
@@ -529,6 +529,8 @@
       </div>
     </div>
   </section>
+
+  <section id="screen-settings" class="screen"></section>
 
   <div id="sessionBanner" role="status" aria-live="polite" hidden>Сессия истекла, войдите снова</div>
   <dialog id="otpModal">

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -1,4 +1,80 @@
-import { supa } from './api.js';
+import { supa, getSession } from './api.js';
+
+const ROUTES = ['home','auth','lobby','create','join','profile','settings'];
+
+const qs = s => document.querySelector(s);
+
+function showScreen(name) {
+  // у экранов уже есть id вида #screen-*
+  document.querySelectorAll('.screen').forEach(el => {
+    el.classList.toggle('visible', el.id === `screen-${name}`);
+    el.setAttribute('aria-hidden', el.id === `screen-${name}` ? 'false':'true');
+  });
+}
+
+function go(name) { location.hash = `#${name}`; }
+
+async function currentSession() {
+  // используй существующий helper Supabase, если он есть.
+  // иначе безопасная заглушка:
+  try { return await getSession(); } catch { return null; }
+}
+
+async function handleRoute() {
+  let route = (location.hash.replace('#','') || 'home');
+  const hasRoute = ROUTES.includes(route);
+  if (!hasRoute) route = 'home';
+
+  const session = await currentSession();
+  // неавторизованных отправляем на auth, авторизованных с auth — домой
+  if (!session && route !== 'auth') route = 'auth';
+  if (session && route === 'auth') route = 'home';
+
+  showScreen(route);
+}
+
+// единая инициализация
+function bindNav() {
+  document.addEventListener('click', (e) => {
+    const a = e.target.closest('[data-link]');
+    if (!a) return;
+    e.preventDefault();
+    const to = a.getAttribute('data-link');
+    if (ROUTES.includes(to)) go(to);
+  });
+
+  window.addEventListener('hashchange', handleRoute);
+}
+
+async function bindAuth() {
+  // логин
+  qs('#login-form')?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try {
+      const nick = qs('#login-nick')?.value?.trim();
+      const pass = qs('#login-pass')?.value ?? '';
+      const ok = await window.FH?.login?.(nick, pass);
+      if (ok) go('home');
+    } catch {}
+  });
+
+  // регистрация (если есть форма)
+  qs('#signup-form')?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    try {
+      const nick = qs('#signup-nick')?.value?.trim();
+      const pass = qs('#signup-pass')?.value ?? '';
+      const ok = await window.FH?.signup?.(nick, pass);
+      if (ok) go('home');
+    } catch {}
+  });
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  bindNav();
+  await bindAuth();
+  handleRoute(); // стартовая отрисовка
+});
 
 const FH_MESSAGES = [
   'Я приду к 19:00 ✨',
@@ -237,6 +313,32 @@ else {
     try { s ? localStorage.setItem(LS_KEY, JSON.stringify(s)) : localStorage.removeItem(LS_KEY); } catch {}
   };
 
+  // методы авторизации для SPA
+  window.FH.getSession = async () => {
+    try { const { data } = await getSupabase().auth.getSession(); return data?.session || null; }
+    catch { return null; }
+  };
+  window.FH.login = async (nick, pass) => {
+    try {
+      const { data, error } = await getSupabase().auth.signInWithPassword({ email: `${nick}@local`, password: pass });
+      if (error) return false;
+      const session = data?.session;
+      if (session) setSavedSession({ user: session.user, access_token: session.access_token });
+      return !!session;
+    } catch { return false; }
+  };
+  window.FH.signup = async (nick, pass) => {
+    try {
+      const { error } = await getSupabase().auth.signUp({ email: `${nick}@local`, password: pass });
+      if (error) return false;
+      const { data, error: err2 } = await getSupabase().auth.signInWithPassword({ email: `${nick}@local`, password: pass });
+      if (err2) return false;
+      const session = data?.session;
+      if (session) setSavedSession({ user: session.user, access_token: session.access_token });
+      return !!session;
+    } catch { return false; }
+  };
+
   // --- Экраны
   const $auth = document.querySelector('#screen-auth');
   const $home = document.querySelector('#screen-home');
@@ -245,47 +347,29 @@ else {
 
   // --- Простенький роутер
   async function route() {
-    const hash = (location.hash || '#auth').toLowerCase();
-    const supa = getSupabase();
-    let session = getSavedSession();
-
-    // быстрая проверка
-    if (!session && supa?.auth) {
-      const ctrl = new AbortController();
-      const t = setTimeout(()=>ctrl.abort(), 1500);
-      try {
-        const { data } = await supa.auth.getSession({ signal: ctrl.signal });
-        session = data?.session || null;
-      } catch { /* таймаут/ошибка – игнор */ }
-      clearTimeout(t);
-      if (session) setSavedSession({ user: session.user, access_token: session.access_token });
-    }
-
-    const authed = !!session;
-
-    if (!authed) {
-      show($auth);
-      location.hash = '#auth';
-      return;
-    }
-
-    // авторизованы
-    show($home);
-    if (hash !== '#home') location.hash = '#home';
+    await handleRoute();
+    // legacy logic retained for reference
+    // const hash = (location.hash || '#auth').toLowerCase();
+    // const supa = getSupabase();
+    // let session = getSavedSession();
+    // ...
   }
 
   // --- Навигационные кнопки (делегирование)
-  document.addEventListener('click', (e) => {
-    const btn = e.target.closest('[data-link]');
-    if (!btn) return;
-    const to = btn.getAttribute('data-link');
-    if (to === 'home') location.hash = '#home';
-    else if (to === 'profile') location.hash = '#profile';   // сейчас просто якорь, UI можно расширять
-    else if (to === 'settings') location.hash = '#settings'; // якорь
-  });
+  // (перенесено в bindNav)
+  // document.addEventListener('click', (e) => {
+  //   const btn = e.target.closest('[data-link]');
+  //   if (!btn) return;
+  //   const to = btn.getAttribute('data-link');
+  //   if (to === 'home') location.hash = '#home';
+  //   else if (to === 'profile') location.hash = '#profile';   // сейчас просто якорь, UI можно расширять
+  //   else if (to === 'settings') location.hash = '#settings'; // якорь
+  // });
+  // bindNav() вызывается при загрузке документа
 
   // --- Обработчики форм логина/регистрации
-  (function bindAuth() {
+  // (оставлено для совместимости)
+  (function bindAuthLegacy() {
     const loginForm  = document.querySelector('#loginForm');
     const signupForm = document.querySelector('#signupForm');
     async function handle(form, kind) {
@@ -340,8 +424,8 @@ else {
     }, 200));
   })();
 
-  // --- Старт
-  document.addEventListener('DOMContentLoaded', route);
-  window.addEventListener('hashchange', route);
+  // --- Старт (обработка маршрута перенесена в верхний хелпер)
+  // document.addEventListener('DOMContentLoaded', route);
+  // window.addEventListener('hashchange', route);
 }
 

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -28,8 +28,8 @@
     <header class="fh-header">
       <a class="fh-logo" href="/">FroggyHub</a>
       <nav class="topbar">
-        <a href="/" class="btn btn--ghost btn--sm">Меню</a>
-        <a href="/profile.html" class="btn btn--ghost btn--sm">Профиль</a>
+        <button class="btn btn--ghost btn--sm" data-link="home">Меню</button>
+        <button class="btn btn--ghost btn--sm" data-link="profile">Профиль</button>
         <button id="logoutBtn" data-logout class="btn btn--ghost btn--sm">Выйти</button>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- add hash-based SPA router with route handling and auth bindings
- make nav buttons declarative via `data-link`
- add missing screen IDs and placeholders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba7e8c286483328c3d98874c042d1e