### PR TITLE
refactor: unify auth gate and asset links

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -4,21 +4,19 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Аналитика события</title>
-  <link rel="stylesheet" href="./style.css" />
-  <link rel="icon"
-        href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
+  <link rel="stylesheet" href="./style.css">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
 </head>
-<body class="guest">
-  <header class="topbar">
+<body class="authed">
+  <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
-      <button class="guest-only" data-link="login">Войти</button>
-      <button class="authed-only" data-link="menu">Меню</button>
-      <button class="authed-only" data-link="profile">Профиль</button>
-      <button class="authed-only" data-action="logout">Выйти</button>
+      <button data-link="menu">Меню</button>
+      <button data-link="profile">Профиль</button>
+      <button data-action="logout">Выйти</button>
     </div>
   </header>
-  <main class="container" role="main">
+  <main class="container" role="main" data-auth-only>
     <div class="card" id="eventHead">
       <div class="hero">
         <div class="hero-text">
@@ -68,7 +66,7 @@
 
     <p id="error" class="error" role="status" aria-live="polite"></p>
   </main>
-  <div id="cookieCard" class="card" style="display:none">
+  <div id="cookieCard" class="card" style="display:none" data-auth-only>
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
     </svg>
@@ -81,7 +79,7 @@
       <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
     </div>
   </div>
-  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden data-auth-only></div>
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -4,22 +4,20 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Редактирование события</title>
-  <link rel="stylesheet" href="./style.css" />
-  <link rel="icon"
-        href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
+  <link rel="stylesheet" href="./style.css">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
 </head>
-<body class="guest">
-  <header class="topbar">
+<body class="authed">
+  <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
-      <button class="guest-only" data-link="login">Войти</button>
-      <button class="authed-only" data-link="menu">Меню</button>
-      <button class="authed-only" data-link="profile">Профиль</button>
-      <button class="authed-only" data-action="logout">Выйти</button>
+      <button data-link="menu">Меню</button>
+      <button data-link="profile">Профиль</button>
+      <button data-action="logout">Выйти</button>
     </div>
   </header>
 
-  <main class="container" role="main">
+  <main class="container" role="main" data-auth-only>
     <form id="editForm" class="card grid edit-form" aria-describedby="editError">
       <h1>Редактировать событие</h1>
       <label>Название
@@ -49,7 +47,7 @@
     </form>
     <p id="editError" class="error" role="status" aria-live="polite"></p>
   </main>
-  <div id="cookieCard" class="card" style="display:none">
+  <div id="cookieCard" class="card" style="display:none" data-auth-only>
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
     </svg>
@@ -62,7 +60,7 @@
       <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
     </div>
   </div>
-  <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
+  <div id="toast" class="toast" role="status" aria-live="polite" hidden data-auth-only></div>
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -4,20 +4,19 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Хаб — FroggyHub</title>
-  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="./style.css">
 </head>
-<body class="guest">
-  <header class="topbar">
+<body class="authed">
+  <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
-      <button class="guest-only" data-link="login">Войти</button>
-      <button class="authed-only" data-link="menu">Меню</button>
-      <button class="authed-only" data-link="profile">Профиль</button>
-      <button class="authed-only" data-action="logout">Выйти</button>
+      <button data-link="menu">Меню</button>
+      <button data-link="profile">Профиль</button>
+      <button data-action="logout">Выйти</button>
     </div>
   </header>
 
-  <main class="fh-content">
+  <main class="fh-content" data-auth-only>
     <div class="container">
       <h2>Мои события</h2>
       <div id="my-events" class="event-grid"></div>
@@ -27,4 +26,3 @@
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>
-

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -4,53 +4,47 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>FroggyHub</title>
-  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body class="guest">
-  <header class="topbar">
+  <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
-      <button class="guest-only" data-link="login">Войти</button>
-      <button class="authed-only" data-link="menu">Меню</button>
-      <button class="authed-only" data-link="profile">Профиль</button>
-      <button class="authed-only" data-action="logout">Выйти</button>
+      <button data-link="menu">Меню</button>
+      <button data-link="profile">Профиль</button>
+      <button data-action="logout">Выйти</button>
     </div>
   </header>
 
-  <main class="fh-content">
-    <section class="auth-card-wrap">
-      <div class="auth-card">
-        <div class="tabs">
-          <div class="tab is-active" data-tab="login">Вход</div>
-          <div class="tab" data-tab="signup">Регистрация</div>
-          <div class="tab" data-tab="reset">Сброс</div>
-        </div>
+  <main class="auth-card" data-guest-only>
+    <div class="tabs">
+      <div class="tab is-active" data-tab="login">Вход</div>
+      <div class="tab" data-tab="signup">Регистрация</div>
+      <div class="tab" data-tab="reset">Сброс</div>
+    </div>
 
-        <div id="paneLogin" class="auth-pane visible">
-          <input id="loginLogin" type="text" placeholder="Email или ник" required />
-          <input id="loginPassword" type="password" placeholder="Пароль" required />
-          <button id="btnLogin" class="btn btn--primary w-full">Войти</button>
-          <div id="loginError" class="form-error"></div>
-        </div>
+    <div id="paneLogin" class="auth-pane visible">
+      <input id="loginLogin" type="text" placeholder="Email или ник" required />
+      <input id="loginPassword" type="password" placeholder="Пароль" required />
+      <button id="btnLogin" class="btn btn--primary w-full">Войти</button>
+      <div id="loginError" class="form-error"></div>
+    </div>
 
-        <div id="paneSignup" class="auth-pane">
-          <input id="signupNickname" type="text" placeholder="Никнейм" required />
-          <input id="signupEmail" type="email" placeholder="Email" required />
-          <input id="signupPassword" type="password" placeholder="Пароль" required />
-          <button id="btnSignup" class="btn btn--primary w-full">Зарегистрироваться</button>
-          <div id="signupError" class="form-error"></div>
-        </div>
+    <div id="paneSignup" class="auth-pane">
+      <input id="signupNickname" type="text" placeholder="Никнейм" required />
+      <input id="signupEmail" type="email" placeholder="Email" required />
+      <input id="signupPassword" type="password" placeholder="Пароль" required />
+      <button id="btnSignup" class="btn btn--primary w-full">Зарегистрироваться</button>
+      <div id="signupError" class="form-error"></div>
+    </div>
 
-        <div id="paneReset" class="auth-pane">
-          <input id="resetEmail" type="email" placeholder="Email" required />
-          <button id="btnReset" class="btn btn--primary w-full">Сбросить пароль</button>
-          <div id="resetError" class="form-error"></div>
-        </div>
-      </div>
-    </section>
+    <div id="paneReset" class="auth-pane">
+      <input id="resetEmail" type="email" placeholder="Email" required />
+      <button id="btnReset" class="btn btn--primary w-full">Сбросить пароль</button>
+      <div id="resetError" class="form-error"></div>
+    </div>
   </main>
 
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>
-

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -23,12 +23,13 @@ const FH = {
   MAX: 20, MARGIN: 20, PLACE_TRIES: 40, MIN_DIST: 120,
   MIN_V: .045, MAX_V: .09, JITTER: .00012, KICK: .12
 };
-let chips = [], animId = 0;
+let chips = [], animId = 0, chipsSpawned = false;
 function rand(a,b){return Math.random()*(b-a)+a}
 function clamp(v,a,b){return Math.min(Math.max(v,a),b)}
 function spawnChips(){
+  if (chipsSpawned) return;
+  chipsSpawned = true;
   const root = ensureCloudsRoot();
-  if (chips.length) return startFloat();
   const pool = [...FH_MESSAGES];
   for(let i=pool.length-1;i>0;i--){const j=(Math.random()*(i+1))|0; [pool[i],pool[j]]=[pool[j],pool[i]]}
   const list = pool.slice(0,FH.MAX);
@@ -210,19 +211,28 @@ document.addEventListener('click', async (e) => {
   }
 });
 
+function handleAuth(session) {
+  const authed = !!session;
+  document.body.classList.toggle('authed', authed);
+  document.body.classList.toggle('guest', !authed);
+  const page = location.pathname.split('/').pop();
+  const guestPages = ['index.html','login.html',''];
+  if (authed && guestPages.includes(page)) {
+    location.href = 'lobby.html';
+  } else if (!authed && !guestPages.includes(page)) {
+    location.href = 'index.html';
+  }
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
-  try { ensureCloudsRoot(); spawnChips(); } catch {}
+  try { spawnChips(); } catch {}
   try {
     const session = await getSession();
-    document.body.classList.toggle('authed', !!session);
-    document.body.classList.toggle('guest', !session);
+    handleAuth(session);
   } catch {
-    document.body.classList.add('guest');
+    handleAuth(null);
   }
 });
 
-onAuthState?.((session) => {
-  document.body.classList.toggle('authed', !!session);
-  document.body.classList.toggle('guest', !session);
-});
 
+onAuthState?.(handleAuth);

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -4,20 +4,19 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Лобби — FroggyHub</title>
-  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="./style.css">
 </head>
-<body class="guest">
-  <header class="topbar">
+<body class="authed">
+  <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
-      <button class="guest-only" data-link="login">Войти</button>
-      <button class="authed-only" data-link="menu">Меню</button>
-      <button class="authed-only" data-link="profile">Профиль</button>
-      <button class="authed-only" data-action="logout">Выйти</button>
+      <button data-link="menu">Меню</button>
+      <button data-link="profile">Профиль</button>
+      <button data-action="logout">Выйти</button>
     </div>
   </header>
 
-  <main class="fh-content">
+  <main class="fh-content" data-auth-only>
     <div class="container">
       <div class="menu-grid">
         <button data-link="event-edit" class="btn btn--primary">Создать событие</button>
@@ -32,4 +31,3 @@
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>
-

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -4,53 +4,47 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Вход — FroggyHub</title>
-  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="./style.css">
 </head>
 <body class="guest">
-  <header class="topbar">
+  <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
-      <button class="guest-only" data-link="login">Войти</button>
-      <button class="authed-only" data-link="menu">Меню</button>
-      <button class="authed-only" data-link="profile">Профиль</button>
-      <button class="authed-only" data-action="logout">Выйти</button>
+      <button data-link="menu">Меню</button>
+      <button data-link="profile">Профиль</button>
+      <button data-action="logout">Выйти</button>
     </div>
   </header>
 
-  <main class="fh-content">
-    <section class="auth-card-wrap">
-      <div class="auth-card">
-        <div class="tabs">
-          <div class="tab is-active" data-tab="login">Вход</div>
-          <div class="tab" data-tab="signup">Регистрация</div>
-          <div class="tab" data-tab="reset">Сброс</div>
-        </div>
+  <main class="auth-card" data-guest-only>
+    <div class="tabs">
+      <div class="tab is-active" data-tab="login">Вход</div>
+      <div class="tab" data-tab="signup">Регистрация</div>
+      <div class="tab" data-tab="reset">Сброс</div>
+    </div>
 
-        <div id="paneLogin" class="auth-pane visible">
-          <input id="loginLogin" type="text" placeholder="Email или ник" required />
-          <input id="loginPassword" type="password" placeholder="Пароль" required />
-          <button id="btnLogin" class="btn btn--primary w-full">Войти</button>
-          <div id="loginError" class="form-error"></div>
-        </div>
+    <div id="paneLogin" class="auth-pane visible">
+      <input id="loginLogin" type="text" placeholder="Email или ник" required />
+      <input id="loginPassword" type="password" placeholder="Пароль" required />
+      <button id="btnLogin" class="btn btn--primary w-full">Войти</button>
+      <div id="loginError" class="form-error"></div>
+    </div>
 
-        <div id="paneSignup" class="auth-pane">
-          <input id="signupNickname" type="text" placeholder="Никнейм" required />
-          <input id="signupEmail" type="email" placeholder="Email" required />
-          <input id="signupPassword" type="password" placeholder="Пароль" required />
-          <button id="btnSignup" class="btn btn--primary w-full">Зарегистрироваться</button>
-          <div id="signupError" class="form-error"></div>
-        </div>
+    <div id="paneSignup" class="auth-pane">
+      <input id="signupNickname" type="text" placeholder="Никнейм" required />
+      <input id="signupEmail" type="email" placeholder="Email" required />
+      <input id="signupPassword" type="password" placeholder="Пароль" required />
+      <button id="btnSignup" class="btn btn--primary w-full">Зарегистрироваться</button>
+      <div id="signupError" class="form-error"></div>
+    </div>
 
-        <div id="paneReset" class="auth-pane">
-          <input id="resetEmail" type="email" placeholder="Email" required />
-          <button id="btnReset" class="btn btn--primary w-full">Сбросить пароль</button>
-          <div id="resetError" class="form-error"></div>
-        </div>
-      </div>
-    </section>
+    <div id="paneReset" class="auth-pane">
+      <input id="resetEmail" type="email" placeholder="Email" required />
+      <button id="btnReset" class="btn btn--primary w-full">Сбросить пароль</button>
+      <div id="resetError" class="form-error"></div>
+    </div>
   </main>
 
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>
-

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -4,20 +4,19 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Профиль — FroggyHub</title>
-  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="./style.css">
 </head>
-<body class="guest">
-  <header class="topbar">
+<body class="authed">
+  <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
-      <button class="guest-only" data-link="login">Войти</button>
-      <button class="authed-only" data-link="menu">Меню</button>
-      <button class="authed-only" data-link="profile">Профиль</button>
-      <button class="authed-only" data-action="logout">Выйти</button>
+      <button data-link="menu">Меню</button>
+      <button data-link="profile">Профиль</button>
+      <button data-action="logout">Выйти</button>
     </div>
   </header>
 
-  <main class="fh-content">
+  <main class="fh-content" data-auth-only>
     <div class="container">
       <div class="card">
         <h2>Профиль</h2>
@@ -31,4 +30,3 @@
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>
-

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -1032,8 +1032,6 @@ html, body {
 #fh-message-clouds .fh-chip.is-placed { visibility: visible; }
 
 /* --- auth gate visibility --- */
-body.guest .authed-only { display: none !important; }
-body.authed .guest-only { display: none !important; }
 
 /* --- message chips layer (behind UI) --- */
 #fh-message-clouds {
@@ -1044,3 +1042,7 @@ body.authed .guest-only { display: none !important; }
   overflow: hidden;
 }
 #fh-message-clouds .fh-chip { position: absolute; }
+
+body.guest [data-auth-only] { display:none !important; }
+body.authed [data-guest-only] { display:none !important; }
+


### PR DESCRIPTION
## Summary
- standardize HTML pages to use relative asset links and auth gate attributes
- centralize Supabase auth flow with redirects and background message chips
- hide guest/authed sections via CSS and spawn chat chips once behind UI

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbd24d7a5c8332a90f658023c52f18