### PR TITLE
feat: add landing hero with join flow

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -16,26 +16,36 @@
     <button class="btn" data-action="logout">Выйти</button>
   </div>
 </header>
-  <!-- фоновые сообщения -->
-  <div id="fh-message-clouds" aria-hidden="true"></div>
 
-  <main class="hero">
-    <div class="hero-box">
-      <button class="btn btn-large" data-link="event-edit">Создать событие</button>
-      <div class="join-block">
-        <input type="text" id="join-code" placeholder="Код события" />
-        <button class="btn btn-large" data-action="join">Присоединиться</button>
-      </div>
+<main class="hero" role="main" aria-label="Главная секция действий">
+  <div class="hero-box" aria-live="polite">
+    <button type="button" class="btn btn-large" data-link="event-edit" aria-label="Создать новое событие">
+      Создать событие
+    </button>
+
+    <div class="join-block" role="group" aria-label="Присоединиться по коду">
+      <input
+        type="text"
+        id="join-code"
+        inputmode="text"
+        autocomplete="one-time-code"
+        placeholder="Код события"
+        aria-label="Введите код события"
+      />
+      <button type="button" class="btn btn-large" data-action="join" aria-label="Присоединиться к событию">
+        Присоединиться
+      </button>
     </div>
-  </main>
+  </div>
+</main>
 
-  <!-- остальной код страницы, скрипты и т.д. оставь как есть -->
+<div id="fh-message-clouds" aria-hidden="true"></div>
 
-  <!-- Supabase client -->
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  <!-- Public env -->
-  <script src="env.js"></script>
-  <!-- App -->
-  <script type="module" src="js/app.js"></script>
+<!-- Supabase client -->
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<!-- Public env -->
+<script src="env.js"></script>
+<!-- App -->
+<script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -148,14 +148,6 @@ document.addEventListener('DOMContentLoaded',()=> setTimeout(startFH,100));
   });
 })();
 
-/* ------------------ Навигация верхних кнопок ------------------ */
-document.addEventListener('click',(e)=>{
-  const b=e.target.closest('[data-link]'); if (!b) return;
-  e.preventDefault();
-  const to = LINKS[b.getAttribute('data-link')];
-  if (to) goto(to);
-});
-
 /* ------------------ Logout ------------------ */
 document.addEventListener('click', async (e)=>{
   const b=e.target.closest('[data-action="logout"]'); if (!b) return;
@@ -509,4 +501,50 @@ async function initEventSummary(){
   toAnalBtn?.addEventListener('click', ()=>{
     location.href = `/event-analytics.html?code=${encodeURIComponent(code)}`;
   });
+}
+
+/* --- Navigation via data-link (no page reload) --- */
+document.addEventListener('click', (e) => {
+  const linkEl = e.target.closest('[data-link]');
+  if (linkEl) {
+    e.preventDefault();
+    const key = linkEl.getAttribute('data-link');
+    const href = LINKS[key];
+    if (href) goto(href);
+    return;
+  }
+
+  // Join by code button
+  const joinBtn = e.target.closest('[data-action="join"]');
+  if (joinBtn) {
+    e.preventDefault();
+    triggerJoinByCode();
+  }
+});
+
+// Handle Enter inside the join input without submitting a form
+document.addEventListener('keydown', (e) => {
+  const active = document.activeElement;
+  if (e.key === 'Enter' && active && active.id === 'join-code') {
+    e.preventDefault();
+    triggerJoinByCode();
+  }
+});
+
+// Safety: block any accidental form submits around the join UI
+document.addEventListener('submit', (e) => {
+  if (e.target.querySelector && e.target.querySelector('#join-code')) {
+    e.preventDefault();
+    triggerJoinByCode();
+  }
+});
+
+function triggerJoinByCode() {
+  const input = document.getElementById('join-code');
+  const code = input ? input.value.trim() : '';
+  if (!code) return;
+  if (typeof joinByCode === 'function') {
+    return joinByCode(code);
+  }
+  goto(`/event-summary.html?code=${encodeURIComponent(code)}`);
 }

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -944,6 +944,7 @@ body.scene-intro, body.scene-final { overflow: hidden; }
   width: min(960px, 94vw);
 }
 
+/* --- Hero (centered CTA) --- */
 .hero {
   display: flex;
   justify-content: center;
@@ -962,6 +963,8 @@ body.scene-intro, body.scene-final { overflow: hidden; }
   padding: 2.5rem 3rem;
   border-radius: 1.5rem;
   box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+  max-width: 640px;
+  width: 100%;
 }
 
 .hero-box .btn-large {
@@ -973,13 +976,42 @@ body.scene-intro, body.scene-final { overflow: hidden; }
 .join-block {
   display: flex;
   gap: 0.8rem;
-  align-items: center;
+  align-items: stretch;
+  width: 100%;
 }
 
 .join-block input {
+  flex: 1 1 auto;
   padding: 0.7rem 1rem;
   border-radius: 1rem;
   border: none;
   outline: none;
   font-size: 1rem;
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+}
+
+.join-block .btn-large {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+/* --- Responsive (stack on small screens) --- */
+@media (max-width: 640px) {
+  .hero {
+    padding: 1.25rem;
+    min-height: calc(100vh - 56px);
+  }
+  .hero-box {
+    padding: 1.5rem;
+    border-radius: 1.25rem;
+  }
+  .join-block {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .join-block input,
+  .join-block .btn-large {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- add centered hero CTA on landing with create/join controls
- style hero block and responsive join layout
- handle data-link navigation and join by code without page reloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be4412e1248332a4c4bcfa08a8c314