### PR TITLE
fix: stop redirect loop and use absolute assets

### DIFF
--- a/FroggyHub/event-analytics.html
+++ b/FroggyHub/event-analytics.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Аналитика события</title>
-<link rel="stylesheet" href="/style.css?v=glass-18">
+<link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -96,9 +96,9 @@
   <!-- Supabase client -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <!-- Public env -->
-  <script src="env.js"></script>
+  <script src="/env.js"></script>
   <!-- App -->
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="/js/app.js"></script>
 
   <script>
     // Небольшой хук: если кнопка «Изменить» видима, клик ведёт на редактирование (app.js тоже навешивает обработчик)

--- a/FroggyHub/event-edit.html
+++ b/FroggyHub/event-edit.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Редактирование события</title>
-<link rel="stylesheet" href="/style.css?v=glass-18">
+<link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -71,7 +71,7 @@
   <!-- Supabase client -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <!-- Public env -->
-  <script src="env.js"></script>
+  <script src="/env.js"></script>
   <!-- App -->
   <script type="module" src="/js/app.js"></script>
 </body>

--- a/FroggyHub/event-summary.html
+++ b/FroggyHub/event-summary.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Итоги события</title>
-  <link rel="stylesheet" href="/style.css?v=glass-18">
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -31,7 +31,7 @@
   </div>
 </main>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-<script src="env.js"></script>
-<script type="module" src="js/app.js"></script>
+<script src="/env.js"></script>
+<script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/gift-claim.html
+++ b/FroggyHub/gift-claim.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Подарки</title>
-  <link rel="stylesheet" href="/style.css?v=glass-18">
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -27,7 +27,7 @@
   </div>
 </main>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-<script src="env.js"></script>
-<script type="module" src="js/app.js"></script>
+<script src="/env.js"></script>
+<script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/guest-summary.html
+++ b/FroggyHub/guest-summary.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Спасибо</title>
-  <link rel="stylesheet" href="/style.css?v=glass-18">
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -26,7 +26,7 @@
   </div>
 </main>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-<script src="env.js"></script>
-<script type="module" src="js/app.js"></script>
+<script src="/env.js"></script>
+<script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Хаб — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=glass-18">
+<link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -28,8 +28,8 @@
   <!-- Supabase client -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <!-- Public env -->
-  <script src="env.js"></script>
+  <script src="/env.js"></script>
   <!-- App -->
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>FroggyHub</title>
-  <link rel="stylesheet" href="style.css?v=glass-18">
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest bg-frog">
 <header class="topbar">
@@ -43,8 +43,8 @@
 <!-- Supabase client -->
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <!-- Public env -->
-<script src="env.js"></script>
+<script src="/env.js"></script>
 <!-- App -->
-<script type="module" src="js/app.js"></script>
+<script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -1,17 +1,28 @@
 import { supa, getSession, signIn, signUpWithNickname, signOut } from './api.js';
 
 const LINKS = {
-  home: '/index.html',
+  home: '/login.html',      // публичная точка входа
+  lobby: '/lobby.html',
   menu: '/lobby.html',
   profile: '/profile.html',
   settings: '/lobby.html',
   'event-edit': '/event-edit.html'
 };
+const normPath = () => {
+  let p = location.pathname || '/';
+  while (p.length > 1 && p.endsWith('/')) p = p.slice(0, -1);
+  return p || '/';
+};
+function goto(href){
+  if (!href) return;
+  // не навигируем, если уже там
+  const url = new URL(href, location.origin);
+  if (url.pathname === normPath() && url.search === location.search) return;
+  location.href = url.href;
+}
 const qs=(s,r=document)=>r.querySelector(s);
 const qsa=(s,r=document)=>Array.from(r.querySelectorAll(s));
-const path=()=>{let p=location.pathname;while(p.endsWith('/'))p=p.slice(0,-1);return p+'/';};
-const isPage=(name)=>path().endsWith(`/${name}`);
-function goto(h){ location.href=h; }
+const isPage=(name)=>normPath().endsWith(`/${name}`);
 function copy(t){ try{ navigator.clipboard?.writeText(t);}catch{} }
 
 /* ------------------ Cloud messages ------------------ */
@@ -77,15 +88,30 @@ function listMyEvents(user){const db=_db();return Object.values(db.events||{}).f
 function listGuestEvents(user){const db=_db();const codes=Object.entries(db.rsvp||{}).filter(([c,l])=>l.some(r=>r.name===user&&r.attend==='yes')).map(([c])=>c);return codes.map(c=>db.events?.[c]).filter(Boolean);}
 
 /* ------------------ Boot ------------------ */
+const REDIRECT_FLAG = 'fh_redirecting';
+function beginRedirectOnce() {
+  if (sessionStorage.getItem(REDIRECT_FLAG)) return false;
+  sessionStorage.setItem(REDIRECT_FLAG, '1');
+  // снимем флаг через тик event loop — после первой успешной загрузки
+  setTimeout(()=>sessionStorage.removeItem(REDIRECT_FLAG), 500);
+  return true;
+}
+
 async function boot(){
-  const session=await getSession();
-  const authed=!!session||JSON.parse(localStorage.getItem('fh_demo_session')||'false');
-  const AUTH_AVAILABLE=!!supa;
-  const p=path(); const isLogin=p.endsWith('/login.html');
-  if(AUTH_AVAILABLE){
-    if(authed&&isLogin){goto('/lobby.html');return;}
-    if(!authed&&!isLogin){goto('/login.html');return;}
-  }
+  const session = await getSession?.();
+  const authed = !!session || JSON.parse(localStorage.getItem('fh_demo_session') || 'false');
+  const AUTH_AVAILABLE = !!window.supa; // если нет supa — НЕ форсим редиректы
+  const p = normPath();
+  const onLogin = p.endsWith('/login.html');
+  // ГАРД: редиректим только один раз
+  const canRedirect = () => AUTH_AVAILABLE && beginRedirectOnce();
+
+  // Авторизован: логин открыт по ошибке → в лобби
+  if (authed && onLogin && canRedirect()) { goto(LINKS.lobby); return; }
+
+  // Не авторизован: любая не-логин страница → на логин
+  if (!authed && !onLogin && AUTH_AVAILABLE && beginRedirectOnce()) { goto(LINKS.home); return; }
+
   if(isPage('login.html')) initAuth();
   if(isPage('lobby.html')) initLobby();
   if(isPage('event-edit.html')) initEventEdit();
@@ -96,7 +122,7 @@ async function boot(){
   if(isPage('guest-summary.html')) initGuestSummary();
   if(isPage('profile.html')) initProfile();
 }
-document.addEventListener('DOMContentLoaded',()=>{boot().catch(console.error);});
+document.addEventListener('DOMContentLoaded', () => { boot().catch?.(console.error); });
 
 /* ------------------ Global navigation ------------------ */
 document.addEventListener('click',e=>{

--- a/FroggyHub/lobby.html
+++ b/FroggyHub/lobby.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Лобби — FroggyHub</title>
-  <link rel="stylesheet" href="/style.css?v=glass-18">
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -41,8 +41,8 @@
   <!-- Supabase client -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <!-- Public env -->
-  <script src="env.js"></script>
+  <script src="/env.js"></script>
   <!-- App -->
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/login.html
+++ b/FroggyHub/login.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Вход — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=glass-18">
+<link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -52,8 +52,8 @@
   <!-- Supabase client -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <!-- Public env -->
-  <script src="env.js"></script>
+  <script src="/env.js"></script>
   <!-- App -->
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/profile.html
+++ b/FroggyHub/profile.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Профиль — FroggyHub</title>
-<link rel="stylesheet" href="/style.css?v=glass-18">
+<link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -43,8 +43,8 @@
   <!-- Supabase client -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <!-- Public env -->
-  <script src="env.js"></script>
+  <script src="/env.js"></script>
   <!-- App -->
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/rsvp.html
+++ b/FroggyHub/rsvp.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>RSVP</title>
-  <link rel="stylesheet" href="/style.css?v=glass-18">
+  <link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -32,7 +32,7 @@
   </div>
 </main>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-<script src="env.js"></script>
-<script type="module" src="js/app.js"></script>
+<script src="/env.js"></script>
+<script type="module" src="/js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/wishlist-setup.html
+++ b/FroggyHub/wishlist-setup.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Wishlist для события</title>
-<link rel="stylesheet" href="/style.css?v=glass-18">
+<link rel="stylesheet" href="/style.css">
 </head>
 <body class="guest">
 <header class="topbar">
@@ -49,8 +49,8 @@
   <!-- Supabase client -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <!-- Public env -->
-  <script src="env.js"></script>
+  <script src="/env.js"></script>
   <!-- App -->
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- guard against redirect loops by checking sessionStorage flag and only redirecting once
- use safer navigation helpers and skip redirects when Supabase is missing
- switch all HTML pages to absolute `/style.css`, `/env.js` and `/js/app.js` references

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be9e746a648332aecf3bd286d063dc