### PR TITLE
Apply unified dark theme to inputs and update stylesheet cache bust

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Аналитика события</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Редактирование события</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/event-summary.html
+++ b/FroggyHub/event-summary.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Wishlist для события</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Хаб — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Лобби — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Вход — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Профиль — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -892,7 +892,9 @@ body.scene-intro .speech{display:block}
   color: #082016;
 }
 
-/* === Dark native inputs (incl. date/time) === */
+/* === GLOBAL DARK INPUT THEME === */
+
+/* Base inputs */
 input[type="text"],
 input[type="password"],
 input[type="email"],
@@ -910,41 +912,69 @@ select{
   border-radius: 10px;
   padding: 12px 14px;
 }
-input::placeholder, textarea::placeholder{ color: var(--muted); }
-input:focus, textarea:focus, select:focus{
+
+/* Focus ring + shadow */
+input:focus,
+textarea:focus,
+select:focus{
   outline: 2px solid var(--ring);
   box-shadow: 0 6px 18px var(--shadow);
 }
+
+/* Placeholder tint */
+input::placeholder,
+textarea::placeholder{ color: var(--muted); }
+
+/* WebKit picker icons & value color */
 input[type="date"]::-webkit-calendar-picker-indicator,
 input[type="time"]::-webkit-calendar-picker-indicator,
 input[type="datetime-local"]::-webkit-calendar-picker-indicator{
   filter: invert(85%);
   opacity: .9;
-  color: var(--text);
 }
 input[type="date"]::-webkit-date-and-time-value,
 input[type="time"]::-webkit-date-and-time-value,
 input[type="datetime-local"]::-webkit-date-and-time-value{
   color: var(--text);
-  filter: invert(85%);
 }
+
+/* Autofill: keep dark */
 input:-webkit-autofill{
   -webkit-text-fill-color: var(--text);
   box-shadow: 0 0 0 100px var(--input-bg) inset !important;
   transition: background-color 9999s ease-in-out 0s;
 }
-/* Force in edit form / modals */
+
+/* Always >=16px to prevent mobile zoom */
+input, textarea, select{ font-size:16px; }
+
+/* === ENFORCE IN CRITICAL AREAS (higher specificity) === */
+
+/* Edit form + Modals: force dark (helps if other rules try to override) */
 .edit-form input,
 .edit-form select,
 .edit-form textarea,
 .modal .card input,
 .modal .card select,
-.modal .card textarea {
+.modal .card textarea{
   background: var(--input-bg) !important;
   color: var(--text) !important;
   border: 1px solid var(--input-border) !important;
 }
 .edit-form input::placeholder,
-.edit-form textarea::placeholder { color: var(--muted) !important; }
+.edit-form textarea::placeholder{
+  color: var(--muted) !important;
+}
+.edit-form input[type="date"]::-webkit-calendar-picker-indicator,
+.edit-form input[type="time"]::-webkit-calendar-picker-indicator,
+.edit-form input[type="datetime-local"]::-webkit-calendar-picker-indicator{
+  filter: invert(85%);
+  opacity: .9;
+}
+.edit-form input[type="date"]::-webkit-date-and-time-value,
+.edit-form input[type="time"]::-webkit-date-and-time-value,
+.edit-form input[type="datetime-local"]::-webkit-date-and-time-value{
+  color: var(--text);
+}
 
 body.scene-intro, body.scene-final { overflow: hidden; }

--- a/FroggyHub/wishlist-setup.html
+++ b/FroggyHub/wishlist-setup.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Wishlist для события</title>
-<link rel="stylesheet" href="/style.css?v=5">
+<link rel="stylesheet" href="/style.css?v=6">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- style all native inputs with a consistent dark "glass" look and fix WebKit picker icons, values and autofill behavior
- force the dark theme in edit forms and modal cards for reliability
- bump global stylesheet reference to `?v=6` for cache-busting

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd78c1bccc8332832d1248d91f506f