### PR TITLE
feat: smart supabase auth and bubble spacing

### DIFF
--- a/FroggyHub/js/api.js
+++ b/FroggyHub/js/api.js
@@ -1,42 +1,91 @@
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
 
-const getEnv = () => (window.ENV || {});
-const makeClient = () => {
-  const { SUPABASE_URL: url, SUPABASE_ANON_KEY: key } = getEnv();
+const ENV = window?.ENV ?? {};
+let _supa;
+
+/** Фабрика клиента Supabase с защитой от пустых creds */
+export function supa() {
+  if (_supa) return _supa;
+  const url = ENV.PUBLIC_SUPABASE_URL;
+  const key = ENV.PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !key) {
-    console.error("Supabase ENV missing", { url, keyPresent: !!key });
+    console.warn('[supa] creds are missing, return null client');
     return null;
   }
-  return createClient(url, key, {
-    auth: { persistSession: true, autoRefreshToken: true }
+  _supa = createClient(url, key, {
+    auth: { persistSession: true, autoRefreshToken: true },
   });
-};
-
-export const supa = makeClient();
-
-// Helpers
-export async function getSession() {
-  if (!supa) return null;
-  const { data } = await supa.auth.getSession();
-  return data?.session || null;
+  return _supa;
 }
 
-export async function signInWithNicknameOrEmail({ login, password }) {
-  if (!supa) throw new Error("Supabase not ready");
-  const isEmail = /\S+@\S+\.\S+/.test(login);
-  const args = isEmail ? { email: login, password } : { email: `${login}@users.local`, password };
-  // Если логина нет — автосоздаем пользователя (upsert-паттерн)
-  let { data, error } = await supa.auth.signInWithPassword(args);
-  if (error?.status === 400) {
-    const reg = await supa.auth.signUp(args);
-    if (reg.error) throw reg.error;
-    ({ data, error } = await supa.auth.signInWithPassword(args));
+/** Простая проверка e-mail */
+const isEmail = v => /\S+@\S+\.\S+/.test(String(v||'').trim());
+
+/** Преобразуем никнейм в валидный e-mail домена проекта */
+export function nicknameToEmail(nickname) {
+  const base = String(nickname||'').trim().toLowerCase();
+  // только буквы/цифры/подчёркивания/точки/дефисы
+  const local = base.replace(/[^a-z0-9._-]/g, '');
+  return `${local}@users.froggyhub.app`;
+}
+
+/** Регистрация по никнейму+email+пароль (email можно сгенерировать) */
+export async function signUpWithNickname({ nickname, email, password }) {
+  const client = supa();
+  if (!client) throw new Error('Supabase is not configured');
+  const safeEmail = isEmail(email) ? email : nicknameToEmail(nickname);
+  if (!nickname || !safeEmail || !password) {
+    throw new Error('Заполните никнейм, email и пароль');
   }
+  const { data, error } = await client.auth.signUp({
+    email: safeEmail,
+    password,
+    options: { data: { nickname: String(nickname).trim() } },
+  });
   if (error) throw error;
-  return data?.session || null;
+  return data;
+}
+
+/** Умный вход: принимает login (ник или e-mail) + пароль */
+export async function signInSmart({ login, password }) {
+  const client = supa();
+  if (!client) throw new Error('Supabase is not configured');
+  const raw = String(login||'').trim();
+  if (!raw || !password) throw new Error('Заполните логин и пароль');
+
+  let email = raw;
+  if (!isEmail(raw)) {
+    // Пробуем найти e-mail по никнейму в публичном профиле (если есть RPC — используй, а пока просто конвертация)
+    email = nicknameToEmail(raw);
+  }
+
+  const { data, error } = await client.auth.signInWithPassword({ email, password });
+  if (error) throw error;
+  return data;
+}
+
+export async function getSession() {
+  const client = supa();
+  if (!client) return null;
+  const { data, error } = await client.auth.getSession();
+  if (error) throw error;
+  return data?.session ?? null;
 }
 
 export async function signOut() {
-  if (!supa) return;
-  await supa.auth.signOut();
+  const client = supa();
+  if (!client) return;
+  const { error } = await client.auth.signOut();
+  if (error) throw error;
 }
+
+/** Подписка на смену состояния авторизации */
+export function onAuthChanged(cb) {
+  const client = supa();
+  if (!client) return () => {};
+  const { data: sub } = client.auth.onAuthStateChange((_evt, session) => {
+    try { cb?.(session); } catch {}
+  });
+  return () => sub?.subscription?.unsubscribe?.();
+}
+

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -1,66 +1,108 @@
-const SCREENS = ["home","auth","profile","settings"];
-export function showScreen(id) {
-  SCREENS.forEach(s => {
-    const el = document.getElementById(`screen-${s}`);
-    if (el) el.classList.toggle("visible", s === id);
-    if (el) el.setAttribute("aria-hidden", String(s !== id));
+import { supa, signInSmart, signUpWithNickname, getSession, signOut, onAuthChanged } from './api.js';
+
+// Вспомогалки выборки
+const qs = (s, r=document) => r.querySelector(s);
+const qa = (s, r=document) => Array.from(r.querySelectorAll(s));
+
+const SCREENS = ['auth','home','profile','settings','create','join'];
+const SCREEN_IDS = Object.fromEntries(SCREENS.map(n=>[n, `#screen-${n}`]));
+
+/** Показ экрана + обновление hash */
+function showScreen(name){
+  const id = SCREEN_IDS[name] || name; // допускаем передачу '#screen-…'
+  qa('.screen').forEach(el=>{
+    const visible = ('#'+el.id) === id;
+    el.classList.toggle('visible', visible);
+    el.setAttribute('aria-hidden', String(!visible));
   });
-  if (id !== "auth") location.hash = `#${id}`;
+  // hash только для не-auth
+  const target = id.startsWith('#') ? id.slice(1) : id;
+  if (!target.includes('auth')) {
+    const newHash = '#'+(SCREENS.includes(target.replace('screen-','')) ? target.replace('screen-','') : target);
+    if (location.hash !== newHash) history.replaceState(null, '', newHash);
+  }
 }
 
-function bindTopNav() {
-  document.addEventListener("click", (e) => {
-    const a = e.target.closest("[data-link]");
-    if (!a) return;
-    const to = a.getAttribute("data-link");
-    if (SCREENS.includes(to)) {
-      e.preventDefault();
-      showScreen(to);
-    }
-  });
-  window.addEventListener("hashchange", () => {
-    const id = (location.hash.replace("#","") || "home");
-    showScreen(SCREENS.includes(id) ? id : "home");
+/** Навигация по клику на элементы с [data-link] */
+function bindNav(){
+  document.addEventListener('click', (e)=>{
+    const a = e.target.closest('[data-link]');
+    if(!a) return;
+    e.preventDefault();
+    const to = a.getAttribute('data-link');
+    if (SCREENS.includes(to)) showScreen(to);
   });
 }
 
-import { getSession, signInWithNicknameOrEmail } from "./api.js";
-
-async function initAuthFlow() {
-  // Показать home сразу (фон, меню), затем проверить сессию и показать auth при необходимости
-  showScreen("home");
-  const session = await getSession();
-  if (!session) showScreen("auth");
-
-  const form = document.getElementById("auth-form");
-  if (form && !form.__bound) {
-    form.__bound = true;
-    form.addEventListener("submit", async (e) => {
+/** Привязка форм авторизации (id="auth-form") и регистрации (id="register-form") */
+function bindAuthForms(){
+  const loginForm = qs('#auth-form');
+  if (loginForm) {
+    loginForm.addEventListener('submit', async (e)=>{
       e.preventDefault();
-      const fd = new FormData(form);
-      const login = fd.get("login")?.toString().trim();
-      const password = fd.get("password")?.toString();
-      form.querySelector("button[type=submit]")?.setAttribute("disabled","true");
-      try {
-        const sess = await signInWithNicknameOrEmail({ login, password });
-        if (sess) {
-          showScreen("home");
-        }
-      } catch (err) {
-        console.error("Auth failed", err);
-        form.querySelector("[data-error]")?.replaceChildren(document.createTextNode("Ошибка входа"));
-      } finally {
-        form.querySelector("button[type=submit]")?.removeAttribute("disabled");
+      const fd = new FormData(loginForm);
+      const login = fd.get('login');
+      const password = fd.get('password');
+      const errBox = loginForm.querySelector('.form-error');
+      try{
+        errBox && (errBox.textContent = '');
+        await signInSmart({ login, password });
+        showScreen('home');
+      }catch(err){
+        console.warn('[auth:login]', err);
+        errBox && (errBox.textContent = err?.message || 'Ошибка входа');
+        loginForm.classList.add('shake');
+        setTimeout(()=>loginForm.classList.remove('shake'), 600);
+      }
+    });
+  }
+
+  const regForm = qs('#register-form');
+  if (regForm){
+    regForm.addEventListener('submit', async (e)=>{
+      e.preventDefault();
+      const fd = new FormData(regForm);
+      const nickname = fd.get('nickname');
+      const email = fd.get('email'); // можно пустым — сгенерим из никнейма
+      const password = fd.get('password');
+      const errBox = regForm.querySelector('.form-error');
+      try{
+        errBox && (errBox.textContent = '');
+        await signUpWithNickname({ nickname, email, password });
+        // после успешной регистрации пробуем залогинить:
+        await signInSmart({ login: email || nickname, password });
+        showScreen('home');
+      }catch(err){
+        console.warn('[auth:register]', err);
+        errBox && (errBox.textContent = err?.message || 'Ошибка регистрации');
+        regForm.classList.add('shake');
+        setTimeout(()=>regForm.classList.remove('shake'), 600);
       }
     });
   }
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  bindTopNav();
-  initAuthFlow();
-  startBubbles(); // см. ниже
-});
+/** Инициализация приложения */
+async function bootstrap(){
+  bindNav();
+  bindAuthForms();
+  startBubbles();
+
+  // первичная отрисовка
+  const session = await getSession().catch(()=>null);
+  showScreen(session ? 'home' : 'auth');
+
+  // слушаем изменения авторизации
+  onAuthChanged((s)=>{
+    showScreen(s ? 'home' : 'auth');
+  });
+}
+
+// запускаемся один раз
+if (!window.__FH_BOOT__) {
+  window.__FH_BOOT__ = true;
+  bootstrap();
+}
 
 // CALM bubbles
 const messages = window.FH_MESSAGES || [
@@ -69,40 +111,43 @@ const messages = window.FH_MESSAGES || [
 ];
 
 function jitterGrid(cols=8, rows=6, margin=16) {
-  const w = innerWidth, h = innerHeight;
+  const w = innerWidth;
+  const style = getComputedStyle(document.documentElement);
+  const topGap = parseFloat(style.getPropertyValue('--fh-bubbles-top-gap'))||0;
+  const bottomGap = parseFloat(style.getPropertyValue('--fh-bubbles-bottom-gap'))||0;
+  const h = innerHeight - topGap - bottomGap;
   const cellW = Math.max(160, (w - margin*2) / cols);
   const cellH = Math.max(56,  (h - margin*2) / rows);
   const pts = [];
   for (let r=0; r<rows; r++) for (let c=0; c<cols; c++) {
     const x = margin + c*cellW + (Math.random()-0.5)*cellW*0.25;
-    const y = margin + r*cellH + (Math.random()-0.5)*cellH*0.25;
+    const y = topGap + margin + r*cellH + (Math.random()-0.5)*cellH*0.25;
     pts.push({x,y});
   }
   return {pts, cellW, cellH};
 }
 
 function createChip(msg) {
-  const el = document.createElement("div");
-  el.className = "fh-chip";
+  const el = document.createElement('div');
+  el.className = 'chip';
   el.textContent = msg;
-  el.style.position = "absolute";
-  el.style.padding = "6px 14px";
-  el.style.borderRadius = "999px";
-  el.style.background = "rgba(23, 65, 53, .85)";
-  el.style.boxShadow = "0 2px 10px rgba(0,0,0,.25)";
-  el.style.color = "var(--chip-fg, #e9ffe8)";
-  el.style.fontSize = "14px";
-  el.style.opacity = "0";
-  el.style.transition = "opacity .6s ease, transform .6s ease";
+  el.style.position = 'absolute';
+  el.style.padding = '6px 14px';
+  el.style.borderRadius = '999px';
+  el.style.background = 'rgba(23, 65, 53, .85)';
+  el.style.boxShadow = '0 2px 10px rgba(0,0,0,.25)';
+  el.style.color = 'var(--chip-fg, #e9ffe8)';
+  el.style.fontSize = '14px';
+  el.style.opacity = '0';
   return el;
 }
 
 let bubblesState = { slots: [], idx: 0, holder: null };
 function layoutChips() {
-  const holder = bubblesState.holder || document.querySelector(".fh-bubbles");
+  const holder = bubblesState.holder || document.querySelector('.fh-bubbles');
   if (!holder) return;
   holder.replaceChildren();
-  const { pts, cellW, cellH } = jitterGrid(9, 6, 24);
+  const { pts } = jitterGrid(9, 6, 24);
   bubblesState.slots = pts;
   bubblesState.holder = holder;
 
@@ -114,7 +159,7 @@ function layoutChips() {
     chip.style.left = `${p.x}px`;
     chip.style.top  = `${p.y}px`;
     holder.appendChild(chip);
-    requestAnimationFrame(()=> chip.style.opacity = "1");
+    requestAnimationFrame(()=> chip.style.opacity = '1');
   }
   // жизненный цикл
   cycleChips();
@@ -127,7 +172,7 @@ function cycleChips() {
   chips.forEach((chip, i) => {
     const delay = 800 + Math.random()*1800; // между волнами
     setTimeout(() => {
-      chip.style.opacity = "0";
+      chip.style.opacity = '0';
       chip.style.transform = `translate(${(Math.random()-0.5)*30}px, ${(Math.random()-0.5)*30}px)`;
       setTimeout(() => {
         // выбрать новый свободный слот
@@ -135,8 +180,8 @@ function cycleChips() {
         chip.textContent = messages[Math.floor(Math.random()*messages.length)];
         chip.style.left = `${p.x}px`;
         chip.style.top  = `${p.y}px`;
-        chip.style.transform = "translate(0,0)";
-        chip.style.opacity = "1";
+        chip.style.transform = 'translate(0,0)';
+        chip.style.opacity = '1';
       }, 600);
     }, 3000 + delay);
   });
@@ -146,9 +191,10 @@ function cycleChips() {
 
 function startBubbles() {
   layoutChips();
-  addEventListener("resize", () => {
+  addEventListener('resize', () => {
     // мягко переложить сетку при ресайзе
     clearTimeout(startBubbles.__t);
     startBubbles.__t = setTimeout(layoutChips, 200);
   });
 }
+

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -34,6 +34,8 @@
   --danger:#ff6b6b;
   --frog-hero-max: 540px;
   --frog-hero-min: 360px;
+  --fh-bubbles-top-gap: 72px;
+  --fh-bubbles-bottom-gap: 120px;
 }
 
 *{box-sizing:border-box}
@@ -52,6 +54,8 @@ body{
   pointer-events: none;
   z-index: 0;
   overflow: hidden;
+  padding-top: var(--fh-bubbles-top-gap);
+  padding-bottom: var(--fh-bubbles-bottom-gap);
 }
 
 /* Состояния пузыря */
@@ -98,6 +102,12 @@ body{
   transition: transform .2s ease-out, opacity .3s ease;
   white-space: nowrap;
   will-change: transform;
+}
+
+.fh-bubbles .chip{
+  margin: 6px 8px;
+  will-change: transform, opacity;
+  transition: opacity .45s ease, transform .6s ease;
 }
 
 /* При скрытии контейнера экрана */
@@ -880,7 +890,10 @@ button:not([disabled]){ cursor:pointer; }
   backdrop-filter:blur(18px) saturate(120%);
   -webkit-backdrop-filter:blur(18px) saturate(120%);
   box-shadow:0 18px 40px rgba(0,0,0,.35);
-  transform:translateY(6vh)}
+  transform:translateY(6vh);
+  position:relative;
+  z-index:5;
+}
 .auth-card h1,.auth-card h2{letter-spacing:.2px}
 .auth-card .tabs{margin:10px 0 14px}
 .auth-card .input, .auth-card input[type="text"], .auth-card input[type="password"]{


### PR DESCRIPTION
## Summary
- implement Supabase client helpers with nickname-to-email and smart sign-in
- wire up auth & registration forms with screen navigation
- polish bubble background spacing and auth card stacking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba9e8b641c83328da8d2b3027ece03