### PR TITLE
feat: add ambient message bubbles background

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -21,6 +21,7 @@
 </head>
 <body class="scene-intro">
   <div class="fh-bubbles" aria-hidden="true"></div>
+  <div id="fh-message-clouds" aria-hidden="true"></div>
   <div id="screens">
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <section id="screen-auth" class="screen container" role="main">

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -134,7 +134,7 @@ function bindAuthForms(){
 /* ---------- BOOT ---------- */
 async function bootstrap(){
   // фоновые чипы
-  startBubbles();
+  // startBubbles();
 
   // рутинг и формы
   bindNav();
@@ -146,3 +146,202 @@ async function bootstrap(){
   showScreen('auth');
 }
 bootstrap();
+
+// ==== Ambient Bubbles ==================================================
+const FH_BUBBLES = (() => {
+  // Тексты можно брать из твоего текущего массива сообщений.
+  // Если он уже есть (например FH_MESSAGES) — используй его. Иначе — fallback:
+  const MESSAGES = (window.FH_MESSAGES && window.FH_MESSAGES.length)
+    ? window.FH_MESSAGES
+    : [
+      'Друзья, до встречи 🌿', 'Кто возьмёт колу? 🥤', 'Я за десерт 🍰', 'Буду с +1 🙂',
+      'Я купил шарики 🎈', 'Нужны свечи 🕯', 'Закажем такси? 🚕', 'Принесу проектор 📽️',
+      'Кто на лимонад? 🍋', 'Кто возьмёт тарелки? 🍽️'
+    ];
+
+  const state = {
+    el: null,
+    chips: [],
+    grid: [],
+    cellW: 280,       // базовая ширина ячейки (адаптивно пересчитаем)
+    cellH: 44,        // базовая высота чипа
+    cols: 0,
+    rows: 0,
+    excludeRects: [], // сюда добавим auth-карточку
+    timer: null,
+    poolSize: 48      // максимум видимых
+  };
+
+  function init(){
+    state.el = document.getElementById('fh-message-clouds');
+    if(!state.el) return;
+
+    // рассчитываем сетку
+    computeGrid();
+    collectExclusions();
+
+    // создаём стартовые чипы
+    const count = Math.min(state.poolSize, Math.max(18, Math.floor(state.cols * state.rows * 0.45)));
+    for(let i=0;i<count;i++){
+      const chip = document.createElement('div');
+      chip.className = 'fh-chip';
+      chip.textContent = pickMessage();
+      chip.style.setProperty('--seed', (Math.random()*2).toFixed(2));
+      state.el.appendChild(chip);
+      state.chips.push(chip);
+    }
+    layoutAll();
+    cycle();
+
+    // события
+    window.addEventListener('resize', onResize, { passive: true });
+    const ro = new ResizeObserver(() => { onResize(); });
+    const auth = document.querySelector('#screen-auth .card, #auth-card, .auth-card');
+    if(auth) ro.observe(auth);
+  }
+
+  function pickMessage(){
+    return MESSAGES[(Math.random()*MESSAGES.length)|0];
+  }
+
+  function computeGrid(){
+    const padTop = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--bubble-top-gap')) || 72;
+    const padBot = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--bubble-bottom-gap')) || 64;
+    const gapX   = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--bubble-gap-x')) || 20;
+    const gapY   = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--bubble-gap-y')) || 18;
+
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    // делаем ширину ячейки адаптивной
+    state.cellW = Math.max(220, Math.min(360, Math.floor(vw/6)));
+    state.cellH = 44;
+
+    const usableW = vw - gapX;
+    const usableH = vh - padTop - padBot - gapY;
+
+    state.cols = Math.max(2, Math.floor(usableW / (state.cellW + gapX)));
+    state.rows = Math.max(3, Math.floor(usableH / (state.cellH + gapY)));
+
+    // подготавливаем сетку центров
+    state.grid = [];
+    for(let r=0; r<state.rows; r++){
+      for(let c=0; c<state.cols; c++){
+        const x = Math.round((gapX/2) + c*(state.cellW+gapX) + (Math.random()*12-6)); // джиттер
+        const y = Math.round(padTop + (gapY/2) + r*(state.cellH+gapY) + (Math.random()*10-5));
+        state.grid.push({x,y, used:false});
+      }
+    }
+  }
+
+  function collectExclusions(){
+    state.excludeRects = [];
+    // auth-карточка
+    const authPanel = document.querySelector('#screen-auth .card, #auth-card, .auth-card');
+    if(authPanel){
+      const r = authPanel.getBoundingClientRect();
+      // чуть расширим, чтобы вокруг было пространство
+      const m = 24;
+      state.excludeRects.push({left:r.left-m, top:r.top-m, right:r.right+m, bottom:r.bottom+m});
+    }
+  }
+
+  function rectsOverlap(a,b){
+    return !(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom);
+  }
+
+  function placeChip(chip){
+    // Сначала сбросим «занятость»
+    state.grid.forEach(g => g.used=false);
+
+    // Текущие занятые прямоугольники: все уже размещённые чипы, + исключения
+    const busy = [...state.excludeRects];
+    for(const c of state.chips){
+      if(c===chip || !c._rect) continue;
+      busy.push(c._rect);
+    }
+
+    // попробуем до N раз найти свободную ячейку
+    for(let k=0;k<60;k++){
+      const slot = state.grid[(Math.random()*state.grid.length)|0];
+      if(slot.used) continue;
+
+      // оценим размер чипа (примерно — пока без DOM-перемеривания)
+      const w = Math.min(state.cellW, Math.max(120, (chip.textContent.length*7 + 24)));
+      const h = state.cellH;
+
+      const rect = {
+        left: slot.x,
+        top:  slot.y,
+        right: slot.x + w,
+        bottom: slot.y + h
+      };
+
+      // проверка на пересечения
+      let ok = true;
+      for(const b of busy){
+        if(rectsOverlap(rect, b)){ ok=false; break; }
+      }
+      if(!ok) continue;
+
+      // ок — применяем
+      chip.style.left = rect.left + 'px';
+      chip.style.top  = rect.top  + 'px';
+      chip.style.width = w + 'px';
+      chip._rect = rect;
+      slot.used = true;
+      return true;
+    }
+    return false;
+  }
+
+  function layoutAll(){
+    // Сначала скрываем всё (без резких анимаций)
+    state.chips.forEach(ch => { ch.classList.remove('show'); ch.style.opacity = '0'; });
+
+    // Расставляем
+    for(const ch of state.chips){
+      if(placeChip(ch)){
+        // задержка проявления — для «рождения»
+        requestAnimationFrame(() => {
+          ch.classList.add('show');
+        });
+      }
+    }
+  }
+
+  // каждые 2.5–3.5с случайную порцию чипов «переставляем» через затухание
+  function cycle(){
+    clearTimeout(state.timer);
+    const batch = Math.max(2, Math.round(state.chips.length * 0.12)); // 10–15%
+    const picks = new Set();
+    while(picks.size < batch){
+      picks.add( state.chips[(Math.random()*state.chips.length)|0] );
+    }
+    picks.forEach(chip => {
+      chip.classList.remove('show');          // уйти в fade-out
+      setTimeout(() => {
+        chip.textContent = pickMessage();     // сменить фразу
+        placeChip(chip);                       // найти новое место
+        requestAnimationFrame(() => chip.classList.add('show')); // fade-in
+      }, 400); // время затухания синхронизировано с CSS transition
+    });
+
+    const next = 2500 + (Math.random()*1200|0);
+    state.timer = setTimeout(cycle, next);
+  }
+
+  function onResize(){
+    computeGrid();
+    collectExclusions();
+    layoutAll();
+  }
+
+  return { init };
+})();
+
+// Инициализация после существующего bootstrapa приложения
+document.addEventListener('DOMContentLoaded', () => {
+  // Запускаем фоновые пузыри, но только если есть контейнер экранов
+  FH_BUBBLES.init();
+});

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -920,3 +920,56 @@ button:not([disabled]){ cursor:pointer; }
 }
 
 
+/* ==== Ambient Message Bubbles ==== */
+:root{
+  --bubble-gap-x: 20px;
+  --bubble-gap-y: 18px;
+  --bubble-top-gap: 72px;      /* отступ от верхней кромки, чтобы не упираться в топбар */
+  --bubble-bottom-gap: 64px;   /* отступ снизу */
+  --bubble-opacity: 0.92;
+  --bubble-blur: 0px;          /* фон у пузырей без блюра (чтобы не спорить с карточкой) */
+}
+#fh-message-clouds{
+  position: fixed;
+  inset: 0;
+  z-index: 0;                  /* ниже экранов */
+  pointer-events: none;
+  overflow: hidden;
+}
+.fh-chip{
+  position: absolute;
+  max-width: 38ch;             /* ограничим длину фразы */
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.04);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.06) inset,
+    0 8px 20px rgba(0,0,0,0.35);
+  outline: 1px solid rgba(255,255,255,0.06);
+  color: rgba(255,255,255,0.88);
+  backdrop-filter: blur(var(--bubble-blur));
+  -webkit-backdrop-filter: blur(var(--bubble-blur));
+  opacity: 0;
+  transform: translate3d(0, 6px, 0) scale(.995);
+  transition:
+    opacity .6s ease,
+    transform .6s cubic-bezier(.2,.65,.2,1);
+  will-change: transform, opacity;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.fh-chip.show{
+  opacity: var(--bubble-opacity);
+  transform: translate3d(0,0,0) scale(1);
+}
+/* лёгкое «дыхание», но только если не reduced-motion */
+@media (prefers-reduced-motion: no-preference){
+  .fh-chip.show{
+    animation: chipFloat 6s ease-in-out infinite alternate;
+    animation-delay: calc(var(--seed, 0) * 1s);
+  }
+  @keyframes chipFloat{
+    to { transform: translate3d(0,-2px,0) scale(1.003); }
+  }
+}


### PR DESCRIPTION
## Summary
- add fixed #fh-message-clouds layer for animated message bubbles
- style and animate non-overlapping chat-like chips
- implement FH_BUBBLES module with grid layout and auth-card exclusion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baae8919a883328fce0e694058a3c0