### PR TITLE
Ensure message clouds sit behind UI and ignore input

### DIFF
--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -127,7 +127,9 @@ function ensureCloudsRoot() {
   if (fhCloudsRoot?.parentNode) fhCloudsRoot.parentNode.removeChild(fhCloudsRoot);
   fhCloudsRoot = document.createElement('div');
   fhCloudsRoot.id = 'fh-message-clouds';
-  document.body.appendChild(fhCloudsRoot);
+  fhCloudsRoot.setAttribute('aria-hidden', 'true');
+  fhCloudsRoot.style.pointerEvents = 'none';
+  document.body.prepend(fhCloudsRoot);
   return fhCloudsRoot;
 }
 

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -50,17 +50,8 @@ body{
   position: fixed;
   inset: 0;
   pointer-events: none;
-  z-index: 1;            /* было 0 — из-за этого могло не быть видно */
+  z-index: 0;
   overflow: hidden;
-}
-
-/* Любые экраны/оверлеи должны быть выше чипов */
-.screen,
-.menu-deck,
-.auth-card,
-#auth-overlay {
-  position: relative;
-  z-index: 10;
 }
 
 /* Состояния пузыря */
@@ -1008,19 +999,22 @@ html, body {
   overflow-x: hidden; /* чтобы пузырьки не вылезали сбоку */
 }
 
-#fh-message-clouds {
-  position: fixed; /* чтобы покрывал весь экран */
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none; /* чтобы не мешало кликам */
-  z-index: 0;
-}
 /* --- layers / order --- */
-#fh-message-clouds { z-index: 1; }          /* фоновые чипы — самый низ */
-.topbar, .menu-deck, .screen { position: relative; z-index: 10; }
-#auth-overlay, .auth-card, .auth-card-wrap { position: relative; z-index: 20; }
+.topbar,
+.screen,
+.card,
+.panel,
+.menu-deck,
+.auth-card,
+.auth-card-wrap {
+  position: relative;
+  z-index: 10;
+}
+
+#auth-overlay {
+  position: relative;
+  z-index: 20;
+}
 
 /* --- no blur on auth overlay (страница авторизации прозрачная) --- */
 #screen-auth,


### PR DESCRIPTION
## Summary
- insert `#fh-message-clouds` at the start of `<body>` and mark it `aria-hidden` with `pointer-events: none`
- move background cloud layer behind all UI and keep chips absolutely positioned
- raise top-level UI containers above the clouds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bba0315368833297297afc2f58dd04