### PR TITLE
Add guest RSVP flow with local demo mode

### DIFF
--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -24,30 +24,29 @@
 
     <form id="editForm" autocomplete="off">
       <div class="grid">
-        <label>
-          Название
-          <input type="text" id="eventTitle" name="title" placeholder="Название события" required />
+        <label>Название
+          <input type="text" id="eventTitle" required />
         </label>
-
-        <label>
-          Дата и время
-          <input type="datetime-local" id="eventDate" name="datetime" required />
+        <label>Дата события
+          <input type="date" id="eventDate" required />
         </label>
-
-        <label>
-          Место
-          <input type="text" id="eventPlace" name="place" placeholder="Адрес или ссылка" />
+        <label>Время начала
+          <input type="time" id="eventTime" required />
         </label>
-
-        <label>
-          Описание
-          <textarea id="eventDesc" name="desc" rows="3" placeholder="Кратко о событии"></textarea>
+        <label>Адрес
+          <input type="text" id="eventPlace" />
+        </label>
+        <label>Дресс-код
+          <input type="text" id="eventDress" />
+        </label>
+        <label>Комментарий
+          <textarea id="eventDesc" rows="3"></textarea>
         </label>
       </div>
 
       <div class="actions">
         <button type="button" class="btn" data-link="menu">Отмена</button>
-        <button type="submit" class="btn primary" id="saveEvent">Сохранить</button>
+        <button type="submit" class="btn primary" id="btnEditNext">Дальше</button>
       </div>
     </form>
   </section>

--- a/FroggyHub/gift-claim.html
+++ b/FroggyHub/gift-claim.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Итоги события</title>
+  <title>Подарки</title>
   <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
@@ -18,16 +18,12 @@
 </header>
 <div id="fh-message-clouds" aria-hidden="true"></div>
 <main class="container">
-  <div class="card summary-card">
-    <h1 id="sumTitle">Событие</h1>
-    <p><strong>Дата:</strong> <span id="sumDate">—</span></p>
-    <p><strong>Время:</strong> <span id="sumTime">—</span></p>
-    <p><strong>Адрес:</strong> <span id="sumPlace">—</span></p>
-    <p><strong>Дресс-код:</strong> <span id="sumDress">—</span></p>
-    <p><strong>Комментарий:</strong> <span id="sumDesc">—</span></p>
-    <h2>Вишлист</h2>
+  <div class="card">
+    <h1>Вишлист</h1>
     <div id="wlGrid" class="wl-grid"></div>
-    <div class="event-code">Код события: <span id="eventCode"></span> <button class="btn" id="copyCode">Скопировать код</button></div>
+    <div class="bar-actions" style="margin-top:1.5rem;">
+      <button class="btn btn--primary" id="giftNext">Дальше</button>
+    </div>
   </div>
 </main>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>

--- a/FroggyHub/guest-summary.html
+++ b/FroggyHub/guest-summary.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Итоги события</title>
+  <title>Спасибо</title>
   <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
@@ -19,15 +19,10 @@
 <div id="fh-message-clouds" aria-hidden="true"></div>
 <main class="container">
   <div class="card summary-card">
-    <h1 id="sumTitle">Событие</h1>
-    <p><strong>Дата:</strong> <span id="sumDate">—</span></p>
-    <p><strong>Время:</strong> <span id="sumTime">—</span></p>
-    <p><strong>Адрес:</strong> <span id="sumPlace">—</span></p>
-    <p><strong>Дресс-код:</strong> <span id="sumDress">—</span></p>
-    <p><strong>Комментарий:</strong> <span id="sumDesc">—</span></p>
-    <h2>Вишлист</h2>
-    <div id="wlGrid" class="wl-grid"></div>
-    <div class="event-code">Код события: <span id="eventCode"></span> <button class="btn" id="copyCode">Скопировать код</button></div>
+    <h1>Спасибо!</h1>
+    <p>Имя: <span id="gsName"></span></p>
+    <p>Статус: <span id="gsAttend"></span></p>
+    <p id="gsGiftWrap">Ваш подарок: <span id="gsGift"></span></p>
   </div>
 </main>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -1,37 +1,21 @@
-// app.js — навигация + поток Owner/Guest + пост-онбординг события
-import {
-  supa, getSession, onAuthState,
-  signIn, signUpWithNickname, signOut,
-  joinEvent
-} from './api.js';
+import { supa, getSession, signIn, signUpWithNickname, signOut } from './api.js';
 
-/* ------------------ Утилиты ------------------ */
 const LINKS = {
   home: '/index.html',
   menu: '/lobby.html',
   profile: '/profile.html',
-  settings: '/profile.html',
-  'event-edit': '/event-edit.html',
-  'wishlist-setup': '/wishlist-setup.html',
-  'event-summary': '/event-summary.html',
-  'event-analytics': '/event-analytics.html'
+  settings: '/lobby.html',
+  'event-edit': '/event-edit.html'
 };
-const qs  = (s, r = document) => r.querySelector(s);
-const qsa = (s, r = document) => Array.from(r.querySelectorAll(s));
-const path   = () => location.pathname.replace(/\/+$/, '/');
-const params = () => Object.fromEntries(new URLSearchParams(location.search).entries());
-const isPage = (name) => path().endsWith(`/${name}`);
-function setAuthState(isAuthed) {
-  document.body.classList.toggle('authed', !!isAuthed);
-  document.body.classList.toggle('guest', !isAuthed);
-  qsa('[data-auth-only]').forEach(el => el.hidden = !isAuthed);
-  qsa('[data-guest-only]').forEach(el => el.hidden = !!isAuthed);
-}
-function goto(href) { location.href = href; }
-function copy(text) { try { navigator.clipboard?.writeText(text); } catch {} }
+const qs=(s,r=document)=>r.querySelector(s);
+const qsa=(s,r=document)=>Array.from(r.querySelectorAll(s));
+const path=()=>location.pathname.replace(/\/+$,'/');
+const isPage=(name)=>path().endsWith(`/${name}`);
+function goto(h){ location.href=h; }
+function copy(t){ try{ navigator.clipboard?.writeText(t);}catch{} }
 
-/* ------------------ Фоновая анимация (чипы) ------------------ */
-const FH_MESSAGES = [
+/* ------------------ Cloud messages ------------------ */
+const FH_MESSAGES=[
   "Я приду к 19:00 ✨","Я возьму пиццу 🍕","Кто возьмёт колу? 🥤",
   "Ребят, постучите в дверь 🚪","Буду позже 🙈","Добавил плейлист 🎶",
   "Кто возьмет настолки? 🎲","Буду через 15 минут ⏳","Я за пивом 🍺",
@@ -45,557 +29,213 @@ const FH_MESSAGES = [
   "У кого есть карты?","Привезу геймпад","Я за хлопьями",
   "Я возьму сок","Приеду на час раньше","Кто возьмёт кофе?","Где паркуемся? 🅿️"
 ];
-let fhRoot=null, chips=[], rafId=0, vw=0, vh=0;
+let fhRoot=null,chips=[],rafId=0,vw=0,vh=0;
 const REDUCED_MOTION = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
 const rnd=(a,b)=>Math.random()*(b-a)+a;
 function ensureFH(){
-  if (!fhRoot){
-    fhRoot = document.getElementById('fh-message-clouds') || (()=> {
-      const d=document.createElement('div'); d.id='fh-message-clouds'; d.setAttribute('aria-hidden','true');
-      d.style.pointerEvents='none'; document.body.prepend(d); return d;
-    })();
-  } return fhRoot;
+  if(!fhRoot){
+    fhRoot=document.getElementById('fh-message-clouds')||(()=>{const d=document.createElement('div');d.id='fh-message-clouds';d.setAttribute('aria-hidden','true');d.style.pointerEvents='none';document.body.prepend(d);return d;})();
+  }
+  return fhRoot;
 }
 function spawnChips(count=null){
-  const root=ensureFH(); if (!root) return;
-  root.innerHTML=''; chips=[];
+  const root=ensureFH(); if(!root) return; root.innerHTML=''; chips=[];
   vw=innerWidth; vh=innerHeight;
-  const n = count ?? Math.min(FH_MESSAGES.length, vw<420?10:vw<768?16:24);
-  const arr = [...FH_MESSAGES].sort(()=>Math.random()-0.5).slice(0,n);
-  arr.forEach(t=>{
-    const el=document.createElement('div');
-    el.className='fh-chip';
-    el.textContent=t;
-    const x=rnd(20,vw-160), y=rnd(20,vh-60);
-    el.style.left=`${x}px`;
-    el.style.top=`${y}px`;
-    el.style.transform='translate3d(0,0,0)';
-    root.appendChild(el);
-    const r=el.getBoundingClientRect();
-    const c={el, w:r.width||140, h:r.height||40, x, y, vx:rnd(-.08,.08), vy:rnd(-.08,.08)};
-    chips.push(c);
-  });
+  const n=count??Math.min(FH_MESSAGES.length,vw<420?10:vw<768?16:24);
+  const arr=[...FH_MESSAGES].sort(()=>Math.random()-0.5).slice(0,n);
+  arr.forEach(t=>{const el=document.createElement('div');el.className='fh-chip';el.textContent=t;const x=rnd(20,vw-160),y=rnd(20,vh-60);el.style.left=`${x}px`;el.style.top=`${y}px`;el.style.transform='translate3d(0,0,0)';root.appendChild(el);const r=el.getBoundingClientRect();const c={el,w:r.width||140,h:r.height||40,x,y,vx:rnd(-.08,.08),vy:rnd(-.08,.08)};chips.push(c);});
 }
-// --- FIXED LOGIC BELOW ---
 function updateChips(){
-  const m = 20;
-  for (const c of chips){
-    c.x += c.vx; c.y += c.vy;
-
-    if (c.x <= m || c.x + c.w >= vw - m){
-      c.vx *= -1;
-      c.x = Math.max(m, Math.min(c.x, vw - c.w - m));
-    }
-    if (c.y <= m || c.y + c.h >= vh - m){
-      c.vy *= -1;
-      // было: Math.min(c.y, vh - m)
-      c.y = Math.max(m, Math.min(c.y, vh - c.h - m));
-    }
-    c.el.style.left = `${c.x}px`;
-    c.el.style.top  = `${c.y}px`;
+  const m=20;
+  for(const c of chips){
+    c.x+=c.vx; c.y+=c.vy;
+    if(c.x<=m||c.x+c.w>=vw-m){c.vx*=-1;c.x=Math.max(m,Math.min(c.x,vw-c.w-m));}
+    if(c.y<=m||c.y+c.h>=vh-m){c.vy*=-1;c.y=Math.max(m,Math.min(c.y,vh-c.h-m));}
+    c.el.style.left=`${c.x}px`; c.el.style.top=`${c.y}px`;
   }
-
-  for (let i = 0; i < chips.length; i++)
-    for (let j = i + 1; j < chips.length; j++){
-      const a = chips[i], b = chips[j];
-      if (a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y){
-        [a.vx, b.vx] = [b.vx, a.vx];
-        [a.vy, b.vy] = [b.vy, a.vy];
-      }
-    }
+  for(let i=0;i<chips.length;i++) for(let j=i+1;j<chips.length;j++){const a=chips[i],b=chips[j];if(a.x<b.x+b.w&&a.x+a.w>b.x&&a.y<b.y+b.h&&a.y+a.h>b.y){[a.vx,b.vx]=[b.vx,a.vx];[a.vy,b.vy]=[b.vy,a.vy];}}
 }
-function tick(){ updateChips(); rafId=requestAnimationFrame(tick); }
-function startFH(){ cancelAnimationFrame(rafId); if (REDUCED_MOTION) return; spawnChips(); rafId=requestAnimationFrame(tick); }
-addEventListener('resize',()=>{ clearTimeout(startFH._t); startFH._t=setTimeout(()=>spawnChips(chips.length),250); });
-document.addEventListener('visibilitychange',()=> document.hidden?cancelAnimationFrame(rafId):startFH());
-document.addEventListener('DOMContentLoaded',()=> setTimeout(startFH,100));
+function tick(){updateChips();rafId=requestAnimationFrame(tick);} 
+function startFH(){cancelAnimationFrame(rafId);if(REDUCED_MOTION) return;spawnChips();rafId=requestAnimationFrame(tick);} 
+addEventListener('resize',()=>{clearTimeout(startFH._t);startFH._t=setTimeout(()=>spawnChips(chips.length),250);});
+document.addEventListener('visibilitychange',()=>document.hidden?cancelAnimationFrame(rafId):startFH());
+setTimeout(startFH,100);
 
-/* ------------------ Auth вкладки (index.html) ------------------ */
-(function wireAuthTabs(){
-  const tabs = qsa('[data-auth-tab]'); const panes = qsa('.auth-pane[data-pane]'); const err = qs('#auth-error');
-  document.addEventListener('click',(e)=>{
-    const t=e.target.closest('[data-auth-tab]'); if (!t) return;
-    const key=t.getAttribute('data-auth-tab');
-    tabs.forEach(b=>b.classList.toggle('is-active', b===t));
-    panes.forEach(p=>{ const on=p.dataset.pane===key; p.hidden=!on; p.classList.toggle('visible', on); });
-    if (err){ err.textContent=''; err.hidden=true; }
-  });
+/* ------------------ Demo polyfills ------------------ */
+function genCode(len=6){const a='ABCDEFGHJKLMNPQRSTUVWXYZ23456789';let s='';for(let i=0;i<len;i++) s+=a[(Math.random()*a.length)|0];return s;}
+function _db(){return JSON.parse(localStorage.getItem('fh_demo_db')||'{}');}
+function _save(db){localStorage.setItem('fh_demo_db',JSON.stringify(db));}
+if(typeof window.saveEvent!=='function'){
+  window.saveEvent=async payload=>{const db=_db();const code=genCode();const sess=JSON.parse(localStorage.getItem('fh_demo_session')||'{}');db.events??={};db.events[code]={code,...payload,ownerId:sess.user?.login||sess.user?.nickname||sess.user?.email||'demo',createdAt:Date.now()};db.wl??={};db.wl[code]=[];_save(db);return code;};
+}
+function getEvent(code){return _db().events?.[code]||null;}
+function addWishlistItem(code,item){const db=_db();db.wl??={};db.wl[code]??=[];db.wl[code].push({...item,id:crypto?.randomUUID?.()||genCode(8),status:'free'});_save(db);}
+function getWishlist(code){return _db().wl?.[code]||[];}
+function claimItem(code,id,name){const db=_db();const list=db.wl?.[code]||[];const it=list.find(x=>x.id===id&&x.status==='free');if(it){it.status='taken';it.by=name;_save(db);return true;}return false;}
+function saveRsvp(code,name,attend){const db=_db();db.rsvp??={};db.rsvp[code]??=[];db.rsvp[code].push({name,attend});_save(db);}
+function listMyEvents(user){const db=_db();return Object.values(db.events||{}).filter(e=>e.ownerId===user);} 
+function listGuestEvents(user){const db=_db();const codes=Object.entries(db.rsvp||{}).filter(([c,l])=>l.some(r=>r.name===user&&r.attend==='yes')).map(([c])=>c);return codes.map(c=>db.events?.[c]).filter(Boolean);}
 
-  const fLogin = qs('#form-login');
-  const fSignup = qs('#form-signup');
+/* ------------------ Boot ------------------ */
+async function boot(){
+  const session=await getSession();
+  const authed=!!session||JSON.parse(localStorage.getItem('fh_demo_session')||'false');
+  const AUTH_AVAILABLE=!!supa;
+  const p=path(); const isLogin=p.endsWith('/login.html');
+  if(AUTH_AVAILABLE){
+    if(authed&&isLogin){goto('/lobby.html');return;}
+    if(!authed&&!isLogin){goto('/login.html');return;}
+  }
+  if(isPage('login.html')) initAuth();
+  if(isPage('lobby.html')) initLobby();
+  if(isPage('event-edit.html')) initEventEdit();
+  if(isPage('wishlist-setup.html')) initWishlistSetup();
+  if(isPage('event-summary.html')) initEventSummary();
+  if(isPage('rsvp.html')) initRsvp();
+  if(isPage('gift-claim.html')) initGiftClaim();
+  if(isPage('guest-summary.html')) initGuestSummary();
+  if(isPage('profile.html')) initProfile();
+}
+document.addEventListener('DOMContentLoaded',()=>{boot().catch(console.error);});
 
-  fLogin?.addEventListener('submit', async (e)=>{
+/* ------------------ Global navigation ------------------ */
+document.addEventListener('click',e=>{
+  const link=e.target.closest('[data-link]');
+  if(link){e.preventDefault();const key=link.getAttribute('data-link');const href=LINKS[key];if(href) goto(href);return;}
+  if(e.target.dataset.action==='logout'){localStorage.removeItem('fh_demo_session');try{signOut?.();}catch{}goto('/login.html');}
+});
+
+/* ------------------ Auth ------------------ */
+function initAuth(){
+  qs('#form-login')?.addEventListener('submit',async e=>{
     e.preventDefault();
-    const nickname = (fLogin.nickname.value||'').trim();
-    const password = fLogin.password.value;
+    const login=qs('#loginId')?.value.trim();
+    const password=qs('#loginPassword')?.value;
+    if(!login||!password){alert('Заполните поля');return;}
     try{
-      const r = await signIn({ login:nickname, password });
-      if (!r) throw new Error('Не удалось войти');
-      goto(LINKS.menu);
-    }catch(er){ if (err){ err.textContent=er.message||'Ошибка входа'; err.hidden=false; } }
+      if(supa){await signIn({login,password});}
+      else{localStorage.setItem('fh_demo_session',JSON.stringify({user:{login}}));}
+      goto('/lobby.html');
+    }catch(err){alert(err.message||'Ошибка входа');}
   });
-
-  fSignup?.addEventListener('submit', async (e)=>{
+  qs('#form-signup')?.addEventListener('submit',async e=>{
     e.preventDefault();
-    const nickname = (fSignup.nickname.value||'').trim();
-    const email    = (fSignup.email.value||'').trim();
-    const password = fSignup.password.value;
+    const nickname=qs('#signupNickname')?.value.trim();
+    const email=qs('#signupEmail')?.value.trim();
+    const password=qs('#signupPassword')?.value;
+    if(!nickname||!email||!password){alert('Заполните поля');return;}
     try{
-      const r = await signUpWithNickname({ nickname, email, password });
-      if (r?.error) throw r.error;
-      goto(LINKS.menu);
-    }catch(er){ if (err){ err.textContent=er.message||'Ошибка регистрации'; err.hidden=false; } }
-  });
-})();
-
-/* ------------------ Logout ------------------ */
-document.addEventListener('click', async (e)=>{
-  const b=e.target.closest('[data-action="logout"]'); if (!b) return;
-  await signOut(); goto(LINKS.home);
-});
-
-/* ------------------ Boot & роутинг ------------------ */
-async function boot() {
-  const session = await getSession();
-  const authed = !!session;
-  setAuthState(authed);
-
-  // --- Safe redirects ---
-  // If auth client is unavailable (no Supabase creds) — do NOT enforce redirects.
-  const AUTH_AVAILABLE = !!supa;
-
-  // Authenticated users who land on the root should go to menu.
-  if (AUTH_AVAILABLE && authed && (path() === '/' || path().endsWith('/index.html'))) {
-    goto(LINKS.menu);
-    return;
-  }
-
-  // IMPORTANT:
-  // Do NOT redirect guests away from non-index pages.
-  // Each page already performs its own checks and shows alerts without navigation.
-  // (So we intentionally removed: if (!authed && not index) goto home;)
-
-  // --- Routes init as before ---
-  if (isPage('lobby.html')) await initLobby();
-
-  if (isPage('event-edit.html')) {
-    await initEventEdit();
-  }
-
-  if (isPage('wishlist-setup.html')) await initWishlistSetup();
-  if (isPage('event-summary.html')) await initEventSummary();
-
-  if (isPage('event-analytics.html')) await initEventAnalytics();
-
-  if (isPage('profile.html')) await initProfile();
-
-  onAuthState((sess) => setAuthState(!!sess));
-}
-document.addEventListener('DOMContentLoaded', () => { boot().catch?.(console.error); });
-
-/* ------------------ Lobby (создать / присоединиться) ------------------ */
-async function initLobby(){
-  document.addEventListener('click', async (e)=>{
-    if (e.target?.id !== 'btnJoin') return;
-    const code = qs('#joinCode')?.value?.trim();
-    if (!code || code.length < 6) return alert('Введите 6-значный код');
-    try {
-      const res = await joinEvent({ code });
-      if (res?.success && res?.url) { goto(res.url); return; }
-      goto(`/event-analytics.html?code=${encodeURIComponent(code)}&guest=1`);
-    } catch (err) {
-      alert(err.message || 'Не удалось присоединиться');
-    }
+      if(supa){await signUpWithNickname({nickname,email,password});}
+      localStorage.setItem('fh_demo_session',JSON.stringify({user:{login:nickname,email}}));
+      goto('/lobby.html');
+    }catch(err){alert(err.message||'Ошибка регистрации');}
   });
 }
 
-/* ------------------ Создание события ------------------ */
-
-function renderEventEditInto(target = document.body) {
-  const existed = qs('#editForm');
-  if (existed) return existed;
-
-  const tpl = `
-  <main class="page event-edit">
-    <section class="card">
-      <h1>Создание события</h1>
-      <form id="editForm" autocomplete="off">
-        <div class="grid">
-          <label>Название
-            <input type="text" id="eventTitle" name="title" placeholder="Название события" required />
-          </label>
-          <label>Дата и время
-            <input type="datetime-local" id="eventDate" name="datetime" required />
-          </label>
-          <label>Место
-            <input type="text" id="eventPlace" name="place" placeholder="Адрес или ссылка" />
-          </label>
-          <label>Описание
-            <textarea id="eventDesc" name="desc" rows="3" placeholder="Кратко о событии"></textarea>
-          </label>
-        </div>
-        <div class="actions">
-          <button type="button" class="btn" data-link="menu">Отмена</button>
-          <button type="submit" class="btn primary" id="saveEvent">Сохранить</button>
-        </div>
-      </form>
-    </section>
-  </main>`;
-  const wrap = document.createElement('div');
-  wrap.innerHTML = tpl.trim();
-  const main = wrap.firstElementChild;
-  // вставляем сразу после шапки
-  const header = qs('header.topbar');
-  if (header && header.parentNode) {
-    header.parentNode.insertBefore(main, header.nextSibling);
-  } else {
-    target.appendChild(main);
-  }
-  return main.querySelector('#editForm');
+/* ------------------ Lobby ------------------ */
+function initLobby(){
+  qs('#btnJoin')?.addEventListener('click',()=>{
+    const code=qs('#joinCode')?.value.trim();
+    if(code&&code.length>=6) goto(`/rsvp.html?code=${encodeURIComponent(code)}`);
+  });
 }
 
-async function initEventEdit() {
-  // если формы нет — создать
-  let form = qs('#editForm') || renderEventEditInto(document.body);
-  if (!form) {
-    console.warn('[event-edit] form not found and failed to render');
-    return;
-  }
-  const saveBtn = qs('#saveEvent');
-
-  // Если нужно — префилл (например, из query)
-  const q = new URLSearchParams(location.search);
-  if (q.get('title')) qs('#eventTitle').value = q.get('title');
-  // другие поля можно дополнить по необходимости
-
-  // Сабмит
-  form.addEventListener('submit', async (e) => {
+/* ------------------ Event Edit ------------------ */
+function initEventEdit(){
+  const form=qs('#editForm');
+  form?.addEventListener('submit',async e=>{
     e.preventDefault();
-    try {
-      const payload = {
-        title: qs('#eventTitle')?.value?.trim(),
-        datetime: qs('#eventDate')?.value,
-        place: qs('#eventPlace')?.value?.trim(),
-        desc: qs('#eventDesc')?.value?.trim(),
-      };
-      if (!payload.title || !payload.datetime) {
-        alert('Заполните название и дату/время');
-        return;
-      }
-      // saveEvent — существующая функция/эндпоинт (оставь как было, если уже есть)
-      const code = await saveEvent(payload); // должен вернуть код события
-      if (code) goto(`/event-summary.html?code=${encodeURIComponent(code)}`);
-    } catch (err) {
-      console.error('[event-edit] save failed', err);
-      alert('Не удалось сохранить событие');
-    }
-  });
-
-  // На всякий — кнопка "Сохранить" кликает submit формы
-  if (saveBtn && !saveBtn.dataset.bound) {
-    saveBtn.dataset.bound = '1';
-    saveBtn.addEventListener('click', (e) => {
-      e.preventDefault();
-      form.requestSubmit?.();
-    });
-  }
-}
-
-/* ------------------ Страница события (аналитика/только владелец) ------------------ */
-
-async function initEventAnalytics(){
-  if (!supa) return;
-  const p = params();
-  const code = p.code?.trim();
-  if (!code) { qs('#error')?.replaceChildren(document.createTextNode('Код события не указан')); return; }
-
-  const { data: ev, error } = await supa.from('events').select('*').eq('code', code).single();
-  if (error || !ev) { qs('#error')?.replaceChildren(document.createTextNode('Событие не найдено')); return; }
-
-  // проверяем владельца
-  const sess = await getSession();
-  let myPid = null;
-  if (sess?.user?.id) {
-    const { data: me } = await supa.from('profiles').select('pid').eq('id', sess.user.id).single();
-    myPid = me?.pid ?? null;
-  }
-  // ИЗМЕНЕНИЕ: теперь только pid совпадает
-  const isOwner = (myPid != null && Number(ev.host_user_id) === Number(myPid));
-
-  if (!isOwner) { alert('Доступ к аналитике есть только у создателя события'); goto(LINKS.menu); return; }
-
-  qs('#eventTitle')?.replaceChildren(document.createTextNode(ev.title || 'Событие'));
-  qs('#eventDate')?.replaceChildren(document.createTextNode(ev.date || '—'));
-  qs('#eventTime')?.replaceChildren(document.createTextNode(ev.time || '—'));
-  qs('#eventAddr')?.replaceChildren(document.createTextNode(ev.address || '—'));
-  qs('#editEventBtn')?.classList.toggle('hidden', !isOwner);
-
-  // FIX: дождаться загрузки списков
-  await renderRSVP(ev.id);
-  await renderWishlist(ev.id);
-
-  qs('#backBtn')?.addEventListener('click', ()=> goto(LINKS.menu));
-  qs('#editEventBtn')?.addEventListener('click', ()=> goto(`${LINKS['event-edit']}?code=${encodeURIComponent(code)}`));
-}
-
-
-/* ------------------ Списки (read-only) ------------------ */
-async function renderRSVP(event_id){
-  const list = qs('#visitorsList'); if (!list) return;
-  const { data } = await supa.from('rsvps').select('nickname,status').eq('event_id', event_id);
-  list.innerHTML = '';
-  (data||[]).forEach(r=>{
-    const li=document.createElement('li');
-    li.className='ea-item';
-    li.textContent = `${r.nickname || 'Гость'} — ${statusEmoji(r.status)}`;
-    list.appendChild(li);
-  });
-  const yes   = (data||[]).filter(x=>x.status==='yes').length;
-  const maybe = (data||[]).filter(x=>x.status==='maybe').length;
-  const no    = (data||[]).filter(x=>x.status==='no').length;
-  const y = qs('#rsvpYesCount'), m = qs('#rsvpMaybeCount'), n = qs('#rsvpNoCount');
-  y && (y.textContent = String(yes));
-  m && (m.textContent = String(maybe));
-  n && (n.textContent = String(no));
-}
-function statusEmoji(s){ return s==='yes'?'🟢 Иду':s==='maybe'?'🟡 Возможно':'🔴 Не иду'; }
-
-async function renderWishlist(event_id){
-  const list = qs('#wishlistList'); if (!list) return;
-  const { data } = await supa.from('gifts').select('title,taken_by').eq('event_id', event_id);
-  list.innerHTML='';
-  (data||[]).forEach(g=>{
-    const li=document.createElement('li');
-    li.className='wl-item';
-    li.textContent = g.title || 'Подарок';
-    if (g.taken_by) li.textContent += ' — 🔒 занято';
-    list.appendChild(li);
-  });
-  const free  = (data||[]).filter(x=>!x.taken_by).length;
-  const taken = (data||[]).filter(x=>x.taken_by).length;
-  const f = qs('#giftFreeCount'), t = qs('#giftTakenCount');
-  f && (f.textContent = String(free));
-  t && (t.textContent = String(taken));
-}
-
-/* ------------------ Профиль ------------------ */
-async function initProfile(){
-  if (!supa) return;
-  const sess = await getSession(); if (!sess?.user?.id) return;
-
-  const { data: me } = await supa.from('profiles').select('pid').eq('id', sess.user.id).single();
-  const myPid = me?.pid; if (!myPid) return;
-
-  const today = new Date().toISOString().slice(0,10);
-
-  const { data: mine } = await supa.from('events')
-    .select('id,title,date,code')
-    .eq('host_user_id', myPid)
-    .order('date', { ascending: true });
-
-  const { data: guestIn } = await supa.from('rsvps')
-    .select('event_id,events(id,title,date,code)')
-    .eq('user_id', sess.user.id)
-    .order('created_at', { ascending: false });
-
-  const container = qs('.container'); if (!container) return;
-  const card=document.createElement('div'); card.className='card';
-  const h2=document.createElement('h2'); h2.textContent='Мои события';
-  card.appendChild(h2);
-
-  function sect(title, items){
-    const d=document.createElement('div');
-    const hh=document.createElement('h3'); hh.textContent=title; d.appendChild(hh);
-    const ul=document.createElement('ul');
-    (items||[]).forEach(ev=>{
-      const e = ev.events || ev;
-      const li=document.createElement('li');
-      const a=document.createElement('a');
-      // Гость: не ведём в аналитику, просто текст
-      if (title === 'Гость') {
-        a.textContent = `${e.title} — ${e.date||'—'}`;
-        a.classList.add('disabled-link');
-        a.title = 'Аналитика доступна только создателю события';
-      } else {
-        a.href=`/event-analytics.html?code=${encodeURIComponent(e.code)}&owner=1`;
-        a.textContent=`${e.title} — ${e.date||'—'}`;
-      }
-      li.appendChild(a); ul.appendChild(li);
-    });
-    d.appendChild(ul); return d;
-  }
-
-  const upcoming = (mine||[]).filter(e=>!e.date || e.date >= today);
-  const past     = (mine||[]).filter(e=> e.date && e.date <  today);
-
-  card.appendChild(sect('Владелец — ближайшие', upcoming));
-  card.appendChild(sect('Владелец — прошедшие', past));
-  card.appendChild(sect('Гость', (guestIn||[])));
-
-  container.appendChild(card);
-}
-
-/* ------------------ Мини-тост ------------------ */
-function toast(msg){
-  const t = qs('#toast'); if (!t) return; t.textContent=msg; t.hidden=false;
-  clearTimeout(toast._t); toast._t=setTimeout(()=>{ t.hidden=true; }, 2000);
-}
-
-/* ------------------ Wishlist Setup (после создания события) ------------------ */
-async function initWishlistSetup(){
-  const p = params();
-  const code = (p.code || '').trim();
-  const errEl = document.getElementById('wlError');
-  const listEl = document.getElementById('giftList');
-  const freeEl = document.getElementById('giftFreeCount');
-  const takenEl = document.getElementById('giftTakenCount');
-  const addBtn = document.getElementById('giftAdd');
-  const nextBtn = document.getElementById('giftNext');
-  const skipBtn = document.getElementById('giftSkip');
-  const inputEl = document.getElementById('giftInput');
-
-  function showErr(m){ if(errEl){ errEl.textContent=m||''; } }
-
-  if (!code){ showErr('Код события не указан'); return; }
-
-  // грузим событие
-  const { data: ev, error: evErr } = await supa.from('events').select('*').eq('code', code).single();
-  if (evErr || !ev){ showErr('Событие не найдено'); return; }
-  document.getElementById('wlTitle')?.replaceChildren(document.createTextNode(`Вишлист: ${ev.title || 'Событие'}`));
-
-  // проверка владельца
-  const sess = await getSession();
-  let isOwner = false;
-  if (sess?.user?.id){
-    const { data: me } = await supa.from('profiles').select('pid').eq('id', sess.user.id).single();
-    isOwner = me?.pid != null && Number(ev.host_user_id) === Number(me.pid);
-  }
-  if (!isOwner){ showErr('Только владелец может редактировать вишлист'); return; }
-
-  async function renderList(){
-    const { data: gifts } = await supa.from('gifts').select('id,title,taken_by').eq('event_id', ev.id).order('id', { ascending: true });
-    listEl.innerHTML = '';
-    let free=0, taken=0;
-    (gifts||[]).forEach(g=>{
-      const li=document.createElement('li');
-      li.className='wl-item';
-      li.textContent = g.title || 'Подарок';
-      if (g.taken_by){ li.textContent += ' — 🔒 занято'; taken++; } else { free++; }
-      listEl.appendChild(li);
-    });
-    if (freeEl)  freeEl.textContent  = String(free);
-    if (takenEl) takenEl.textContent = String(taken);
-  }
-
-  async function addGift(){
-    showErr('');
-    const title = (inputEl?.value || '').trim();
-    if (!title){ showErr('Введите название подарка'); return; }
-    const { error } = await supa.from('gifts').insert([{ event_id: ev.id, title }]);
-    if (error){ showErr(error.message || 'Не удалось добавить'); return; }
-    inputEl.value = '';
-    await renderList();
-  }
-
-  addBtn?.addEventListener('click', addGift);
-  inputEl?.addEventListener('keydown', (e)=>{ if(e.key==='Enter'){ e.preventDefault(); addGift(); }});
-
-  nextBtn?.addEventListener('click', ()=>{
-    location.href = `/event-summary.html?code=${encodeURIComponent(code)}`;
-  });
-  skipBtn?.addEventListener('click', ()=>{
-    location.href = `/event-summary.html?code=${encodeURIComponent(code)}`;
-  });
-
-  await renderList();
-}
-
-/* ------------------ Event Summary (итоги + код приглашения) ------------------ */
-async function initEventSummary(){
-  const p = params();
-  const code = (p.code || '').trim();
-  const errEl = document.getElementById('sumError');
-
-  function showErr(m){ if(errEl){ errEl.textContent=m||''; } }
-
-  if (!code){ showErr('Код события не указан'); return; }
-
-  const { data: ev, error } = await supa.from('events').select('*').eq('code', code).single();
-  if (error || !ev){ showErr('Событие не найдено'); return; }
-
-  // только владелец видит эту страницу как финальный шаг
-  const sess = await getSession();
-  let isOwner = false;
-  if (sess?.user?.id){
-    const { data: me } = await supa.from('profiles').select('pid').eq('id', sess.user.id).single();
-    isOwner = me?.pid != null && Number(ev.host_user_id) === Number(me.pid);
-  }
-  if (!isOwner){ showErr('Только владелец может просматривать итоговую информацию'); return; }
-
-  const setText = (id, val)=> document.getElementById(id)?.replaceChildren(document.createTextNode(val ?? '—'));
-
-  setText('sumTitle', ev.title || 'Событие');
-  setText('sumDate', ev.date || '—');
-  setText('sumTime', ev.time || '—');
-  setText('sumAddr', ev.address || '—');
-  setText('sumNotes', ev.notes || '—');
-  setText('sumCode', ev.code || '—');
-
-  const copyBtn = document.getElementById('sumCopy');
-  copyBtn?.addEventListener('click', ()=> {
-    navigator.clipboard?.writeText(ev.code || '');
-    const t = document.getElementById('toast');
-    if (t){ t.textContent='Код скопирован'; t.hidden=false; clearTimeout(copyBtn._t); copyBtn._t=setTimeout(()=>{ t.hidden=true; }, 1500); }
-  });
-
-  const toAnalBtn = document.getElementById('toAnalytics');
-  toAnalBtn?.addEventListener('click', ()=>{
-    location.href = `/event-analytics.html?code=${encodeURIComponent(code)}`;
+    const payload={
+      title:qs('#eventTitle')?.value?.trim(),
+      date:qs('#eventDate')?.value,
+      time:qs('#eventTime')?.value,
+      place:qs('#eventPlace')?.value?.trim(),
+      dress:qs('#eventDress')?.value?.trim(),
+      desc:qs('#eventDesc')?.value?.trim(),
+    };
+    if(!payload.title||!payload.date||!payload.time){alert('Введите название, дату и время');return;}
+    const code=await saveEvent(payload);
+    goto(`/wishlist-setup.html?code=${encodeURIComponent(code)}`);
   });
 }
 
-/* --- Navigation via data-link (no page reload) --- */
-document.addEventListener('click', (e) => {
-  const linkEl = e.target.closest('[data-link]');
-  if (linkEl) {
+/* ------------------ Wishlist Setup ------------------ */
+function initWishlistSetup(){
+  const code=new URLSearchParams(location.search).get('code');
+  const grid=qs('#wlGrid');
+  const render=()=>{grid.innerHTML='';getWishlist(code).forEach(it=>{grid.insertAdjacentHTML('beforeend',`<div class="wl-item ${it.status}"><div class="wl-name">${it.name}</div>${it.url?`<a class="wl-link" href="${it.url}" target="_blank" rel="noopener">ссылка</a>`:''}</div>`);});};
+  render();
+  qs('#giftAdd')?.addEventListener('click',()=>qs('#giftModal').removeAttribute('hidden'));
+  qs('#giftSave')?.addEventListener('click',()=>{
+    const name=qs('#giftName').value.trim();
+    const url=qs('#giftUrl').value.trim();
+    if(!name) return;
+    addWishlistItem(code,{name,url:url||null});
+    qs('#giftName').value='';qs('#giftUrl').value='';qs('#giftModal').setAttribute('hidden','');
+    render();
+  });
+  qs('#giftNext')?.addEventListener('click',()=>goto(`/event-summary.html?code=${encodeURIComponent(code)}`));
+  qs('#giftSkip')?.addEventListener('click',()=>goto(`/event-summary.html?code=${encodeURIComponent(code)}`));
+}
+
+/* ------------------ Event Summary ------------------ */
+function initEventSummary(){
+  const code=new URLSearchParams(location.search).get('code');
+  const ev=getEvent(code); if(!ev) return;
+  qs('#sumTitle').textContent=ev.title||'Событие';
+  qs('#sumDate').textContent=ev.date||'—';
+  qs('#sumTime').textContent=ev.time||'—';
+  qs('#sumPlace').textContent=ev.place||'—';
+  qs('#sumDress').textContent=ev.dress||'—';
+  qs('#sumDesc').textContent=ev.desc||'—';
+  qs('#eventCode').textContent=code;
+  qs('#copyCode')?.addEventListener('click',()=>copy(code));
+  const grid=qs('#wlGrid');
+  getWishlist(code).forEach(it=>{grid.insertAdjacentHTML('beforeend',`<div class="wl-item ${it.status}"><div class="wl-name">${it.name}</div>${it.url?`<a class="wl-link" href="${it.url}" target="_blank" rel="noopener">ссылка</a>`:''}${it.status==='taken'?`<div class="tag">Занято — ${it.by||''}</div>`:''}</div>`);});
+}
+
+/* ------------------ RSVP ------------------ */
+function initRsvp(){
+  const code=new URLSearchParams(location.search).get('code');
+  qs('#formRsvp')?.addEventListener('submit',e=>{
     e.preventDefault();
-    const key = linkEl.getAttribute('data-link');
-    const href = LINKS[key];
-    if (href) goto(href);
-    return;
-  }
-
-  // Join by code button
-  const joinBtn = e.target.closest('[data-action="join"]');
-  if (joinBtn) {
-    e.preventDefault();
-    triggerJoinByCode();
-  }
-});
-
-// Handle Enter inside the join input without submitting a form
-document.addEventListener('keydown', (e) => {
-  const active = document.activeElement;
-  if (e.key === 'Enter' && active && active.id === 'join-code') {
-    e.preventDefault();
-    triggerJoinByCode();
-  }
-});
-
-// Safety: block any accidental form submits around the join UI
-document.addEventListener('submit', (e) => {
-  if (e.target.querySelector && e.target.querySelector('#join-code')) {
-    e.preventDefault();
-    triggerJoinByCode();
-  }
-});
-
-function triggerJoinByCode() {
-  const input = document.getElementById('join-code');
-  const code = input ? input.value.trim() : '';
-  if (!code) return;
-  if (typeof joinByCode === 'function') {
-    return joinByCode(code);
-  }
-  goto(`/event-summary.html?code=${encodeURIComponent(code)}`);
+    const name=qs('#guestName').value.trim();
+    const attend=qs('input[name="attend"]:checked')?.value;
+    if(!name||!attend){alert('Заполните имя и выбор');return;}
+    saveRsvp(code,name,attend);
+    const next=attend==='yes'?`/gift-claim.html?code=${code}&name=${encodeURIComponent(name)}`:`/guest-summary.html?code=${code}&name=${encodeURIComponent(name)}&attend=no`;
+    goto(next);
+  });
 }
+
+/* ------------------ Gift Claim ------------------ */
+function initGiftClaim(){
+  const url=new URLSearchParams(location.search); const code=url.get('code'); const name=url.get('name');
+  const grid=qs('#wlGrid');
+  const render=()=>{grid.innerHTML='';getWishlist(code).forEach(it=>{grid.insertAdjacentHTML('beforeend',`<div class="wl-item ${it.status}"><div class="wl-name">${it.name}</div>${it.url?`<a class="wl-link" href="${it.url}" target="_blank">ссылка</a>`:''}${it.status==='free'?`<button class="btn claim" data-id="${it.id}">Забрать!</button>`:`<div class="tag">Занято — ${it.by||''}</div>`}</div>`);});};
+  grid?.addEventListener('click',e=>{const id=e.target.closest('.claim')?.dataset.id;if(!id)return;if(claimItem(code,id,name)) render();});
+  render();
+  qs('#giftNext')?.addEventListener('click',()=>goto(`/guest-summary.html?code=${code}&name=${encodeURIComponent(name)}`));
+}
+
+/* ------------------ Guest Summary ------------------ */
+function initGuestSummary(){
+  const url=new URLSearchParams(location.search); const code=url.get('code'); const name=url.get('name'); const attend=url.get('attend')!=='no';
+  qs('#gsName').textContent=name||''; qs('#gsAttend').textContent=attend?'Иду':'Не иду';
+  const wl=getWishlist(code); const it=wl.find(i=>i.by===name);
+  if(it){qs('#gsGift').textContent=it.name;} else {qs('#gsGiftWrap').hidden=true;}
+}
+
+/* ------------------ Profile ------------------ */
+function initProfile(){
+  const input=qs('#avatarInput'); const prev=qs('#avatarPreview');
+  const stored=localStorage.getItem('fh_demo_avatar'); if(stored) prev.src=stored;
+  input?.addEventListener('change',e=>{const file=e.target.files[0]; if(!file) return; const reader=new FileReader(); reader.onload=()=>{prev.src=reader.result; localStorage.setItem('fh_demo_avatar',reader.result);}; reader.readAsDataURL(file);});
+  const sess=JSON.parse(localStorage.getItem('fh_demo_session')||'{}'); const user=sess.user?.login||sess.user?.nickname||sess.user?.email||'demo';
+  const mine=listMyEvents(user); const guest=listGuestEvents(user);
+  const mt=qs('#myEvents'); mine.forEach(ev=>{mt.insertAdjacentHTML('beforeend',`<tr data-code="${ev.code}"><td>${ev.code}</td><td>${ev.title}</td><td>${ev.date||''}</td></tr>`);});
+  const gt=qs('#guestEvents'); guest.forEach(ev=>{gt.insertAdjacentHTML('beforeend',`<tr data-code="${ev.code}"><td>${ev.code}</td><td>${ev.title}</td><td>${ev.date||''}</td></tr>`);});
+  document.addEventListener('click',e=>{const tr=e.target.closest('#myEvents tr');if(tr) goto(`/event-summary.html?code=${tr.dataset.code}`);});
+}
+
+export {}

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -26,8 +26,8 @@
 
     <section id="pane-login" class="auth-pane visible" data-pane="login">
       <form id="form-login" novalidate>
-        <label for="loginNickname">Никнейм</label>
-        <input id="loginNickname" name="nickname" autocomplete="username" required />
+        <label for="loginId">Никнейм или Email</label>
+        <input id="loginId" name="login" autocomplete="username" required />
         <label for="loginPassword">Пароль</label>
         <input id="loginPassword" name="password" type="password" autocomplete="current-password" required />
         <button id="btnLogin" class="btn btn--primary" type="submit">Войти</button>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -18,13 +18,24 @@
 </header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
 
-  <main class="fh-content" data-auth-only>
+  <main class="fh-content">
     <div class="container">
       <div class="card">
         <h2>Профиль</h2>
-        <div>Ник: <span id="profile-nickname"></span></div>
-        <div>Email: <span id="profile-email"></span></div>
-        <div>Создан: <span id="profile-created"></span></div>
+        <div class="avatar-block">
+          <img id="avatarPreview" class="avatar" alt="Аватар" />
+          <input type="file" id="avatarInput" accept="image/*" />
+        </div>
+        <h3>Мои события</h3>
+        <table class="tbl">
+          <thead><tr><th>Код</th><th>Название</th><th>Дата</th></tr></thead>
+          <tbody id="myEvents"></tbody>
+        </table>
+        <h3>Участвую</h3>
+        <table class="tbl">
+          <thead><tr><th>Код</th><th>Название</th><th>Дата</th></tr></thead>
+          <tbody id="guestEvents"></tbody>
+        </table>
       </div>
     </div>
   </main>

--- a/FroggyHub/rsvp.html
+++ b/FroggyHub/rsvp.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Итоги события</title>
+  <title>RSVP</title>
   <link rel="stylesheet" href="/style.css?v=glass-18">
 </head>
 <body class="guest">
@@ -18,16 +18,17 @@
 </header>
 <div id="fh-message-clouds" aria-hidden="true"></div>
 <main class="container">
-  <div class="card summary-card">
-    <h1 id="sumTitle">Событие</h1>
-    <p><strong>Дата:</strong> <span id="sumDate">—</span></p>
-    <p><strong>Время:</strong> <span id="sumTime">—</span></p>
-    <p><strong>Адрес:</strong> <span id="sumPlace">—</span></p>
-    <p><strong>Дресс-код:</strong> <span id="sumDress">—</span></p>
-    <p><strong>Комментарий:</strong> <span id="sumDesc">—</span></p>
-    <h2>Вишлист</h2>
-    <div id="wlGrid" class="wl-grid"></div>
-    <div class="event-code">Код события: <span id="eventCode"></span> <button class="btn" id="copyCode">Скопировать код</button></div>
+  <div class="card">
+    <form id="formRsvp">
+      <label>Имя
+        <input id="guestName" required />
+      </label>
+      <div class="rsvp-radio">
+        <label><input type="radio" name="attend" value="yes" required /> Иду</label>
+        <label><input type="radio" name="attend" value="no" required /> Не иду</label>
+      </div>
+      <button class="btn btn--primary" type="submit">Дальше</button>
+    </form>
   </div>
 </main>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -20,7 +20,7 @@ body {
 }
 
 #fh-message-clouds{
-  position:fixed; inset:0; pointer-events:none; z-index:0; overflow:hidden;
+  position:fixed; inset:0; pointer-events:none; z-index:-1; overflow:hidden;
 }
 
 /* Базовый пузырёк-сообщение (чип), который app.js позиционирует по X/Y */
@@ -182,6 +182,21 @@ input:-webkit-autofill{
   50% { transform: translate(4px, -6px) scale(1.05); }
   100% { transform: translate(-3px, 3px) scale(0.95); }
 }
+
+/* Wishlist grid & modal */
+.wl-grid{ display:grid; grid-template-columns:repeat(auto-fill,minmax(180px,1fr)); gap:12px; }
+.wl-item{ background:rgba(20,30,25,.35); backdrop-filter:blur(10px); border:1px solid rgba(255,255,255,.1); border-radius:16px; padding:12px; }
+.wl-item .tag{ margin-top:6px; opacity:.85; }
+.wl-item.taken{ opacity:.7; }
+.modal{ position:fixed; inset:0; display:flex; justify-content:center; align-items:center; background:rgba(0,0,0,.35); backdrop-filter:blur(8px); }
+.modal[hidden]{ display:none; }
+.modal-card{ background:rgba(20,30,25,.6); border:1px solid rgba(255,255,255,.1); border-radius:16px; padding:16px; width:min(480px,92vw); }
+.summary-card{ max-width:720px; margin:0 auto; }
+.avatar-block{ display:flex; align-items:center; gap:12px; margin-bottom:12px; }
+.avatar{ width:80px; height:80px; border-radius:50%; object-fit:cover; background:rgba(255,255,255,.1); }
+.tbl{ width:100%; border-collapse:collapse; margin-bottom:12px; }
+.tbl th,.tbl td{ padding:4px 8px; border-bottom:1px solid rgba(255,255,255,.1); }
+@media (max-width:640px){ .wl-grid{ grid-template-columns:repeat(auto-fill,minmax(140px,1fr)); } }
 
 /* Respect reduced motion preference */
 @media (prefers-reduced-motion: reduce) {

--- a/FroggyHub/wishlist-setup.html
+++ b/FroggyHub/wishlist-setup.html
@@ -18,49 +18,33 @@
 </header>
   <div id="fh-message-clouds" aria-hidden="true"></div>
 
-  <main class="container" role="main" data-auth-only>
+  <main class="container" role="main">
     <div class="card">
-      <h1 id="wlTitle">Добавьте подарки к событию</h1>
-      <p class="hint">Сначала создайте событие, затем добавьте несколько позиций в вишлист. Гости смогут «занимать» эти позиции позже.</p>
-
-      <div class="grid">
-        <label>Новая позиция
-          <input id="giftInput" placeholder="Напр.: Безалкогольный сидр" />
-        </label>
-        <button id="giftAdd" class="btn btn--primary" aria-label="Добавить позицию">Добавить</button>
-      </div>
-
-      <div class="stats" style="margin-top: 1rem;">
-        <span class="badge free" id="giftFreeCount">0</span>
-        <span class="badge taken" id="giftTakenCount">0</span>
-      </div>
-
-      <ul id="giftList" class="wl-list" role="list" aria-live="polite" style="margin-top:1rem;"></ul>
-
+      <h1>Вишлист</h1>
+      <div id="wlGrid" class="wl-grid"></div>
       <div class="bar-actions" style="margin-top:1.5rem;">
+        <button class="btn" id="giftAdd">Добавить</button>
+        <span style="flex:1"></span>
         <button class="btn btn--ghost" id="giftSkip">Пропустить</button>
         <button class="btn btn--primary" id="giftNext">Далее</button>
       </div>
-
-      <p id="wlError" class="error" role="status" aria-live="polite"></p>
     </div>
   </main>
 
-  <div id="cookieCard" class="card" style="display:none" data-auth-only>
-    <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
-      <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>
-    </svg>
-    <div class="cookieHeading">Cookies</div>
-    <div class="cookieDescription">
-      Мы используем файлы cookies, чтобы сайт работал быстрее и удобнее. Продолжая, вы соглашаетесь с их использованием.
-    </div>
-    <div class="buttonContainer">
-      <button class="btn btn--primary acceptButton" id="cookieAccept">Ок</button>
-      <button class="btn btn--ghost declineButton" id="cookieDecline">Только необходимые</button>
+  <div id="giftModal" class="modal" hidden>
+    <div class="modal-card">
+      <h2>Новый предмет</h2>
+      <label>Название предмета
+        <input id="giftName" required />
+      </label>
+      <label>Ссылка
+        <input id="giftUrl" />
+      </label>
+      <div class="actions">
+        <button class="btn btn--primary" id="giftSave">Сохранить</button>
+      </div>
     </div>
   </div>
-
-  <div id="toast" class="toast" role="status" aria-live="polite" hidden data-auth-only></div>
 
   <!-- Supabase client -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>


### PR DESCRIPTION
## Summary
- add authentication redirects with localStorage fallback
- implement event creation, wishlist, and guest RSVP/claim pages
- support avatar and event lists on profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be959715b0833299acd827b74344eb