### PR TITLE
refactor: simplify topbar buttons

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -10,12 +10,9 @@
   <div id="fh-message-clouds" aria-hidden="true"></div>
 
   <header class="topbar" data-auth-only>
-    <a href="#" class="logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button data-link="menu">Меню</button>
-      <button data-link="profile">Профиль</button>
-      <button data-action="logout">Выйти</button>
-    </div>
+    <button data-link="menu">Меню</button>
+    <button data-link="profile">Профиль</button>
+    <button data-action="logout">Выйти</button>
   </header>
 
   <main class="container" role="main" data-auth-only>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -9,12 +9,9 @@
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>
   <header class="topbar" data-auth-only>
-    <a href="#" class="logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button data-link="menu">Меню</button>
-      <button data-link="profile">Профиль</button>
-      <button data-action="logout">Выйти</button>
-    </div>
+    <button data-link="menu">Меню</button>
+    <button data-link="profile">Профиль</button>
+    <button data-action="logout">Выйти</button>
   </header>
 
   <main class="container" role="main" data-auth-only>

--- a/FroggyHub/event-summary.html
+++ b/FroggyHub/event-summary.html
@@ -10,12 +10,9 @@
   <div id="fh-message-clouds" aria-hidden="true"></div>
 
   <header class="topbar" data-auth-only>
-    <a href="#" class="logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button data-link="menu">Меню</button>
-      <button data-link="profile">Профиль</button>
-      <button data-action="logout">Выйти</button>
-    </div>
+    <button data-link="menu">Меню</button>
+    <button data-link="profile">Профиль</button>
+    <button data-action="logout">Выйти</button>
   </header>
 
   <main class="container" role="main" data-auth-only>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -9,12 +9,9 @@
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>
   <header class="topbar" data-auth-only>
-    <a href="#" class="logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button data-link="menu">Меню</button>
-      <button data-link="profile">Профиль</button>
-      <button data-action="logout">Выйти</button>
-    </div>
+    <button data-link="menu">Меню</button>
+    <button data-link="profile">Профиль</button>
+    <button data-action="logout">Выйти</button>
   </header>
 
   <main class="fh-content" data-auth-only>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -9,12 +9,9 @@
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>
   <header class="topbar" data-auth-only>
-    <a href="#" class="logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button data-link="menu">Меню</button>
-      <button data-link="profile">Профиль</button>
-      <button data-action="logout">Выйти</button>
-    </div>
+    <button data-link="menu">Меню</button>
+    <button data-link="profile">Профиль</button>
+    <button data-action="logout">Выйти</button>
   </header>
 
   <main class="auth-card" data-guest-only>

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -9,12 +9,9 @@
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>
   <header class="topbar" data-auth-only>
-    <a href="#" class="logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button data-link="menu">Меню</button>
-      <button data-link="profile">Профиль</button>
-      <button data-action="logout">Выйти</button>
-    </div>
+    <button data-link="menu">Меню</button>
+    <button data-link="profile">Профиль</button>
+    <button data-action="logout">Выйти</button>
   </header>
 
   <main class="fh-content" data-auth-only>

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -9,12 +9,9 @@
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>
   <header class="topbar" data-auth-only>
-    <a href="#" class="logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button data-link="menu">Меню</button>
-      <button data-link="profile">Профиль</button>
-      <button data-action="logout">Выйти</button>
-    </div>
+    <button data-link="menu">Меню</button>
+    <button data-link="profile">Профиль</button>
+    <button data-action="logout">Выйти</button>
   </header>
 
   <main class="auth-card" data-guest-only>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -9,12 +9,9 @@
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>
   <header class="topbar" data-auth-only>
-    <a href="#" class="logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button data-link="menu">Меню</button>
-      <button data-link="profile">Профиль</button>
-      <button data-action="logout">Выйти</button>
-    </div>
+    <button data-link="menu">Меню</button>
+    <button data-link="profile">Профиль</button>
+    <button data-action="logout">Выйти</button>
   </header>
 
   <main class="fh-content" data-auth-only>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -832,8 +832,9 @@ body.scene-intro .speech{display:block}
 /* === 2) КНОПКИ В ВЕРХНЕМ ХАБЕ (без .btn) === */
 .fh-header, .topbar{
   display:flex;
-  justify-content:space-between;
+  justify-content:flex-end;
   align-items:center;
+  gap:10px;
   padding:12px 20px;
   position:sticky;
   top:0;
@@ -844,27 +845,26 @@ body.scene-intro .speech{display:block}
   border-bottom:1px solid rgba(255,255,255,.08);
 }
 
-/* Header links & buttons */
-.fh-header a, .fh-header button, .fh-header input[type="button"], .fh-header input[type="submit"],
-.topbar a, .topbar button, .topbar input[type="button"], .topbar input[type="submit"]{
-  display:inline-flex;
-  align-items:center;
-  gap:6px;
-  padding:6px 10px;
-  border-radius:12px;
-  background:var(--glass);
-  border:1px solid var(--border);
-  color:var(--text) !important;
-  font-weight:600;
-  text-decoration:none;
-  line-height:1;
+/* Header buttons */
+.topbar button,
+.fh-header button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: var(--glass);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
 }
-.fh-header a:hover, .fh-header button:hover, .fh-header input[type="button"]:hover, .fh-header input[type="submit"]:hover,
-.topbar a:hover, .topbar button:hover, .topbar input[type="button"]:hover, .topbar input[type="submit"]:hover{
-  background:rgba(255,255,255,.10);
+
+.topbar button:hover,
+.fh-header button:hover {
+  background: rgba(255,255,255,.10);
 }
-.fh-header a:link, .fh-header a:visited,
-.topbar a:link, .topbar a:visited{ color:var(--text) !important; }
 
 /* === 3) ВЕРНИМ «СТЕКЛО» И УБЕРЁМ СВЕТЛЫЕ ПЕРЕОПРЕДЕЛЕНИЯ === */
 /* Универсальный класс стекла */

--- a/FroggyHub/wishlist-setup.html
+++ b/FroggyHub/wishlist-setup.html
@@ -10,12 +10,9 @@
   <div id="fh-message-clouds" aria-hidden="true"></div>
 
   <header class="topbar" data-auth-only>
-    <a href="#" class="logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button data-link="menu">Меню</button>
-      <button data-link="profile">Профиль</button>
-      <button data-action="logout">Выйти</button>
-    </div>
+    <button data-link="menu">Меню</button>
+    <button data-link="profile">Профиль</button>
+    <button data-action="logout">Выйти</button>
   </header>
 
   <main class="container" role="main" data-auth-only>


### PR DESCRIPTION
## Summary
- style topbar and header buttons with a unified glass block
- remove anchors and unused CSS in topbar so only menu/profile/logout buttons remain

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd75988f148332a22df719c9ce2eff