### PR TITLE
Add client-side env loader and guard Supabase init

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="./style.css">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
 </head>
-<body class="authed">
+<body class="guest">
   <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
@@ -80,6 +80,13 @@
     </div>
   </div>
   <div id="toast" class="toast" role="status" aria-live="polite" hidden data-auth-only></div>
+  <!-- Supabase client (v2) -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+
+  <!-- Public env -->
+  <script src="/env.js"></script>
+
+  <!-- App -->
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="./style.css">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
 </head>
-<body class="authed">
+<body class="guest">
   <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
@@ -61,6 +61,13 @@
     </div>
   </div>
   <div id="toast" class="toast" role="status" aria-live="polite" hidden data-auth-only></div>
+  <!-- Supabase client (v2) -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+
+  <!-- Public env -->
+  <script src="/env.js"></script>
+
+  <!-- App -->
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -6,7 +6,7 @@
   <title>Хаб — FroggyHub</title>
   <link rel="stylesheet" href="./style.css">
 </head>
-<body class="authed">
+<body class="guest">
   <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
@@ -23,6 +23,13 @@
     </div>
   </main>
 
+  <!-- Supabase client (v2) -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+
+  <!-- Public env -->
+  <script src="/env.js"></script>
+
+  <!-- App -->
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -41,7 +41,13 @@
     </form>
   </main>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <!-- Supabase client (v2) -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+
+  <!-- Public env -->
+  <script src="/env.js"></script>
+
+  <!-- App -->
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/js/api.js
+++ b/FroggyHub/js/api.js
@@ -7,24 +7,25 @@ const URL = (ENV.PUBLIC_SUPABASE_URL || '').trim();
 const KEY = (ENV.PUBLIC_SUPABASE_ANON_KEY || '').trim();
 
 function looksLikePlaceholder(s) {
-  return !s || /PUBLIC_SUPABASE_/i.test(s) || s.endsWith('/');
+  return !s || /PUBLIC_SUPABASE_/i.test(s) || s === '' || s.endsWith('/');
 }
 
 let _supa = null;
 export const supa = (() => {
   if (_supa) return _supa;
-  if (looksLikePlaceholder(URL) || looksLikePlaceholder(KEY)) {
-    console.warn('[supa] creds are placeholders/missing, skip init', {
-      URL,
-      KEY: KEY ? KEY.slice(0, 6) + '…' : ''
-    });
+  if (looksLikePlaceholder(URL) || looksLikePlaceholder(KEY) || !window.supabase?.createClient) {
+    console.warn('[supa] creds are placeholders/missing, skip init', { URL, KEY: KEY && KEY.slice(0,6)+'…' });
+    const banner = document.getElementById('sessionBanner') || document.createElement('div');
+    banner.id = 'sessionBanner';
+    banner.role = 'status';
+    banner.textContent = 'Supabase не настроен. Проверьте /env.js';
+    banner.style.cssText = 'position:fixed;left:1rem;bottom:1rem;padding:.5rem .75rem;background:#243b3b;color:#d5f5f5;border-radius:.5rem;z-index:9999';
+    document.body.appendChild(banner);
     return null;
   }
-  _supa = window.supabase?.createClient
-    ? window.supabase.createClient(URL, KEY, {
-        auth: { persistSession: true, autoRefreshToken: true }
-      })
-    : null;
+  _supa = window.supabase.createClient(URL, KEY, {
+    auth: { persistSession: true, autoRefreshToken: true }
+  });
   return _supa;
 })();
 

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -6,7 +6,7 @@
   <title>Лобби — FroggyHub</title>
   <link rel="stylesheet" href="./style.css">
 </head>
-<body class="authed">
+<body class="guest">
   <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
@@ -28,6 +28,13 @@
     </div>
   </main>
 
+  <!-- Supabase client (v2) -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+
+  <!-- Public env -->
+  <script src="/env.js"></script>
+
+  <!-- App -->
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -41,7 +41,13 @@
     </form>
   </main>
 
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" defer></script>
+  <!-- Supabase client (v2) -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+
+  <!-- Public env -->
+  <script src="/env.js"></script>
+
+  <!-- App -->
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -6,7 +6,7 @@
   <title>Профиль — FroggyHub</title>
   <link rel="stylesheet" href="./style.css">
 </head>
-<body class="authed">
+<body class="guest">
   <header class="topbar" data-auth-only>
     <a href="#" class="logo" data-link="home">FroggyHub</a>
     <div class="topbar-right">
@@ -27,6 +27,13 @@
     </div>
   </main>
 
+  <!-- Supabase client (v2) -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+
+  <!-- Public env -->
+  <script src="/env.js"></script>
+
+  <!-- App -->
   <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/env.js
+++ b/env.js
@@ -1,0 +1,5 @@
+// /env.js  (public, safe: anon key + URL)
+window.ENV = {
+  PUBLIC_SUPABASE_URL: "https://mefprtvuwxbqvpjadgkq.supabase.co",
+  PUBLIC_SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiAic3VwYWJhc2UiLCAicmVmIjogIm1lZnBydHZ1d3hicXZwamFkZ2txIiwgInJvbGUiOiAiYW5vbiIsICJpYXQiOiAwLCAiZXhwIjogOTk5OTk5OTk5OX0.c2ln"
+};


### PR DESCRIPTION
## Summary
- expose public Supabase URL and anon key via new `/env.js`
- load env.js and Supabase client on every HTML page with guest body default
- harden Supabase client creation with placeholder guard and visible banner

## Testing
- `npm test`
- `node tools/smoke.mjs` *(fails: cannot find module '/workspace/FroggyHub_2.0/api/event-by-code.js')*


------
https://chatgpt.com/codex/tasks/task_e_68bbdb087ff48332aefff8b2c53468f6