### PR TITLE
feat: redesign home topbar and hero

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -6,44 +6,36 @@
   <title>FroggyHub</title>
 <link rel="stylesheet" href="/style.css?v=6">
 </head>
-<body class="guest">
+<body class="guest bg-frog">
+  <!-- фоновые сообщения -->
   <div id="fh-message-clouds" aria-hidden="true"></div>
+
+  <!-- TOPBAR -->
   <header class="topbar" data-auth-only>
-    <button data-link="menu">Меню</button>
-    <button data-link="profile">Профиль</button>
-    <button data-action="logout">Выйти</button>
+    <a class="logo" href="index.html" data-link="home">FroggyHub</a>
+    <nav class="topbar-right">
+      <button data-link="menu">Меню</button>
+      <button data-link="profile">Профиль</button>
+      <button data-action="logout">Выйти</button>
+    </nav>
   </header>
 
-  <main class="auth-card" data-guest-only>
-    <nav class="auth-tabs" data-guest-only>
-      <button type="button" class="tab is-active" data-auth-tab="login">Вход</button>
-      <button type="button" class="tab" data-auth-tab="signup">Регистрация</button>
-    </nav>
-
-    <section id="pane-login" class="auth-pane visible" data-pane="login">
-      <form id="form-login" novalidate>
-        <label for="loginNickname">Никнейм</label>
-        <input id="loginNickname" name="nickname" autocomplete="username" required />
-        <label for="loginPassword">Пароль</label>
-        <input id="loginPassword" name="password" type="password" autocomplete="current-password" required />
-        <button id="btnLogin" class="btn btn--primary" type="submit">Войти</button>
-      </form>
+  <!-- HERO на главной -->
+  <main id="home" class="home-screen">
+    <section class="home-hero">
+      <div class="join-wrap glassy">
+        <div class="join-row">
+          <a class="btn btn--primary" data-link="create">Создать событие</a>
+          <input id="joinCode" inputmode="numeric" maxlength="6"
+                 class="pill-input"
+                 placeholder="Введите 6-значный код" />
+          <button class="btn" id="joinBtn" data-action="join">Присоединиться</button>
+        </div>
+      </div>
     </section>
-
-    <section id="pane-signup" class="auth-pane" data-pane="signup" hidden>
-      <form id="form-signup" novalidate>
-        <label for="signupNickname">Никнейм</label>
-        <input id="signupNickname" name="nickname" required />
-        <label for="signupEmail">Email</label>
-        <input id="signupEmail" name="email" type="email" autocomplete="email" required />
-        <label for="signupPassword">Пароль</label>
-        <input id="signupPassword" name="password" type="password" autocomplete="new-password" required />
-        <button id="btnSignup" class="btn btn--primary" type="submit">Зарегистрироваться</button>
-      </form>
-    </section>
-
-    <p id="auth-error" class="error" role="alert" aria-live="polite" hidden></p>
   </main>
+
+  <!-- остальной код страницы, скрипты и т.д. оставь как есть -->
 
   <!-- Supabase client -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -891,3 +891,105 @@ body.scene-intro .speech{display:block}
 
 
 body.scene-intro, body.scene-final { overflow: hidden; }
+
+/* ===== Главная: центрирование блока ввода ===== */
+.home-screen{
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding-top: 56px; /* чтобы не залезть под шапку */
+}
+
+.home-hero{
+  width: 100%;
+  display: grid;
+  place-items: center;
+}
+
+.join-wrap{
+  border-radius: 16px;
+  padding: 14px 18px;
+  /* лёгкий сдвиг «чуть ниже середины» */
+  transform: translateY(6vh);
+}
+
+.join-row{
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  align-items: center;
+  gap: 10px;
+}
+
+/* компактный стек на мобильных */
+@media (max-width: 720px){
+  .join-row{ grid-auto-flow: row; width: min(92vw, 420px); }
+}
+
+/* ===== Унифицированные «пилюли» (инпут и чипы) ===== */
+
+/* компактный «стеклянный» инпут-пилюля */
+.pill-input{
+  -webkit-appearance: none; appearance: none;
+  display: inline-flex; align-items: center; gap: .5rem;
+  padding: 8px 12px; line-height: 1;
+  border-radius: 999px;
+  background: rgba(255,255,255,.08);
+  border: 1px solid rgba(255,255,255,.16);
+  color: var(--text);
+  box-shadow:
+    0 4px 20px rgba(0,0,0,.25),
+    inset 0 0 0 1px rgba(255,255,255,.06);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  font-weight: 600;
+  font-size: 14px;
+  min-height: 36px;
+}
+.pill-input::placeholder{ color: rgba(255,255,255,.65); }
+.pill-input:focus{
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+  box-shadow: 0 8px 28px rgba(0,0,0,.28);
+}
+
+/* единый стиль для «строк/чипов» в облаках (белые таблетки) */
+.bubble.chip, .fh-chip{
+  display:inline-flex; align-items:center; gap:.5rem;
+  padding:8px 12px;
+  border-radius:999px;
+  background:#fff;
+  color:#204b3a; /* читаемый зелёный текст */
+  border: 0;
+  box-shadow: 0 10px 24px rgba(0,0,0,.22);
+  font-weight: 600;
+  line-height:1;
+}
+
+/* ===== Шапка: логотип слева, кнопки справа ===== */
+.topbar{
+  position: sticky; top: 0; z-index: 10;
+  display:flex; justify-content:space-between; align-items:center;
+  padding: 10px 14px;
+  background: rgba(0,0,0,.15);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(255,255,255,.08);
+}
+.topbar .logo{
+  font-weight: 900; letter-spacing:.2px;
+  text-decoration:none; color: var(--text);
+  padding: 6px 10px; border-radius: 12px;
+}
+.topbar-right{ display:flex; gap:8px; }
+
+/* чтобы любые <a>/<button>/<input type=submit> в топбаре были «стеклом» */
+.topbar a, .topbar button, .topbar input[type="submit"]{
+  -webkit-appearance:none; appearance:none;
+  display:inline-flex; align-items:center; gap:6px;
+  padding:6px 10px; border-radius:12px;
+  background:var(--glass);
+  border:1px solid var(--border);
+  color:var(--text); font-weight:600; text-decoration:none;
+}
+.topbar a:hover, .topbar button:hover{ background: rgba(255,255,255,.10); }


### PR DESCRIPTION
## Summary
- add new topbar with logo and buttons on home screen
- center hero join block and update pill and chip styles
- extend topbar glass styling in CSS

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bde8eac17c8332bf5fc43eed48f8e4