### PR TITLE
Implement floating background bubbles and adjust auth layout

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -32,5 +32,11 @@
   <section id="screen-settings" class="screen" aria-hidden="true"></section>
 
   <script type="module" src="./js/app.js"></script>
+  <script type="module">
+  import { initBubbles } from './js/bubbles.js';
+  window.addEventListener('DOMContentLoaded', () => {
+    initBubbles({ containerId: 'fh-message-clouds', count: 7 });
+  });
+  </script>
 </body>
 </html>

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -135,8 +135,8 @@ function bindAuthForms(){
 
 function bootstrap(){
   // фоновые чипы
-  mountClouds(AMBIENT);
-  shuffleClouds(9000);
+  // mountClouds(AMBIENT);
+  // shuffleClouds(9000);
 
   // навигация
   bindNav();

--- a/FroggyHub/js/bubbles.js
+++ b/FroggyHub/js/bubbles.js
@@ -1,0 +1,134 @@
+// js/bubbles.js
+export function initBubbles({ containerId = 'fh-message-clouds', count = 7 } = {}) {
+  const root = document.getElementById(containerId);
+  if (!root) return;
+
+  const MARGIN = 12;                 // внутренний "зазор" от краёв
+  const CELL_W = 160, CELL_H = 120;  // виртуальная сетка
+  const MIN_DIST = 48;               // мин. дистанция между центрами
+  const LIFETIME = 3200;             // "жизнь" в мс
+  const ENTER_MS = 320, EXIT_MS = 320;
+
+  // соберём тексты из уже имеющихся .bubble.chip (если есть), иначе fallback
+  const texts = Array.from(root.querySelectorAll('.bubble.chip'))
+    .map(n => n.textContent.trim())
+    .filter(Boolean);
+  const FALLBACK = [
+    'Я возьму пиццу', 'Я приду в 9', 'Постучите в дверь', 'Куплю свечи',
+    'Нужны тарелки?', 'Я возьму игры', 'Без лука, пожалуйста', 'Кто за музыкой?',
+    'Скину адрес в чат', 'Нужен чайник?', 'Буду через 15', 'Я заберу торт',
+  ];
+  const pool = texts.length ? texts : FALLBACK;
+
+  // очищаем контейнер — но НЕ трогаем исходные DOM-узлы вне контейнера
+  root.innerHTML = '';
+
+  function getGridPositions(w, h) {
+    const cols = Math.max(1, Math.floor((w - MARGIN * 2) / CELL_W));
+    const rows = Math.max(1, Math.floor((h - MARGIN * 2) / CELL_H));
+    const cells = [];
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const x = MARGIN + c * CELL_W + Math.random() * 32 - 16;
+        const y = MARGIN + r * CELL_H + Math.random() * 24 - 12;
+        cells.push({ x, y });
+      }
+    }
+    return cells.sort(() => Math.random() - 0.5);
+  }
+
+  function okDistance(x, y, placed) {
+    for (const p of placed) {
+      const dx = p.x - x, dy = p.y - y;
+      if (Math.hypot(dx, dy) < MIN_DIST) return false;
+    }
+    return true;
+  }
+
+  function spawnWave() {
+    const { clientWidth: w, clientHeight: h } = root;
+    const cells = getGridPositions(w, h);
+    const placed = [];
+    const items = [];
+
+    // выбираем не более `count` корректных позиций
+    for (let i = 0; i < cells.length && placed.length < count; i++) {
+      const { x, y } = cells[i];
+      if (okDistance(x, y, placed)) {
+        placed.push({ x, y });
+      }
+    }
+
+    // создаём элементы на выбранных местах
+    placed.forEach((pos, idx) => {
+      const el = document.createElement('div');
+      el.className = 'bubble chip bubble-enter';
+      el.textContent = pool[Math.floor(Math.random() * pool.length)];
+      // задаём кастомные CSS-переменные для трансформа
+      el.style.setProperty('--tx', `${pos.x}px`);
+      el.style.setProperty('--ty', `${pos.y}px`);
+      root.appendChild(el);
+      // после enter → alive → exit → remove → respawn
+      setTimeout(() => {
+        el.classList.remove('bubble-enter');
+        el.classList.add('bubble-alive');
+        setTimeout(() => {
+          el.classList.remove('bubble-alive');
+          el.classList.add('bubble-exit');
+          setTimeout(() => {
+            el.remove();
+            // запускаем новый пузырь вместо удалённого
+            respawnOne();
+          }, EXIT_MS);
+        }, LIFETIME);
+      }, ENTER_MS);
+      items.push(el);
+    });
+  }
+
+  function respawnOne() {
+    const { clientWidth: w, clientHeight: h } = root;
+    const existing = Array.from(root.querySelectorAll('.bubble.chip'))
+      .map(el => {
+        const tx = parseFloat(getComputedStyle(el).getPropertyValue('--tx')) || 0;
+        const ty = parseFloat(getComputedStyle(el).getPropertyValue('--ty')) || 0;
+        return { x: tx, y: ty };
+      });
+
+    const cells = getGridPositions(w, h);
+    let candidate = null;
+    for (const c of cells) {
+      if (okDistance(c.x, c.y, existing)) { candidate = c; break; }
+    }
+    if (!candidate) return;
+
+    const el = document.createElement('div');
+    el.className = 'bubble chip bubble-enter';
+    el.textContent = pool[Math.floor(Math.random() * pool.length)];
+    el.style.setProperty('--tx', `${candidate.x}px`);
+    el.style.setProperty('--ty', `${candidate.y}px`);
+    root.appendChild(el);
+
+    setTimeout(() => {
+      el.classList.remove('bubble-enter');
+      el.classList.add('bubble-alive');
+      setTimeout(() => {
+        el.classList.remove('bubble-alive');
+        el.classList.add('bubble-exit');
+        setTimeout(() => el.remove(), EXIT_MS);
+      }, LIFETIME);
+    }, ENTER_MS);
+  }
+
+  // первая волна
+  spawnWave();
+  // на ресайз — пересоздаём волны мягко (чтобы не залипали в углу)
+  let rid = null;
+  window.addEventListener('resize', () => {
+    if (rid) cancelAnimationFrame(rid);
+    rid = requestAnimationFrame(() => {
+      root.innerHTML = '';
+      spawnWave();
+    });
+  }, { passive: true });
+}

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -1006,3 +1006,68 @@ input, .input{
   padding: 0 14px;
 }
 
+
+/* Пузырьки не мешают кликам по UI */
+#fh-message-clouds {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  z-index: var(--bubble-layer-z);
+  padding: 0;
+}
+
+/* Базовый вид iOS-pill, опираемся на уже существующую .bubble.chip */
+.bubble.chip {
+  position: absolute;
+  will-change: transform, opacity;
+  backface-visibility: hidden;
+  transform: translate3d(0,0,0) scale(0.98);
+  opacity: 0;
+}
+
+/* фаза появления */
+.bubble-enter {
+  animation: bubbleEnter 320ms ease-out forwards;
+}
+@keyframes bubbleEnter {
+  from { opacity: 0; transform: translate3d(var(--tx,0), var(--ty,0), 0) scale(0.9); }
+  to   { opacity: 1; transform: translate3d(var(--tx,0), var(--ty,0), 0) scale(1); }
+}
+
+/* лёгкое «покачивание» */
+.bubble-alive {
+  animation: bubbleFloat 3.2s ease-in-out infinite alternate;
+}
+@keyframes bubbleFloat {
+  from { transform: translate3d(calc(var(--tx,0) + -4px), calc(var(--ty,0) + -3px), 0) scale(1); }
+  to   { transform: translate3d(calc(var(--tx,0) + 4px),  calc(var(--ty,0) + 3px),  0) scale(1.01); }
+}
+
+/* фаза исчезновения */
+.bubble-exit {
+  animation: bubbleExit 320ms ease-in forwards;
+}
+@keyframes bubbleExit {
+  from { opacity: 1; filter: none; }
+  to   { opacity: 0; filter: blur(1px); }
+}
+
+/* чуть ниже центра и чуть более выраженный фон */
+.auth-card {
+  margin-top: 10vh;
+  background: rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(10px);
+}
+
+/* Глобально отключаем прокрутку */
+html, body {
+  overflow: hidden;
+}
+
+/* Разрешаем прокрутку ТОЛЬКО в зоне wishlist */
+#screen-wishlist, #screen-wishlist .wl-wrap {
+  max-height: 100svh;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+


### PR DESCRIPTION
## Summary
- add lifecycle-managed floating bubbles background
- darken and lower auth card positioning
- restrict global scrolling except wishlist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68babb9e53cc83328753b454a315999f