### PR TITLE
Restore universal button styles and refresh stylesheet cache

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Аналитика события</title>
-<link rel="stylesheet" href="/style.css?v=6">
+<link rel="stylesheet" href="/style.css?v=glass-16">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Редактирование события</title>
-<link rel="stylesheet" href="/style.css?v=6">
+<link rel="stylesheet" href="/style.css?v=glass-16">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/event-summary.html
+++ b/FroggyHub/event-summary.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Wishlist для события</title>
-<link rel="stylesheet" href="/style.css?v=6">
+<link rel="stylesheet" href="/style.css?v=glass-16">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Хаб — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=6">
+<link rel="stylesheet" href="/style.css?v=glass-16">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>FroggyHub</title>
-  <link rel="stylesheet" href="style.css?v=glass-15">
+  <link rel="stylesheet" href="style.css?v=glass-16">
 </head>
 <body class="guest bg-frog">
   <!-- фоновые сообщения -->

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Лобби — FroggyHub</title>
-<link rel="stylesheet" href="style.css?v=glass-15">
+<link rel="stylesheet" href="style.css?v=glass-16">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Вход — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=6">
+<link rel="stylesheet" href="/style.css?v=glass-16">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Профиль — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=6">
+<link rel="stylesheet" href="/style.css?v=glass-16">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -66,10 +66,41 @@ body {
 }
 
 /* === СБРОС нативных кнопок, чтобы не ломали внешний вид === */
-button, input[type="button"], input[type="submit"]{
-  -webkit-appearance:none; appearance:none;
-  background:none; border:none; color:inherit; font:inherit; padding:0; border-radius:0;
-  cursor:pointer;
+button, input[type="button"], input[type="submit"] {
+  background: none;
+  border: none;
+  color: inherit;
+  padding: 0;
+}
+
+/* === UNIVERSAL BUTTON STYLES === */
+.btn {
+  -webkit-appearance: none;
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,.10);
+  background: rgba(255,255,255,.08);
+  color: var(--text, #eaf7f1);
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  box-shadow: 0 4px 20px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.06);
+}
+
+.btn--primary {
+  background: rgba(22,163,74,.22);
+  border-color: rgba(190,255,220,.25);
+}
+
+.btn:hover {
+  background: rgba(255,255,255,.12);
 }
 
 /* ===== UNIFIED "GLASS" INPUTS ACROSS THE APP ===== */
@@ -848,20 +879,6 @@ body.scene-intro, body.scene-final { overflow: hidden; }
 }
 .pill-input::placeholder{ color: rgba(234,247,241,.55); }
 .pill-input:focus{ outline: 2px solid var(--ring); outline-offset: 2px; }
-
-/* Универсальные кнопки */
-.btn{
-  -webkit-appearance:none; appearance:none;
-  display:inline-flex; align-items:center; justify-content:center;
-  gap:.5rem; padding:8px 12px; line-height:1;
-  border-radius:12px; border:1px solid rgba(255,255,255,.10);
-  background:rgba(255,255,255,.08);
-  color:var(--text,#eaf7f1); font-weight:600; cursor:pointer; text-decoration:none;
-  backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px);
-  box-shadow:0 4px 20px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.06);
-}
-.btn:hover{ background:rgba(255,255,255,.12); }
-.btn--primary{ background:rgba(22,163,74,.22); border-color:rgba(190,255,220,.25); }
 
 /* Мобильная адаптация: столбиком и по центру, блок остаётся «чуть ниже середины» */
 @media (max-width: 720px){

--- a/FroggyHub/wishlist-setup.html
+++ b/FroggyHub/wishlist-setup.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Wishlist для события</title>
-<link rel="stylesheet" href="/style.css?v=6">
+<link rel="stylesheet" href="/style.css?v=glass-16">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- reinstate universal `.btn` styling directly after button reset
- simplify native button reset to avoid duplicate rules
- bump stylesheet query string to `glass-16` across pages for cache busting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be178b4f54833285bf1a3fe295e98f