### PR TITLE
Refactor landing hero into centered create/join block

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -19,24 +19,14 @@
   <!-- фоновые сообщения -->
   <div id="fh-message-clouds" aria-hidden="true"></div>
 
-  <!-- HERO на главной -->
-  <main id="home" class="home-screen">
-    <section class="home-hero hero-center">
-      <div class="join-wrap glassy hero-card" role="group" aria-label="Создать или присоединиться">
-        <div class="join-row hero-row">
-          <a class="btn btn--primary" data-link="event-edit">Создать событие</a>
-          <input
-            id="joinCode"
-            class="pill-input"
-            inputmode="numeric"
-            maxlength="6"
-            placeholder="Введите 6-значный код"
-            aria-label="Код приглашения"
-          />
-          <button id="btnJoin" class="btn" data-action="join">Присоединиться</button>
-        </div>
+  <main class="hero">
+    <div class="hero-box">
+      <button class="btn btn-large" data-link="event-edit">Создать событие</button>
+      <div class="join-block">
+        <input type="text" id="join-code" placeholder="Код события" />
+        <button class="btn btn-large" data-action="join">Присоединиться</button>
       </div>
-    </section>
+    </div>
   </main>
 
   <!-- остальной код страницы, скрипты и т.д. оставь как есть -->

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -812,7 +812,7 @@ body.scene-intro .speech{display:block}
 #screen-profile:not(.hidden),
 #screen-hub:not(.hidden) { display: block; }
 
-.hero, .hero-frog, .frog-hero, .hero .frog,
+.hero-frog, .frog-hero, .hero .frog,
 #hero, .hero-wrap, .hero-stump {
   display: none !important;
 }
@@ -942,4 +942,44 @@ body.scene-intro, body.scene-final { overflow: hidden; }
   -webkit-backdrop-filter: blur(12px) saturate(120%);
   box-shadow: 0 18px 40px rgba(0,0,0,.35);
   width: min(960px, 94vw);
+}
+
+.hero {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 60px); /* minus topbar height */
+  padding: 2rem;
+}
+
+.hero-box {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(12px);
+  padding: 2.5rem 3rem;
+  border-radius: 1.5rem;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+}
+
+.hero-box .btn-large {
+  font-size: 1.2rem;
+  padding: 0.8rem 1.6rem;
+  border-radius: 1rem;
+}
+
+.join-block {
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+}
+
+.join-block input {
+  padding: 0.7rem 1rem;
+  border-radius: 1rem;
+  border: none;
+  outline: none;
+  font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- Replace home hero markup with centered create/join block
- Add hero-box styles for translucent card and input layout
- Remove old hero suppression rule so landing content displays

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3fa89b2c8332b87e87f11d9d0f2d