### PR TITLE
refactor: simplify auth tabs

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -17,34 +17,31 @@
   </header>
 
   <main class="auth-card" data-guest-only>
-    <div class="tabs">
-      <div class="tab is-active" data-tab="login">Вход</div>
-      <div class="tab" data-tab="signup">Регистрация</div>
-      <div class="tab" data-tab="reset">Сброс</div>
-    </div>
+    <nav class="auth-tabs" data-guest-only>
+      <button type="button" class="tab is-active" data-tab="login">Вход</button>
+      <button type="button" class="tab" data-tab="signup">Регистрация</button>
+    </nav>
 
-    <div id="paneLogin" class="auth-pane visible">
-      <input id="loginLogin" type="text" placeholder="Email или ник" required />
-      <input id="loginPassword" type="password" placeholder="Пароль" required />
-      <button id="btnLogin" class="btn btn--primary w-full">Войти</button>
-      <div id="loginError" class="form-error"></div>
-    </div>
+    <form id="formLogin" class="auth-pane" data-pane="login" data-guest-only>
+      <label for="loginNickname">Никнейм</label>
+      <input id="loginNickname" name="nickname" autocomplete="username" required />
+      <label for="loginPassword">Пароль</label>
+      <input id="loginPassword" name="password" type="password" autocomplete="current-password" required />
+      <button id="btnLogin" class="btn btn--primary" type="submit">Войти</button>
+    </form>
 
-    <div id="paneSignup" class="auth-pane">
-      <input id="signupNickname" type="text" placeholder="Никнейм" required />
-      <input id="signupEmail" type="email" placeholder="Email" required />
-      <input id="signupPassword" type="password" placeholder="Пароль" required />
-      <button id="btnSignup" class="btn btn--primary w-full">Зарегистрироваться</button>
-      <div id="signupError" class="form-error"></div>
-    </div>
-
-    <div id="paneReset" class="auth-pane">
-      <input id="resetEmail" type="email" placeholder="Email" required />
-      <button id="btnReset" class="btn btn--primary w-full">Сбросить пароль</button>
-      <div id="resetError" class="form-error"></div>
-    </div>
+    <form id="formSignup" class="auth-pane is-hidden" data-pane="signup" data-guest-only>
+      <label for="signupNickname">Никнейм</label>
+      <input id="signupNickname" name="nickname" required />
+      <label for="signupEmail">Email</label>
+      <input id="signupEmail" name="email" type="email" autocomplete="email" required />
+      <label for="signupPassword">Пароль</label>
+      <input id="signupPassword" name="password" type="password" autocomplete="new-password" required />
+      <button id="btnSignup" class="btn btn--primary" type="submit">Зарегистрироваться</button>
+    </form>
   </main>
 
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -1,4 +1,4 @@
-import { signIn, signUpWithNickname, resetPassword, signOut, getSession, onAuthState, joinEvent } from './api.js';
+import { supa, signIn, signUpWithNickname, signOut, getSession, onAuthState, joinEvent } from './api.js';
 
 let fhCloudsRoot;
 function ensureCloudsRoot() {
@@ -126,58 +126,39 @@ document.addEventListener('click', (e) => {
 });
 
 // ===== Auth handlers =====
-async function handleLogin() {
-  const login = document.querySelector('#loginLogin')?.value?.trim();
-  const password = document.querySelector('#loginPassword')?.value;
-  const err = document.querySelector('#loginError');
-  if (!login || !password) return err && (err.textContent = 'Заполните поля');
-  err && (err.textContent = '');
+const tabs = document.querySelectorAll('.auth-tabs .tab');
+const panes = document.querySelectorAll('.auth-pane[data-guest-only]');
+tabs.forEach(t => t.addEventListener('click', () => {
+  tabs.forEach(x => x.classList.toggle('is-active', x === t));
+  const key = t.dataset.tab;
+  panes.forEach(p => p.classList.toggle('is-hidden', p.dataset.pane !== key));
+}));
+
+document.getElementById('formLogin')?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const nickname = document.getElementById('loginNickname').value.trim();
+  const password = document.getElementById('loginPassword').value;
   try {
-    const { data, error } = await signIn({ login, password });
+    const { data, error } = await signIn({ login: nickname, password });
     if (error) throw error;
-    location.href = 'lobby.html';
-  } catch (e) {
-    err && (err.textContent = e.message || 'Ошибка входа');
+    location.href = './lobby.html';
+  } catch (err) {
+    console.warn('[login]', err);
   }
-}
-document.addEventListener('click', (e) => {
-  if (e.target?.id === 'btnLogin') handleLogin();
 });
 
-async function handleSignup() {
-  const nickname = document.querySelector('#signupNickname')?.value?.trim();
-  const email    = document.querySelector('#signupEmail')?.value?.trim();
-  const password = document.querySelector('#signupPassword')?.value;
-  const err = document.querySelector('#signupError');
-  if (!nickname || !email || !password) return err && (err.textContent = 'Заполните поля');
-  err && (err.textContent = '');
+document.getElementById('formSignup')?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const nickname = document.getElementById('signupNickname').value.trim();
+  const email = document.getElementById('signupEmail').value.trim();
+  const password = document.getElementById('signupPassword').value;
   try {
     const { data, error } = await signUpWithNickname({ nickname, email, password });
     if (error) throw error;
-    location.href = 'lobby.html';
-  } catch (e) {
-    err && (err.textContent = e.message || 'Ошибка регистрации');
+    document.querySelector('.auth-tabs .tab[data-tab="login"]')?.click();
+  } catch (err) {
+    console.warn('[signup]', err);
   }
-}
-document.addEventListener('click', (e) => {
-  if (e.target?.id === 'btnSignup') handleSignup();
-});
-
-async function handleReset() {
-  const email = document.querySelector('#resetEmail')?.value?.trim();
-  const err = document.querySelector('#resetError');
-  if (!email) return err && (err.textContent = 'Укажите email');
-  err && (err.textContent = '');
-  try {
-    const { data, error } = await resetPassword(email);
-    if (error) throw error;
-    err && (err.textContent = 'Письмо отправлено, проверьте почту');
-  } catch (e) {
-    err && (err.textContent = e.message || 'Ошибка сброса');
-  }
-}
-document.addEventListener('click', (e) => {
-  if (e.target?.id === 'btnReset') handleReset();
 });
 
 document.addEventListener('click', (e) => {
@@ -185,14 +166,6 @@ document.addEventListener('click', (e) => {
     e.preventDefault();
     signOut()?.finally(() => location.href = 'index.html');
   }
-});
-
-document.addEventListener('click', (e) => {
-  const tab = e.target.closest('.tab[data-tab]');
-  if (!tab) return;
-  const name = tab.dataset.tab;
-  document.querySelectorAll('.tab').forEach(t => t.classList.toggle('is-active', t === tab));
-  document.querySelectorAll('.auth-pane').forEach(p => p.classList.toggle('visible', p.id.toLowerCase().includes(name)));
 });
 
 document.addEventListener('click', async (e) => {

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -17,34 +17,31 @@
   </header>
 
   <main class="auth-card" data-guest-only>
-    <div class="tabs">
-      <div class="tab is-active" data-tab="login">Вход</div>
-      <div class="tab" data-tab="signup">Регистрация</div>
-      <div class="tab" data-tab="reset">Сброс</div>
-    </div>
+    <nav class="auth-tabs" data-guest-only>
+      <button type="button" class="tab is-active" data-tab="login">Вход</button>
+      <button type="button" class="tab" data-tab="signup">Регистрация</button>
+    </nav>
 
-    <div id="paneLogin" class="auth-pane visible">
-      <input id="loginLogin" type="text" placeholder="Email или ник" required />
-      <input id="loginPassword" type="password" placeholder="Пароль" required />
-      <button id="btnLogin" class="btn btn--primary w-full">Войти</button>
-      <div id="loginError" class="form-error"></div>
-    </div>
+    <form id="formLogin" class="auth-pane" data-pane="login" data-guest-only>
+      <label for="loginNickname">Никнейм</label>
+      <input id="loginNickname" name="nickname" autocomplete="username" required />
+      <label for="loginPassword">Пароль</label>
+      <input id="loginPassword" name="password" type="password" autocomplete="current-password" required />
+      <button id="btnLogin" class="btn btn--primary" type="submit">Войти</button>
+    </form>
 
-    <div id="paneSignup" class="auth-pane">
-      <input id="signupNickname" type="text" placeholder="Никнейм" required />
-      <input id="signupEmail" type="email" placeholder="Email" required />
-      <input id="signupPassword" type="password" placeholder="Пароль" required />
-      <button id="btnSignup" class="btn btn--primary w-full">Зарегистрироваться</button>
-      <div id="signupError" class="form-error"></div>
-    </div>
-
-    <div id="paneReset" class="auth-pane">
-      <input id="resetEmail" type="email" placeholder="Email" required />
-      <button id="btnReset" class="btn btn--primary w-full">Сбросить пароль</button>
-      <div id="resetError" class="form-error"></div>
-    </div>
+    <form id="formSignup" class="auth-pane is-hidden" data-pane="signup" data-guest-only>
+      <label for="signupNickname">Никнейм</label>
+      <input id="signupNickname" name="nickname" required />
+      <label for="signupEmail">Email</label>
+      <input id="signupEmail" name="email" type="email" autocomplete="email" required />
+      <label for="signupPassword">Пароль</label>
+      <input id="signupPassword" name="password" type="password" autocomplete="new-password" required />
+      <button id="btnSignup" class="btn btn--primary" type="submit">Зарегистрироваться</button>
+    </form>
   </main>
 
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -1046,3 +1046,11 @@ html, body {
 body.guest [data-auth-only] { display:none !important; }
 body.authed [data-guest-only] { display:none !important; }
 
+/* --- auth panes --- */
+.auth-tabs { display: inline-flex; gap: .5rem; margin-bottom: 1rem; }
+.auth-tabs .tab { padding: .5rem 1rem; border-radius: .75rem; }
+.auth-tabs .tab.is-active { background: rgba(60,140,110,.35); }
+
+.auth-pane { display: grid; gap: .75rem; max-width: 420px; margin: 0 auto; }
+.auth-pane.is-hidden { display: none; }
+


### PR DESCRIPTION
## Summary
- simplify auth card to only login and signup panes
- add basic tab switcher and nickname-based auth handlers
- style auth panes and remove reset controls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbd60f91908332aac2b3b5f4047059