### PR TITLE
feat: configure supabase via global env

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -5,10 +5,16 @@
   <meta name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
   <title>FroggyHub — события и вишлисты</title>
-  <link rel="stylesheet" href="style.css">
-  <link rel="icon"
-        href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
-  <style>
+    <link rel="stylesheet" href="style.css">
+    <link rel="icon"
+          href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
+    <script>
+      window.ENV = {
+        SUPABASE_URL: "PUBLIC_SUPABASE_URL",
+        SUPABASE_ANON_KEY: "PUBLIC_SUPABASE_ANON_KEY",
+      };
+    </script>
+    <style>
     /* Message clouds background */
     #fh-message-clouds {
       position: fixed; inset: 0;

--- a/FroggyHub/js/api.js
+++ b/FroggyHub/js/api.js
@@ -1,7 +1,6 @@
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
-const SUPABASE_URL = 'https://smamhlfzserjkdfhthwhdv.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNtYW1obGZ6ZXJqa2RmaHR3aGR2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUxMzQ0MzYsImV4cCI6MjA3MDcxMDQzNn0.PwRF3OAtlpJ7zu2lsIb46V7XLINlyhfC97Jgbu--Vv4';
+const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.ENV;
 
 export const supa = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {


### PR DESCRIPTION
## Summary
- read Supabase credentials from `window.ENV` instead of hardcoded values
- expose `window.ENV` with Netlify-provided `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8964c4748332bce9210e456a6826