### PR TITLE
Fix navigation and unify top bar across pages

### DIFF
--- a/FroggyHub/_redirects
+++ b/FroggyHub/_redirects
@@ -1,4 +1,3 @@
 /style.css      /style.css      200
 /env.js         /env.js         200
 /js/*           /js/:splat      200
-/*              /index.html     200

--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -7,13 +7,16 @@
 <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
+<header class="topbar">
+  <a class="logo fh-logo" data-link="home">FroggyHub</a>
+  <div class="topbar-right">
+    <button class="btn" data-link="menu">Меню</button>
+    <button class="btn" data-link="profile">Профиль</button>
+    <button class="btn" data-link="settings">Настройки</button>
+    <button class="btn" data-action="logout">Выйти</button>
+  </div>
+</header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
-
-  <header class="topbar" data-auth-only>
-    <button data-link="menu">Меню</button>
-    <button data-link="profile">Профиль</button>
-    <button data-action="logout">Выйти</button>
-  </header>
 
   <main class="container" role="main" data-auth-only>
     <div class="card" id="eventHead">

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -7,12 +7,16 @@
 <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
+<header class="topbar">
+  <a class="logo fh-logo" data-link="home">FroggyHub</a>
+  <div class="topbar-right">
+    <button class="btn" data-link="menu">Меню</button>
+    <button class="btn" data-link="profile">Профиль</button>
+    <button class="btn" data-link="settings">Настройки</button>
+    <button class="btn" data-action="logout">Выйти</button>
+  </div>
+</header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
-  <header class="topbar" data-auth-only>
-    <button data-link="menu">Меню</button>
-    <button data-link="profile">Профиль</button>
-    <button data-action="logout">Выйти</button>
-  </header>
 
   <main class="container" role="main" data-auth-only>
     <form id="editForm" class="card grid edit-form" aria-describedby="editError">

--- a/FroggyHub/event-summary.html
+++ b/FroggyHub/event-summary.html
@@ -7,13 +7,16 @@
 <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
+<header class="topbar">
+  <a class="logo fh-logo" data-link="home">FroggyHub</a>
+  <div class="topbar-right">
+    <button class="btn" data-link="menu">Меню</button>
+    <button class="btn" data-link="profile">Профиль</button>
+    <button class="btn" data-link="settings">Настройки</button>
+    <button class="btn" data-action="logout">Выйти</button>
+  </div>
+</header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
-
-  <header class="topbar" data-auth-only>
-    <button data-link="menu">Меню</button>
-    <button data-link="profile">Профиль</button>
-    <button data-action="logout">Выйти</button>
-  </header>
 
   <main class="container" role="main" data-auth-only>
     <div class="card">

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -7,12 +7,16 @@
 <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
+<header class="topbar">
+  <a class="logo fh-logo" data-link="home">FroggyHub</a>
+  <div class="topbar-right">
+    <button class="btn" data-link="menu">Меню</button>
+    <button class="btn" data-link="profile">Профиль</button>
+    <button class="btn" data-link="settings">Настройки</button>
+    <button class="btn" data-action="logout">Выйти</button>
+  </div>
+</header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
-  <header class="topbar" data-auth-only>
-    <button data-link="menu">Меню</button>
-    <button data-link="profile">Профиль</button>
-    <button data-action="logout">Выйти</button>
-  </header>
 
   <main class="fh-content" data-auth-only>
     <div class="container">

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -7,18 +7,17 @@
   <link rel="stylesheet" href="style.css?v=glass-18">
 </head>
 <body class="guest bg-frog">
+<header class="topbar">
+  <a class="logo fh-logo" data-link="home">FroggyHub</a>
+  <div class="topbar-right">
+    <button class="btn" data-link="menu">Меню</button>
+    <button class="btn" data-link="profile">Профиль</button>
+    <button class="btn" data-link="settings">Настройки</button>
+    <button class="btn" data-action="logout">Выйти</button>
+  </div>
+</header>
   <!-- фоновые сообщения -->
   <div id="fh-message-clouds" aria-hidden="true"></div>
-
-  <!-- TOPBAR -->
-  <header class="topbar" data-auth-only>
-    <a class="logo fh-logo" data-link="home">FroggyHub</a>
-    <div class="topbar-right">
-      <button class="btn" data-link="menu">Меню</button>
-      <button class="btn" data-link="profile">Профиль</button>
-      <button class="btn" data-action="logout">Выйти</button>
-    </div>
-  </header>
 
   <!-- HERO на главной -->
   <main id="home" class="home-screen">

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -7,12 +7,16 @@
   <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
+<header class="topbar">
+  <a class="logo fh-logo" data-link="home">FroggyHub</a>
+  <div class="topbar-right">
+    <button class="btn" data-link="menu">Меню</button>
+    <button class="btn" data-link="profile">Профиль</button>
+    <button class="btn" data-link="settings">Настройки</button>
+    <button class="btn" data-action="logout">Выйти</button>
+  </div>
+</header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
-  <header class="topbar" data-auth-only>
-    <button data-link="menu">Меню</button>
-    <button data-link="profile">Профиль</button>
-    <button data-action="logout">Выйти</button>
-  </header>
 
   <!-- Центрированный hero-блок как на главной -->
   <main id="home" class="home-screen">

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -7,12 +7,16 @@
 <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
+<header class="topbar">
+  <a class="logo fh-logo" data-link="home">FroggyHub</a>
+  <div class="topbar-right">
+    <button class="btn" data-link="menu">Меню</button>
+    <button class="btn" data-link="profile">Профиль</button>
+    <button class="btn" data-link="settings">Настройки</button>
+    <button class="btn" data-action="logout">Выйти</button>
+  </div>
+</header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
-  <header class="topbar" data-auth-only>
-    <button data-link="menu">Меню</button>
-    <button data-link="profile">Профиль</button>
-    <button data-action="logout">Выйти</button>
-  </header>
 
   <main class="auth-card" data-guest-only>
     <nav class="auth-tabs" data-guest-only>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -7,12 +7,16 @@
 <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
+<header class="topbar">
+  <a class="logo fh-logo" data-link="home">FroggyHub</a>
+  <div class="topbar-right">
+    <button class="btn" data-link="menu">Меню</button>
+    <button class="btn" data-link="profile">Профиль</button>
+    <button class="btn" data-link="settings">Настройки</button>
+    <button class="btn" data-action="logout">Выйти</button>
+  </div>
+</header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
-  <header class="topbar" data-auth-only>
-    <button data-link="menu">Меню</button>
-    <button data-link="profile">Профиль</button>
-    <button data-action="logout">Выйти</button>
-  </header>
 
   <main class="fh-content" data-auth-only>
     <div class="container">

--- a/FroggyHub/wishlist-setup.html
+++ b/FroggyHub/wishlist-setup.html
@@ -7,13 +7,16 @@
 <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
+<header class="topbar">
+  <a class="logo fh-logo" data-link="home">FroggyHub</a>
+  <div class="topbar-right">
+    <button class="btn" data-link="menu">Меню</button>
+    <button class="btn" data-link="profile">Профиль</button>
+    <button class="btn" data-link="settings">Настройки</button>
+    <button class="btn" data-action="logout">Выйти</button>
+  </div>
+</header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
-
-  <header class="topbar" data-auth-only>
-    <button data-link="menu">Меню</button>
-    <button data-link="profile">Профиль</button>
-    <button data-action="logout">Выйти</button>
-  </header>
 
   <main class="container" role="main" data-auth-only>
     <div class="card">


### PR DESCRIPTION
## Summary
- remove SPA fallback from `_redirects` so individual pages load directly
- standardize top bar with logo and menu/profile/settings/logout buttons on all html pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3c861cb8833281e58c352094b071