### PR TITLE
feat: add centralized hero actions

### DIFF
--- a/FroggyHub/hub.html
+++ b/FroggyHub/hub.html
@@ -18,17 +18,21 @@
 </header>
 
 <main class="hero" role="main" aria-label="Главные действия">
-  <div class="hero-glass">
-    <button type="button" class="btn btn-large" data-link="event-edit">Создать событие</button>
+  <div class="hero-glass" aria-live="polite">
+    <button type="button" class="btn btn-large" data-link="event-edit">
+      Создать событие
+    </button>
     <div class="join-row" role="group" aria-label="Присоединиться по коду">
       <input
-        id="join-code"
-        inputmode="numeric"
-        maxlength="6"
-        placeholder="Введите 6-значный код"
-        aria-label="Код приглашения"
+        type="text"
+        id="joinCode"
+        placeholder="Код события"
+        autocomplete="one-time-code"
+        aria-label="Код события"
       />
-      <button type="button" class="btn btn-large" data-action="join">Присоединиться</button>
+      <button type="button" class="btn btn-large" data-action="join">
+        Присоединиться
+      </button>
     </div>
   </div>
 </main>


### PR DESCRIPTION
## Summary
- center hero-glass actions after header with create event and join controls
- ensure message clouds remain behind hero content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2358d04a88332844517a4ddb99b67