### PR TITLE
Align lobby hero with homepage and deduplicate styles

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Аналитика события</title>
-<link rel="stylesheet" href="/style.css?v=glass-16">
+<link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Редактирование события</title>
-<link rel="stylesheet" href="/style.css?v=glass-16">
+<link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/event-summary.html
+++ b/FroggyHub/event-summary.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Wishlist для события</title>
-<link rel="stylesheet" href="/style.css?v=glass-16">
+<link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Хаб — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=glass-16">
+<link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>FroggyHub</title>
-  <link rel="stylesheet" href="style.css?v=glass-16">
+  <link rel="stylesheet" href="style.css?v=glass-18">
 </head>
 <body class="guest bg-frog">
   <!-- фоновые сообщения -->

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Лобби — FroggyHub</title>
-  <link rel="stylesheet" href="/style.css?v=glass-17">
+  <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Вход — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=glass-16">
+<link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Профиль — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=glass-16">
+<link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -41,7 +41,8 @@ body {
 }
 
 /* === UI ВСЕГДА ВЫШЕ ЧИПОВ === */
-.topbar, .fh-header, .screen, .panel, .card, .modal, .final-card {
+.topbar, .fh-header, .screen, .panel, .card, .modal, .final-card,
+.container, header, nav {
   position: relative;
   z-index: 10;
 }
@@ -827,84 +828,59 @@ body.scene-intro .speech{display:block}
 body.scene-intro, body.scene-final { overflow: hidden; }
 
 /* ===== Центрирование героя для главной/лобби ===== */
+
 .home-screen{
-  min-height: calc(100dvh - 60px);
-  display:grid;
-  place-items:center;
-  position:relative;
-  z-index: 10; /* выше чипов */
+  min-height: calc(100dvh - 60px); /* учет топбара */
+  display: grid;
+  place-items: center;
 }
 .home-hero{
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  width:min(880px, 92vw);
-  transform: translateY(6vh); /* «чуть ниже середины» */
+  display:flex; align-items:center; justify-content:center;
+  width: min(880px, 92vw);
+  transform: translateY(-5vh);
 }
-.home-card{
-  padding: 14px 16px;
+.join-wrap.glassy.hero-card{
+  padding: 12px;
   border-radius: 20px;
   background: rgba(0,0,0,.22);
   border: 1px solid rgba(255,255,255,.09);
   backdrop-filter: blur(12px) saturate(120%);
   -webkit-backdrop-filter: blur(12px) saturate(120%);
   box-shadow: 0 18px 40px rgba(0,0,0,.35);
+  position: relative;
+  z-index: 10; /* над чипами */
 }
 
 /* Универсальная строка: 2 кнопки + инпут, по центру */
+
 .join-row{
   display:flex;
   gap:12px;
   flex-wrap:wrap;
-  align-items:center;
   justify-content:center;
-}
-.join-row .pill-input{
-  min-width: 220px;
-  text-align:center;
 }
 
 /* Инпут-пилюля компактный, но читабельный */
-.pill-input{
-  -webkit-appearance:none;
-  appearance:none;
-  display:inline-flex;
-  align-items:center;
-  gap:.5rem;
-  padding: 10px 14px;
-  min-height: 38px;
-  border-radius: 999px;
-  background: rgba(255,255,255,.06);
-  border: 1px solid rgba(255,255,255,.10);
-  color: var(--text, #eaf7f1);
-  box-shadow: 0 4px 20px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.06);
-  font: 600 14px/1 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial;
-  text-align: center;
-}
-.pill-input::placeholder{ color: rgba(234,247,241,.55); }
-.pill-input:focus{ outline: 2px solid var(--ring); outline-offset: 2px; }
 
-/* Кнопки – стекло (должно уже быть, дублируем на случай регресса) */
-.btn{
+.pill-input{
   -webkit-appearance:none; appearance:none;
   display:inline-flex; align-items:center; justify-content:center;
-  gap:.5rem; padding:8px 12px; line-height:1;
-  border-radius:12px; border:1px solid rgba(255,255,255,.10);
-  background:rgba(255,255,255,.08);
-  color:var(--text, #eaf7f1); font-weight:600; text-decoration:none;
-  cursor:pointer;
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  box-shadow: 0 4px 20px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.06);
+  padding:10px 14px; min-height:38px; line-height:1;
+  border-radius:999px;
+  background:rgba(255,255,255,.06);
+  border:1px solid rgba(255,255,255,.10);
+  color:var(--text,#eaf7f1);
+  font:600 14px/1 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial;
+  text-align:center;
+  box-shadow:0 4px 20px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.06);
 }
-.btn:hover{ background: rgba(255,255,255,.12); }
-.btn--primary{ background: rgba(22,163,74,.22); border-color: rgba(190,255,220,.25); }
+.pill-input::placeholder{ color: rgba(234,247,241,.55); }
+.pill-input:focus{ outline:2px solid var(--ring); outline-offset:2px; }
 
-/* Мобилка: столбиком и всё по центру, карточка остаётся «чуть ниже середины» */
 @media (max-width: 720px){
-  .home-hero{ transform: translateY(4vh); }
-  .join-row{ flex-direction: column; gap: 10px; }
-  .join-row .pill-input{ width: min(420px, 92vw); align-self: center; }
+  .home-hero{ transform: translateY(-2vh); }
+  .join-row{ flex-direction: column; gap: 12px; }
+  .btn, .pill-input{ width: min(420px, 92vw); align-self: center; }
 }
 
 /* единый стиль для «строк/чипов» в облаках (белые таблетки) */
@@ -946,7 +922,6 @@ body.scene-intro, body.scene-final { overflow: hidden; }
   min-height: calc(100dvh - 96px); /* с запасом под топбар, если есть */
   display: grid;
   place-items: center;
-  transform: translateY(-4vh);   /* «чуть ниже середины» ощущается лучше */
 }
 
 .hero-card{
@@ -959,54 +934,3 @@ body.scene-intro, body.scene-final { overflow: hidden; }
   box-shadow: 0 18px 40px rgba(0,0,0,.35);
   width: min(960px, 94vw);
 }
-
-.hero-row{
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: max-content;
-  gap: 12px;
-  align-items: center;
-  justify-content: center;
-}
-
-/* пилюльный инпут одинаковой высоты с кнопками */
-.hero-row .pill-input{
-  min-height: 40px;
-  padding: 10px 14px;
-  border-radius: 999px;
-  text-align: center;
-  width: min(360px, 38vw);
-}
-
-/* кнопки стекло (если где-то переопределили — вернём вид тут) */
-.hero-row .btn{
-  display:inline-flex; align-items:center; justify-content:center;
-  gap:.5rem; padding:8px 12px; line-height:1;
-  border-radius:12px; border:1px solid rgba(255,255,255,.10);
-  background:rgba(255,255,255,.08);
-  color:var(--text, #eaf7f1); font-weight:600; text-decoration:none;
-  cursor:pointer;
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  box-shadow: 0 4px 20px rgba(0,0,0,.25), inset 0 0 1px rgba(255,255,255,.06);
-}
-.hero-row .btn:hover{ background:rgba(255,255,255,.12); }
-.hero-row .btn.btn--primary{
-  background: rgba(22,163,74,.22);
-  border-color: rgba(190,255,220,.25);
-}
-
-/* адаптив: в столбик, всё по центру и одинаковой ширины */
-@media (max-width: 760px){
-  .hero-center{ transform: translateY(-2vh); }
-  .hero-row{
-    grid-auto-flow: row;
-    grid-template-columns: 1fr;
-    justify-items: center;
-  }
-  .hero-row .btn,
-  .hero-row .pill-input{ width: min(420px, 92vw); }
-}
-
-/* убедимся, что облака-чипы не перекрывают UI */
-#fh-message-clouds{ z-index: 0; pointer-events: none; }

--- a/FroggyHub/wishlist-setup.html
+++ b/FroggyHub/wishlist-setup.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Wishlist для события</title>
-<link rel="stylesheet" href="/style.css?v=glass-16">
+<link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
   <div id="fh-message-clouds" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- Center lobby join/create block using the same hero layout as the homepage
- Consolidate glassy button and input styles and ensure hero row stacks on mobile
- Bump CSS cache bust query to `glass-18` across all pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be2b2dfcd48332821083ea8b042719