### PR TITLE
Auth gate + login tabs + background chips; unify asset paths

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -8,8 +8,17 @@
   <link rel="icon"
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
 </head>
-<body>
-  <main class="container" role="main">
+  <body>
+    <nav class="topbar">
+      <a class="logo" href="./">FroggyHub</a>
+      <div class="topbar-right">
+        <a class="btn btn--chip" data-authed href="./hub.html">Меню</a>
+        <a class="btn btn--chip" data-authed href="./profile.html">Профиль</a>
+        <a class="btn btn--chip" data-authed id="btn-logout" href="#">Выйти</a>
+        <a class="btn btn--chip" data-guest  href="./login.html">Войти</a>
+      </div>
+    </nav>
+    <main class="container" role="main">
     <div class="card" id="eventHead">
       <div class="hero">
         <div class="hero-text">

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -8,8 +8,17 @@
   <link rel="icon"
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
 </head>
-<body>
-  <main class="container" role="main">
+  <body>
+    <nav class="topbar">
+      <a class="logo" href="./">FroggyHub</a>
+      <div class="topbar-right">
+        <a class="btn btn--chip" data-authed href="./hub.html">Меню</a>
+        <a class="btn btn--chip" data-authed href="./profile.html">Профиль</a>
+        <a class="btn btn--chip" data-authed id="btn-logout" href="#">Выйти</a>
+        <a class="btn btn--chip" data-guest  href="./login.html">Войти</a>
+      </div>
+    </nav>
+    <main class="container" role="main">
     <form id="editForm" class="card grid edit-form" aria-describedby="editError">
       <h1>Редактировать событие</h1>
       <label>Название

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -8,17 +8,22 @@
   <link rel="icon"
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
 </head>
-<body>
-  <div id="mini-profile" style="position:absolute;top:10px;right:10px;text-align:right;">
-    Ник: <span id="mp-nick"></span>, Создан: <span id="mp-created"></span>
-    <button id="hub-logout" data-logout class="btn btn--ghost btn--sm">Выйти</button>
-  </div>
-  <main class="container" role="main">
+  <body>
+    <nav class="topbar">
+      <a class="logo" href="./">FroggyHub</a>
+      <div class="topbar-right">
+        <a class="btn btn--chip" data-authed href="./hub.html">Меню</a>
+        <a class="btn btn--chip" data-authed href="./profile.html">Профиль</a>
+        <a class="btn btn--chip" data-authed id="btn-logout" href="#">Выйти</a>
+        <a class="btn btn--chip" data-guest  href="./login.html">Войти</a>
+      </div>
+    </nav>
+    <main class="container" role="main">
     <div class="card" style="max-width:760px;margin:40px auto">
       <h1>Хаб</h1>
       <div class="grid">
         <div class="card inner">
-          <a class="btn btn--primary" href="/event-edit.html" data-action="create">Создать событие</a>
+            <a class="btn btn--primary" href="./event-edit.html" data-action="create">Создать событие</a>
         </div>
         <div class="card inner">
           <h3>Войти в ивент</h3>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -37,15 +37,15 @@
 </head>
 <body>
 
-  <!-- Топ-бар -->
-  <header class="topbar">
-    <a href="#" class="logo fh-logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <a href="#" class="btn btn--chip" data-link="menu">Меню</a>
-      <a href="#" class="btn btn--chip" data-link="profile">Профиль</a>
-      <button id="btnLogout" class="btn btn--chip">Выйти</button>
-    </div>
-  </header>
+    <nav class="topbar">
+      <a class="logo" href="./">FroggyHub</a>
+      <div class="topbar-right">
+        <a class="btn btn--chip" data-authed href="./hub.html">Меню</a>
+        <a class="btn btn--chip" data-authed href="./profile.html">Профиль</a>
+        <a class="btn btn--chip" data-authed id="btn-logout" href="#">Выйти</a>
+        <a class="btn btn--chip" data-guest  href="./login.html">Войти</a>
+      </div>
+    </nav>
 
   <!-- Фоновые “смски” -->
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -1,164 +1,89 @@
-// FroggyHub/js/app.js
-import {
-  supa, getSession, onAuthState,
-  signIn, signUpWithNickname, resetPassword,
-  signOut, getProfile
-} from './api.js';
+import { getSession, signOut, signIn, signUpWithNickname, resetPassword } from './api.js';
 
-// ====== простая система экранов ======
-function showScreen(id) {
-  document.querySelectorAll('.screen').forEach(s => s.classList.remove('visible'));
-  const el = document.getElementById(id);
-  if (el) el.classList.add('visible');
+/* --- auth gate --- */
+function setAuthed(on){
+  document.body.classList.toggle('authed', !!on);
+  document.body.classList.toggle('guest', !on);
+}
+async function gate(){
+  try{
+    const sess = await getSession();
+    setAuthed(!!sess);
+
+    const here = (location.pathname.split('/').pop() || '').toLowerCase();
+    const isLogin = here === '' || here === 'index.html' || here === 'login.html';
+
+    if (!sess && !isLogin) location.href = './login.html';
+    if (sess && isLogin)  location.href = './lobby.html';
+  }catch(e){
+    setAuthed(false);
+  }
 }
 
-// data-link навигация (между разделами одной страницы)
-const linkMap = {
-  home: 'screen-home',
-  menu: 'screen-home',
-  auth: 'screen-auth',
-  profile: 'screen-profile',
-  hub: 'screen-home',
-  settings: 'screen-home'
-};
-document.addEventListener('click', (e) => {
-  const a = e.target.closest('[data-link]');
+/* logout */
+document.addEventListener('click', (e)=>{
+  const a = e.target.closest('#btn-logout');
   if (!a) return;
   e.preventDefault();
-  const key = a.getAttribute('data-link');
-  const target = linkMap[key] || key;
-  showScreen(target);
+  signOut()?.finally(()=>location.href='./');
 });
 
-// ====== auth UI ======
-function wireAuthTabs() {
-  const tabs = document.querySelectorAll('[data-auth-tab]');
-  const panes = {
-    login: document.getElementById('paneLogin'),
-    signup: document.getElementById('paneSignup'),
-    reset: document.getElementById('paneReset')
-  };
-  tabs.forEach(t => {
-    t.addEventListener('click', () => {
-      tabs.forEach(x => x.classList.remove('active'));
-      t.classList.add('active');
-      const key = t.getAttribute('data-auth-tab');
-      Object.entries(panes).forEach(([k, el]) => el?.classList.toggle('is-hidden', k !== key));
-    });
-  });
-}
+/* --- tabs on login page --- */
+document.addEventListener('click', (e)=>{
+  const btn = e.target.closest('[data-tab]');
+  if (!btn) return;
+  document.querySelectorAll('.tab').forEach(t=>t.classList.toggle('active', t===btn));
+  const key = btn.dataset.tab;
+  document.querySelectorAll('[data-pane]').forEach(p=>p.hidden = (p.dataset.pane !== key));
+});
 
-function wireAuthForms() {
-  // login
-  const fLogin = document.getElementById('formLogin');
-  fLogin?.addEventListener('submit', async (e) => {
+/* --- forms --- */
+document.addEventListener('submit', async (e)=>{
+  // Login
+  if (e.target.id === 'formLogin'){
     e.preventDefault();
-    const login = fLogin.login.value.trim();
-    const password = fLogin.password.value;
-    try {
-      await signIn({ login, password });
-      await afterAuthSuccess();
-    } catch (err) {
-      showFieldError(fLogin, err);
-    }
-  });
-
-  // signup
-  const fSignup = document.getElementById('formSignup');
-  fSignup?.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const nickname = fSignup.nickname.value.trim();
-    const email = fSignup.email.value.trim();
-    const password = fSignup.password.value;
-    try {
-      await signUpWithNickname({ nickname, email, password });
-      await afterAuthSuccess();
-    } catch (err) {
-      showFieldError(fSignup, err);
-    }
-  });
-
-  // reset
-  const fReset = document.getElementById('formReset');
-  fReset?.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const email = fReset.email.value.trim();
-    try {
-      await resetPassword(email);
-      fReset.querySelector('.form-success')?.classList.remove('is-hidden');
-    } catch (err) {
-      showFieldError(fReset, err);
-    }
-  });
-
-  // logout (в хэдэре)
-  document.getElementById('btnLogout')?.addEventListener('click', async () => {
-    await signOut();
-    showScreen('screen-auth');
-  });
-}
-
-function showFieldError(form, err) {
-  const box = form.querySelector('.form-error');
-  if (box) {
-    box.textContent = err?.message || 'Ошибка';
-    box.classList.remove('is-hidden');
-  } else {
-    alert(err?.message || 'Ошибка');
-  }
-}
-
-async function afterAuthSuccess() {
-  const p = await getProfile().catch(() => null);
-  renderProfile(p);
-  showScreen('screen-home');
-}
-
-// ====== профиль ======
-function renderProfile(p) {
-  const nick = document.getElementById('profNick');
-  const created = document.getElementById('profCreated');
-  nick && (nick.textContent = p?.nickname || '—');
-  created && (created.textContent = p?.created_at ? new Date(p.created_at).toLocaleString() : '—');
-}
-
-// ====== старт приложения ======
-async function boot() {
-  wireAuthTabs();
-  wireAuthForms();
-  placeMessageCloudsBehind();
-
-  // если supa не настроен — показываем auth-экран (пустая форма), но без реального сабмита
-  const session = await getSession();
-  if (session) {
-    // профиль и меню
-    try {
-      const p = await getProfile().catch(() => null);
-      renderProfile(p);
-    } catch {}
-    showScreen('screen-home');
-  } else {
-    showScreen('screen-auth');
+    const login = document.getElementById('loginLogin').value.trim();
+    const password = document.getElementById('loginPassword').value;
+    const out = document.getElementById('loginErr'); out.textContent='';
+    try{
+      const { error } = await signIn({ login, password });
+      if (error) throw error;
+      location.href='./lobby.html';
+    }catch(err){ out.textContent = err.message || 'Не удалось войти'; }
   }
 
-  // реакция на смену авторизации
-  onAuthState(async (sess) => {
-    if (sess) {
-      const p = await getProfile().catch(() => null);
-      renderProfile(p);
-      showScreen('screen-home');
-    } else {
-      showScreen('screen-auth');
-    }
-  });
-}
+  // Signup
+  if (e.target.id === 'formSignup'){
+    e.preventDefault();
+    const nickname = document.getElementById('suNickname').value.trim();
+    const email    = document.getElementById('suEmail').value.trim();
+    const password = document.getElementById('suPass').value;
+    const out = document.getElementById('signupErr'); out.textContent='';
+    try{
+      const { error } = await signUpWithNickname({ nickname, email, password });
+      if (error) throw error;
+      location.href='./lobby.html';
+    }catch(err){ out.textContent = err.message || 'Регистрация не удалась'; }
+  }
 
-document.addEventListener('DOMContentLoaded', boot);
+  // Reset
+  if (e.target.id === 'formReset'){
+    e.preventDefault();
+    const email = document.getElementById('rpEmail').value.trim();
+    const ok = document.getElementById('resetOk'); const err = document.getElementById('resetErr');
+    ok.textContent = err.textContent = '';
+    try{
+      const { error } = await resetPassword(email);
+      if (error) throw error;
+      ok.textContent = 'Письмо отправлено ✉️';
+    }catch(ex){ err.textContent = ex.message || 'Не удалось отправить письмо'; }
+  }
+});
 
-// ====== фоновые чипы (смски) — всегда позади и не перехватывают клики ======
+/* --- message chips --- */
 const FH_MESSAGES = [
   'Я приду к 19:00 ✨','Я возьму пиццу 🍕','Кто возьмёт колу? 🥤','Буду позже 🙈',
-  'Добавил плейлист 🎶','Я за хлебом 🍞','Кто за лимонадом? 🍋','Увидимся у входа 🚪',
+  'Добавил плейлист 🎶','Я за хлебом 🍞','Кто за лимнадом? 🍋','Увидимся у входа 🚪',
   'Зайду за напитками 🍻','Давайте фильм посмотрим 🎬','Встречаемся у метро 🚉'
 ];
 
@@ -186,3 +111,8 @@ function placeMessageCloudsBehind() {
     root.appendChild(el);
   });
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  gate();
+  placeMessageCloudsBehind();
+});

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -10,7 +10,7 @@
   <style>
     .fh-bg {
       position: fixed; inset: 0; z-index: 0;
-      background: #0b241b url("/assets/froggy_glass_bg.jpeg") center 45% / cover no-repeat;
+      background: #0b241b url("./assets/froggy_glass_bg.jpeg") center 45% / cover no-repeat;
     }
     @media (min-width: 640px) {
       .fh-bg { background-position: center; }
@@ -25,14 +25,15 @@
   <div class="fh-bg" aria-hidden="true"></div>
   <div id="fh-message-clouds" aria-hidden="true"></div>
   <div class="fh-content">
-    <header class="fh-header">
-      <a class="fh-logo" href="/">FroggyHub</a>
-      <nav class="topbar">
-        <a href="/" class="btn btn--ghost btn--sm">Меню</a>
-        <a href="/profile.html" class="btn btn--ghost btn--sm">Профиль</a>
-        <button id="logoutBtn" data-logout class="btn btn--ghost btn--sm">Выйти</button>
-      </nav>
-    </header>
+    <nav class="topbar">
+      <a class="logo" href="./">FroggyHub</a>
+      <div class="topbar-right">
+        <a class="btn btn--chip" data-authed href="./hub.html">Меню</a>
+        <a class="btn btn--chip" data-authed href="./profile.html">Профиль</a>
+        <a class="btn btn--chip" data-authed id="btn-logout" href="#">Выйти</a>
+        <a class="btn btn--chip" data-guest  href="./login.html">Войти</a>
+      </div>
+    </nav>
 
   <main class="lobby-grid">
     <!-- Левая колонка: лягушка + счётчик -->
@@ -75,7 +76,7 @@
       </div>
 
       <div class="actions">
-        <a class="btn btn--ghost" href="/index.html">Вернуться в меню</a>
+        <a class="btn btn--ghost" href="./index.html">Вернуться в меню</a>
       </div>
     </section>
   </main>

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -9,20 +9,52 @@
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
 </head>
 <body>
-  <div class="container" role="main">
-    <div class="card" style="max-width:480px;margin:40px auto">
-      <h1>Вход</h1>
-      <form id="login-form" class="grid" novalidate onsubmit="handleLogin(event)">
-        <label>Никнейм
-          <input id="login-nickname" type="text" autocomplete="username" required />
-        </label>
-        <label>Пароль
-          <input id="login-password" type="password" autocomplete="current-password" required />
-        </label>
-        <button class="btn btn--primary" type="submit">Войти</button>
-      </form>
+  <nav class="topbar">
+    <a class="logo" href="./">FroggyHub</a>
+    <div class="topbar-right">
+      <a class="btn btn--chip" data-authed href="./hub.html">Меню</a>
+      <a class="btn btn--chip" data-authed href="./profile.html">Профиль</a>
+      <a class="btn btn--chip" data-authed id="btn-logout" href="#">Выйти</a>
+      <a class="btn btn--chip" data-guest  href="./login.html">Войти</a>
     </div>
-  </div>
+  </nav>
+  <main class="container" role="main">
+    <div class="auth-card auth-card-wrap">
+      <div class="tabs" role="tablist">
+        <button class="tab active" data-tab="login"  role="tab">Вход</button>
+        <button class="tab"         data-tab="signup" role="tab">Регистрация</button>
+        <button class="tab"         data-tab="reset"  role="tab">Сброс</button>
+      </div>
+
+      <section data-pane="login">
+        <form id="formLogin" class="stack">
+          <input id="loginLogin"    autocomplete="username" placeholder="Email или ник" required>
+          <input id="loginPassword" type="password" autocomplete="current-password" placeholder="Пароль" required>
+          <button class="btn btn--primary">Войти</button>
+          <p id="loginErr" class="error" aria-live="polite"></p>
+        </form>
+      </section>
+
+      <section data-pane="signup" hidden>
+        <form id="formSignup" class="stack">
+          <input id="suNickname" required placeholder="Никнейм">
+          <input id="suEmail"    type="email" required placeholder="Email">
+          <input id="suPass"     type="password" required placeholder="Пароль">
+          <button class="btn btn--primary">Создать аккаунт</button>
+          <p id="signupErr" class="error" aria-live="polite"></p>
+        </form>
+      </section>
+
+      <section data-pane="reset" hidden>
+        <form id="formReset" class="stack">
+          <input id="rpEmail" type="email" required placeholder="Email">
+          <button class="btn btn--primary">Отправить ссылку</button>
+          <p id="resetOk" class="hint"></p>
+          <p id="resetErr" class="error" aria-live="polite"></p>
+        </form>
+      </section>
+    </div>
+  </main>
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -8,16 +8,24 @@
   <link rel="icon"
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
 </head>
-<body>
-  <main class="container" role="main">
-    <div class="card" style="max-width:480px;margin:40px auto">
-      <a href="/lobby.html" style="text-decoration:none;color:inherit;display:inline-block;margin-bottom:12px">← В лобби</a>
-      <h1>Профиль</h1>
-      <p>Никнейм: <strong id="profile-nickname"></strong></p>
-      <p>Создан: <span id="profile-created"></span></p>
-      <button type="button" class="btn btn--ghost" id="btn-logout" data-logout>Выйти</button>
-    </div>
-  </main>
+  <body>
+    <nav class="topbar">
+      <a class="logo" href="./">FroggyHub</a>
+      <div class="topbar-right">
+        <a class="btn btn--chip" data-authed href="./hub.html">Меню</a>
+        <a class="btn btn--chip" data-authed href="./profile.html">Профиль</a>
+        <a class="btn btn--chip" data-authed id="btn-logout" href="#">Выйти</a>
+        <a class="btn btn--chip" data-guest  href="./login.html">Войти</a>
+      </div>
+    </nav>
+    <main class="container" role="main">
+      <div class="card" style="max-width:480px;margin:40px auto">
+        <a href="./lobby.html" style="text-decoration:none;color:inherit;display:inline-block;margin-bottom:12px">← В лобби</a>
+        <h1>Профиль</h1>
+        <p>Никнейм: <strong id="profile-nickname"></strong></p>
+        <p>Создан: <span id="profile-created"></span></p>
+      </div>
+    </main>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -1030,3 +1030,22 @@ html, body {
 /* фоновые чипы по умолчанию невидимы, пока не расставим координаты */
 #fh-message-clouds .fh-chip { visibility: hidden; }
 #fh-message-clouds .fh-chip.is-placed { visibility: visible; }
+/* ---- auth gate ---- */
+body.guest [data-authed]{ display:none !important; }
+body.authed [data-guest]{ display:none !important; }
+
+/* фоновые чипы позади UI */
+#fh-message-clouds{
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+#fh-message-clouds .fh-chip{ position:absolute; }
+
+/* любой основной UI выше чипов */
+.topbar, .screen, .panel, .card, .menu-deck, .auth-card, .auth-card-wrap {
+  position: relative;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary
- Hide authed buttons behind `body.authed` while guests see only "Войти"
- Add login/signup/reset tabs with Supabase handlers and redirects
- Keep floating message chips behind UI and standardize asset paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbc9fcca088332bcc97adb1dab3b3b