### PR TITLE
chore: bust css cache and reset topbar buttons

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Аналитика события</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Редактирование события</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/event-summary.html
+++ b/FroggyHub/event-summary.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Wishlist для события</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Хаб — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Лобби — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Вход — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Профиль — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -936,3 +936,31 @@ input:-webkit-autofill{
 
 body.scene-intro, body.scene-final { overflow: hidden; }
 body:not(.scene-intro):not(.scene-final) { overflow: auto; }
+button, input[type="button"], input[type="submit"] {
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+}
+
+/* === TOPBAR / FH-HEADER SAFE RESET === */
+.fh-header a, .fh-header button, .fh-header input[type="button"], .fh-header input[type="submit"],
+.topbar    a, .topbar    button, .topbar    input[type="button"], .topbar    input[type="submit"] {
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: var(--glass) !important;
+  border: 1px solid var(--border) !important;
+  color: var(--text) !important;
+  font-weight: 600;
+  text-decoration: none;
+  line-height: 1;
+}
+.fh-header a:hover, .fh-header button:hover, .fh-header input[type="button"]:hover, .fh-header input[type="submit"]:hover,
+.topbar    a:hover, .topbar    button:hover, .topbar    input[type="button"]:hover, .topbar    input[type="submit"]:hover {
+  background: rgba(255,255,255,.10) !important;
+}

--- a/FroggyHub/wishlist-setup.html
+++ b/FroggyHub/wishlist-setup.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Wishlist для события</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- bump CSS links to `style.css?v=6` across pages for cache busting
- add global button reset and consistent topbar/header button styling

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd6c4b72008332a644ddfb3c645dcd