### PR TITLE
feat: integrate supabase auth

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -146,14 +146,17 @@
               <input id="resetPass2" type="password" minlength="4" autocomplete="new-password">
             </label>
           </div>
-          <div id="login-status" aria-live="polite"></div>
+          <div id="login-status" class="form-error" aria-live="polite"></div>
         </form>
       </section>
 
       <section id="pane-register" class="pane is-hidden" role="tabpanel" aria-labelledby="tab-register">
-        <form id="signupForm" class="grid" novalidate>
+        <form id="register-form" class="grid" novalidate>
           <label>Имя / Никнейм
             <input id="signup-nickname" name="nickname" required minlength="2" autocomplete="nickname">
+          </label>
+          <label>Email
+            <input id="signup-email" name="email" type="email" required autocomplete="email">
           </label>
           <label>Пароль
             <input id="signup-password" name="password" type="password" required minlength="4" autocomplete="new-password">
@@ -162,7 +165,7 @@
             <input id="signup-password2" name="password2" type="password" required minlength="4" autocomplete="new-password">
           </label>
             <button id="signup-btn" class="btn btn-primary btn-xl w-100" type="submit">Зарегистрироваться</button>
-          <div id="reg-status" aria-live="polite"></div>
+          <div id="reg-status" class="form-error" aria-live="polite"></div>
         </form>
       </section>
     </div>

--- a/FroggyHub/js/api.js
+++ b/FroggyHub/js/api.js
@@ -1,42 +1,52 @@
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
-const { SUPABASE_URL, SUPABASE_ANON_KEY } = window.ENV || {};
+const ENV = window?.ENV ?? {};
 let _supa;
-export function getSupa() {
-  if (!_supa) {
-    _supa = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-      auth: { persistSession: true, autoRefreshToken: true }
-    });
-  }
+export const supa = (() => {
+  if (_supa) return _supa;
+  _supa = createClient(ENV.PUBLIC_SUPABASE_URL, ENV.PUBLIC_SUPABASE_ANON_KEY, {
+    auth: { persistSession: true, autoRefreshToken: true },
+  });
+  window.FH = window.FH || {};
+  window.FH.supa = _supa;
   return _supa;
-}
+})();
 
-export async function signInOrSignUp({ identifier, password }) {
-  const supa = getSupa();
-  const email = identifier.includes('@') ? identifier : `${identifier}@local.froggyhub`;
-  let { data, error } = await supa.auth.signInWithPassword({ email, password });
-  if (error && error.message?.toLowerCase().includes('invalid login credentials')) {
-    const reg = await supa.auth.signUp({ email, password });
-    if (reg.error) throw reg.error;
-    ({ data, error } = await supa.auth.signInWithPassword({ email, password }));
-  }
+const isEmail = (v) => /\S+@\S+\.\S+/.test(String(v||'').trim());
+
+export async function signUpWithNickname({ nickname, email, password }) {
+  if (!nickname || !email || !password) throw new Error('Заполните никнейм, email и пароль');
+  const { data, error } = await supa.auth.signUp({
+    email, password,
+    options: { data: { nickname: String(nickname).trim() } },
+  });
   if (error) throw error;
-  return data?.session ?? null;
+  try {
+    const user = data.user;
+    if (user) {
+      await supa.from('profiles').upsert({
+        id: user.id, nickname: String(nickname).trim(), email: String(email).trim(),
+      });
+    }
+  } catch {}
+  return data;
 }
 
-export function onAuth(cb) {
-  const supa = getSupa();
-  return supa.auth.onAuthStateChange((_evt, session) => cb(session));
+export async function signInSmart({ login, password }) {
+  const raw = String(login||'').trim();
+  if (!raw || !password) throw new Error('Заполните логин и пароль');
+  let email = raw;
+  if (!isEmail(raw)) {
+    const { data, error } = await supa.rpc('get_email_by_nickname', { p_nickname: raw });
+    if (error) throw error;
+    if (!data || !data.email) throw new Error('Пользователь с таким никнеймом не найден');
+    email = data.email;
+  }
+  const { data, error } = await supa.auth.signInWithPassword({ email, password });
+  if (error) throw error;
+  return data;
 }
 
-export async function signOut() {
-  const supa = getSupa();
-  await supa.auth.signOut();
-}
-
-export async function getSession() {
-  const supa = getSupa();
-  const { data } = await supa.auth.getSession();
-  return data?.session ?? null;
-}
-
+export async function getSession(){ const {data,error}=await supa.auth.getSession(); if(error)throw error; return data.session??null;}
+export async function signOut(){ const {error}=await supa.auth.signOut(); if(error)throw error;}
+export function onAuthChanged(cb){ return supa.auth.onAuthStateChange((e,s)=>{ try{cb?.(e,s);}catch{} }); }

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -1,75 +1,66 @@
-import { getSession, onAuth, signInOrSignUp } from './api.js';
+import { supa, signUpWithNickname, signInSmart, getSession, signOut, onAuthChanged } from './api.js';
 
-const SCREENS = ['auth','home','profile','settings','create','join'];
+const qs=(s,r=document)=>r.querySelector(s);
+const qa=(s,r=document)=>Array.from(r.querySelectorAll(s));
+const SCREENS={ auth:'#screen-auth', home:'#screen-home' };
 
-function showScreen(name) {
-  SCREENS.forEach(id => {
-    const el = document.querySelector(`#screen-${id}`);
-    if (!el) return;
-    el.classList.toggle('visible', id === name);
-    el.setAttribute('aria-hidden', id === name ? 'false' : 'true');
+function showScreen(name){
+  const id=SCREENS[name]||name;
+  qa('.screen').forEach(el=>{
+    const visible=('#'+el.id)===id;
+    el.classList.toggle('visible',visible);
+    el.setAttribute('aria-hidden',String(!visible));
   });
-  // Обновляем hash для SPA
-  if (name !== 'auth') location.hash = `#${name}`;
+  const newHash=id.startsWith('#')?id:`#${id}`;
+  if(location.hash!==newHash) history.replaceState(null,'',newHash);
 }
 
-function routeFromHash() {
-  const target = (location.hash || '#home').replace('#','');
-  showScreen(SCREENS.includes(target) ? target : 'home');
-}
-
-function bindNav() {
-  document.addEventListener('click', (e) => {
-    const btn = e.target.closest('[data-link]');
-    if (!btn) return;
+function navBind(){
+  document.addEventListener('click',e=>{
+    const a=e.target.closest('[data-link]');
+    if(!a) return;
     e.preventDefault();
-    const dest = btn.getAttribute('data-link');
-    if (SCREENS.includes(dest)) showScreen(dest);
+    const target=a.getAttribute('data-link');
+    if(target) showScreen(target);
+  });
+  window.addEventListener('hashchange',()=>{
+    const key=location.hash.replace('#','')||'home';
+    if(SCREENS[key]) showScreen(key);
   });
 }
 
-function bindAuthForm() {
-  const form = document.querySelector('#auth-form');
-  if (!form) return;
-  const loginInput = form.querySelector('input[name="login"]');
-  const passInput  = form.querySelector('input[name="password"]');
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const identifier = (loginInput?.value || '').trim();
-    const password   = (passInput?.value  || '').trim();
-    if (!identifier || !password) return;
-    form.classList.add('is-loading');
-    try {
-      const session = await signInOrSignUp({ identifier, password });
-      if (session) showScreen('home');
-    } catch (err) {
-      console.warn('[auth]', err?.message || err);
-      // Мягкая подсветка ошибки
-      form.classList.add('shake');
-      setTimeout(() => form.classList.remove('shake'), 300);
-    } finally {
-      form.classList.remove('is-loading');
-    }
+function bindAuthForms(){
+  const authForm=qs('#auth-form');
+  if(authForm){
+    authForm.addEventListener('submit',async e=>{
+      e.preventDefault();
+      const fd=new FormData(authForm);
+      const login=fd.get('login'), password=fd.get('password');
+      const errBox=authForm.querySelector('.form-error');
+      try{ await signInSmart({login,password}); showScreen('home'); }
+      catch(err){ errBox&&(errBox.textContent=err.message); }
+    });
+  }
+  const regForm=qs('#register-form');
+  if(regForm){
+    regForm.addEventListener('submit',async e=>{
+      e.preventDefault();
+      const fd=new FormData(regForm);
+      const nickname=fd.get('nickname'), email=fd.get('email'), password=fd.get('password');
+      const errBox=regForm.querySelector('.form-error');
+      try{ await signUpWithNickname({nickname,email,password}); showScreen('home'); }
+      catch(err){ errBox&&(errBox.textContent=err.message); }
+    });
+  }
+  qa('[data-action="logout"]').forEach(btn=>{
+    btn.addEventListener('click',async()=>{ try{await signOut();}catch{} });
   });
 }
 
-async function bootstrap() {
-  // 1) отрисовываем Home по умолчанию, auth поверх если нет сессии
-  showScreen('home');
-  // 2) слушаем auth
-  onAuth((session) => {
-    if (session) showScreen('home'); else showScreen('auth');
-  });
-  // 3) проверяем существующую сессию
-  const session = await getSession();
-  if (session) showScreen('home'); else showScreen('auth');
-  // 4) навигация
-  bindNav();
-  bindAuthForm();
-  // 5) роутинг по hash
-  window.addEventListener('hashchange', routeFromHash);
-  if (location.hash) routeFromHash();
+async function boot(){
+  navBind(); bindAuthForms();
+  try{ const s=await getSession(); showScreen(s?'home':'auth'); }
+  catch{ showScreen('auth'); }
+  onAuthChanged((_e,s)=>showScreen(s?'home':'auth'));
 }
-
-document.addEventListener('DOMContentLoaded', bootstrap);
-
+document.addEventListener('DOMContentLoaded',boot);


### PR DESCRIPTION
## Summary
- use singleton supabase client with nickname-aware signup and smart login helpers
- handle auth forms and navigation via hash router
- add registration form with email field and error displays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba97d0db2083328326843656e20227