### PR TITLE
feat: add floating message clouds

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,3 +5,32 @@
 body {
   @apply antialiased;
 }
+
+#fh-message-clouds {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.fh-message-cloud {
+  position: absolute;
+  background: #fff;
+  color: #1a4535;
+  border-radius: 20px;
+  padding: 6px 14px;
+  font-size: 14px;
+  line-height: 1.4;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  white-space: nowrap;
+  will-change: transform;
+  user-select: none;
+}
+
+@media (max-width: 640px) {
+  .fh-message-cloud {
+    font-size: 12px;
+    padding: 4px 10px;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
+import Script from "next/script";
 import GlassLogoBackground from "@/components/GlassLogoBackground";
 
 export const metadata: Metadata = { title: "FroggyHub — события и вишлисты" };
@@ -11,10 +12,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="preload" href="/assets/frog_idle.png" as="image" />
       </head>
       {/* предотвращаем «дрожание» при появлении скролла */}
-      <body className="min-h-screen text-white overflow-hidden">
+      <body className="min-h-screen text-white overflow-hidden bg-gradient-to-b from-[#0b241a] to-[#1a4535]">
+        <div id="fh-message-clouds" aria-hidden="true"></div>
         <GlassLogoBackground />
         {/* весь контент поверх фона */}
         <div className="relative z-20 min-h-screen">{children}</div>
+        <Script src="/fh-message-clouds.js" strategy="afterInteractive" />
       </body>
     </html>
   );

--- a/public/fh-message-clouds.js
+++ b/public/fh-message-clouds.js
@@ -1,0 +1,147 @@
+(() => {
+  const MESSAGES = [
+    "Я приду к 19:00 ✨", "Я возьму пиццу 🍕", "Кто возьмёт колу? 🥤",
+    "Ребят, постучите в дверь 🚪", "Буду позже 🙈", "Добавил плейлист 🎶",
+    "Кто возьмет настолки? 🎲", "Буду через 15 минут ⏳", "Я за пивом 🍺",
+    "Буду online 💻", "Встречаемся у метро 🚉", "Я за мороженым 🍦",
+    "Принесу колонку 📢", "Сделаем фото 📸", "Не забудьте зарядки 🔌",
+    "Привезу попкорн 🍿", "Подготовлю викторину ❓", "Нужен штопор?",
+    "Устроим караоке", "Кто возьмет тарелки?", "Заберу пиццу по пути",
+    "Я за салатом", "Буду с +1", "Берите тёплые вещи", "Давайте играть в мафию",
+    "Принесу проектор", "У меня есть проектор", "Привезу настольный футбол",
+    "Прикажу фрукты", "Кто за лимонадом?", "Друзья, до встречи",
+    "У кого есть карты?", "Привезу геймпад", "Я за хлопьями",
+    "Я возьму сок", "Привезу на час раньше", "Что возьмёт кофе?",
+    "Где парусник?"
+  ];
+
+  const clouds = [];
+  let frame;
+  let resizeTimer;
+
+  function init() {
+    const container = document.getElementById('fh-message-clouds');
+    if (!container) return;
+    container.innerHTML = '';
+    const max = MESSAGES.length;
+    for (let i = 0; i < max; i++) {
+      const el = document.createElement('div');
+      el.className = 'fh-message-cloud';
+      el.textContent = MESSAGES[i % MESSAGES.length];
+      container.appendChild(el);
+      const rect = el.getBoundingClientRect();
+      const cloud = {
+        el,
+        w: rect.width,
+        h: rect.height,
+        x: 0,
+        y: 0,
+        vx: 0,
+        vy: 0
+      };
+      clouds.push(cloud);
+    }
+    positionClouds();
+    observeVisibility();
+    start();
+    window.addEventListener('resize', onResize);
+    document.addEventListener('visibilitychange', onVisibility);
+  }
+
+  function positionClouds() {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    for (const c of clouds) {
+      let tries = 0;
+      do {
+        c.x = Math.random() * (w - c.w);
+        c.y = Math.random() * (h - c.h);
+        var overlap = clouds.some(o => o !== c && intersects(c, o));
+        tries++;
+      } while (overlap && tries < 50);
+      c.vx = (Math.random() * 0.6 + 0.2) * (Math.random() < 0.5 ? -1 : 1);
+      c.vy = (Math.random() * 0.6 + 0.2) * (Math.random() < 0.5 ? -1 : 1);
+      c.el.style.transform = `translate3d(${c.x}px, ${c.y}px, 0)`;
+    }
+  }
+
+  function start() {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(tick);
+  }
+
+  function tick() {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    for (const c of clouds) {
+      c.x += c.vx;
+      c.y += c.vy;
+      if (c.x <= 0 || c.x + c.w >= w) {
+        c.vx *= -1;
+        c.x = Math.max(0, Math.min(c.x, w - c.w));
+      }
+      if (c.y <= 0 || c.y + c.h >= h) {
+        c.vy *= -1;
+        c.y = Math.max(0, Math.min(c.y, h - c.h));
+      }
+    }
+    for (let i = 0; i < clouds.length; i++) {
+      const a = clouds[i];
+      for (let j = i + 1; j < clouds.length; j++) {
+        const b = clouds[j];
+        if (intersects(a, b)) {
+          const vx = a.vx; a.vx = b.vx; b.vx = vx;
+          const vy = a.vy; a.vy = b.vy; b.vy = vy;
+        }
+      }
+    }
+    for (const c of clouds) {
+      c.el.style.transform = `translate3d(${c.x}px, ${c.y}px, 0)`;
+    }
+    frame = requestAnimationFrame(tick);
+  }
+
+  function onResize() {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      for (const c of clouds) {
+        c.x = Math.min(c.x, w - c.w);
+        c.y = Math.min(c.y, h - c.h);
+      }
+    }, 200);
+  }
+
+  function onVisibility() {
+    if (document.hidden) {
+      cancelAnimationFrame(frame);
+    } else {
+      start();
+    }
+  }
+
+  function observeVisibility() {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((e) => {
+        e.target.style.visibility = e.isIntersecting ? 'visible' : 'hidden';
+      });
+    });
+    clouds.forEach((c) => observer.observe(c.el));
+  }
+
+  function intersects(a, b) {
+    return (
+      a.x < b.x + b.w &&
+      a.x + a.w > b.x &&
+      a.y < b.y + b.h &&
+      a.y + a.h > b.y
+    );
+  }
+
+  if (document.readyState !== 'loading') {
+    init();
+  } else {
+    document.addEventListener('DOMContentLoaded', init);
+  }
+})();


### PR DESCRIPTION
## Summary
- add floating message cloud container and gradient background
- style message chips with rounded bubbles and shadows
- animate message clouds with collision handling and resize/visibility updates

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc0f1964bc83328f0305833d27ecfb