### PR TITLE
Fix malformed path utility causing syntax error

### DIFF
--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -9,7 +9,7 @@ const LINKS = {
 };
 const qs=(s,r=document)=>r.querySelector(s);
 const qsa=(s,r=document)=>Array.from(r.querySelectorAll(s));
-const path=()=>location.pathname.replace(/\/+$,'/');
+const path=()=>{let p=location.pathname;while(p.endsWith('/'))p=p.slice(0,-1);return p+'/';};
 const isPage=(name)=>path().endsWith(`/${name}`);
 function goto(h){ location.href=h; }
 function copy(t){ try{ navigator.clipboard?.writeText(t);}catch{} }


### PR DESCRIPTION
## Summary
- replace faulty regex in path helper with loop-based slash trim

## Testing
- `node --check FroggyHub/js/app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be990157f48332ab114fef7f2cb60a