### PR TITLE
fix: protect SPA assets with explicit redirects

### DIFF
--- a/FroggyHub/_redirects
+++ b/FroggyHub/_redirects
@@ -1,1 +1,4 @@
-/*    /index.html   200
+/style.css      /style.css      200
+/env.js         /env.js         200
+/js/*           /js/:splat      200
+/*              /index.html     200


### PR DESCRIPTION
## Summary
- ensure static assets get 200s instead of SPA redirects by adding explicit Netlify rules
- verified FroggyHub HTML files contain only relative asset paths

## Testing
- `grep -RIn "$PATTERN" FroggyHub/*.html`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc1b35947c8332aae1c2ed392b0dfd