### PR TITLE
Fix homepage: remove frog/stump visuals; place bubbles behind UI; tidy scroll

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -8,69 +8,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="icon"
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
-  <style>
-    /* Message clouds background */
-    #fh-message-clouds {
-      position: fixed; inset: 0;
-      z-index: 0;             /* ниже основного контента */
-      pointer-events: none;   /* не перехватываем клики */
-      overflow: hidden;
-    }
-    .fh-cloud {
-      position: absolute;
-      max-width: 44ch;
-      padding: 10px 14px;
-      border-radius: 16px;
-      background: rgba(255,255,255,0.08);
-      backdrop-filter: saturate(150%) blur(6px);
-      -webkit-backdrop-filter: saturate(150%) blur(6px);
-      border: 1px solid rgba(255,255,255,0.12);
-      color: rgba(255,255,255,0.85);
-      font-size: 14px;
-      line-height: 1.3;
-      box-shadow: 0 8px 20px rgba(0,0,0,0.25);
-      transform-origin: center;
-    }
-    /* на маленьких экранах делаем меньше, чтобы не мешало */
-    @media (max-width: 640px) {
-      .fh-cloud { font-size: 12px; max-width: 32ch; }
-    }
-  </style>
-  <style>
-    /* Message clouds background */
-    #fh-message-clouds {
-      position: fixed; inset: 0;
-      z-index: 0;             /* ниже основного контента */
-      pointer-events: none;   /* не перехватываем клики */
-      overflow: hidden;
-    }
-    .fh-cloud {
-      position: absolute;
-      max-width: 44ch;
-      padding: 10px 14px;
-      border-radius: 16px;
-      background: rgba(255,255,255,0.08);
-      backdrop-filter: saturate(150%) blur(6px);
-      -webkit-backdrop-filter: saturate(150%) blur(6px);
-      border: 1px solid rgba(255,255,255,0.12);
-      color: rgba(255,255,255,0.85);
-      font-size: 14px;
-      line-height: 1.3;
-      box-shadow: 0 8px 20px rgba(0,0,0,0.25);
-      transform-origin: center;
-      animation: floaty 6s ease-in-out infinite;
-    }
-
-    @keyframes floaty {
-      0%   { transform: translateY(0) rotate(var(--rot, 0deg)); }
-      50%  { transform: translateY(-6px) rotate(calc(var(--rot, 0deg) * 1.1)); }
-      100% { transform: translateY(0) rotate(var(--rot, 0deg)); }
-    }
-
-    @media (max-width: 640px) {
-      .fh-cloud { font-size: 12px; max-width: 32ch; }
-    }
-  </style>
+  
   <style>
     .fh-bg {
       position: fixed; inset: 0; z-index: 0;
@@ -80,20 +18,13 @@
       .fh-bg { background-position: center; }
     }
     .fh-bg::after { content:""; position:absolute; inset:0; background: rgba(11,36,27,.55); }
-    #fh-message-clouds { position: fixed; inset: 0; z-index: 0; pointer-events:none; }
     .fh-content { position: relative; z-index: 20; min-height: 100svh; padding-inline: 1rem; }
     #fh-cta { position: relative; z-index: 30; }
   </style>
 </head>
 <body class="scene-intro">
   <div class="fh-bg" aria-hidden="true"></div>
-  <div id="fh-message-clouds" class="fh-bubbles" aria-hidden="true">
-    <div class="bubble chip">Создавайте события</div>
-    <div class="bubble chip">Делитесь вишлистами</div>
-    <div class="bubble chip">Планируйте встречи</div>
-    <div class="bubble chip">Приглашайте друзей</div>
-    <div class="bubble chip">Следите за ответами</div>
-  </div>
+  <main id="hero" class="hero" role="main" aria-label="Главные действия">
   <div class="fh-content">
   <!-- Шапка -->
   <nav class="topbar">
@@ -564,6 +495,8 @@
     </div>
   </div>
 </div>
+  <div class="fh-bubbles" aria-hidden="true"></div>
+  </main>
 <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/FroggyHub/js/app.js
+++ b/FroggyHub/js/app.js
@@ -330,13 +330,13 @@ else {
     const root = document.querySelector('.fh-bubbles');
     if (!root) return;
 
+    root.innerHTML = '';
     spawnBubbles(root, desiredBubbleCount());
 
     window.addEventListener('resize', debounce(() => {
-      const box = document.querySelector('.fh-bubbles');
-      if (!box) return;
-      box.innerHTML = '';
-      spawnBubbles(box, desiredBubbleCount());
+      if (!root) return;
+      root.innerHTML = '';
+      spawnBubbles(root, desiredBubbleCount());
     }, 200));
   })();
 

--- a/FroggyHub/style.css
+++ b/FroggyHub/style.css
@@ -37,7 +37,7 @@
 }
 
 *{box-sizing:border-box}
-html,body{height:100%;overflow-x:hidden}
+html,body{min-height:100%;overflow-x:hidden}
 body{
   margin:0;
   background:radial-gradient(120% 120% at 50% 30%, var(--bg-dark2), var(--bg-dark));
@@ -45,19 +45,42 @@ body{
   font:16px/1.5 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial;
 }
 
-/* Контейнер для фона с пузырями */
+/* ==== Bubbles layer (всегда на фоне, за UI) ==== */
 .fh-bubbles {
   position: fixed;
   inset: 0;
-  pointer-events: none;
-  z-index: 1;
   overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
 }
 
-#screen-auth,
-#screen-home {
+/* ==== UI выше пузырьков ==== */
+.topbar,
+.topbar-right {
+  position: relative;
+  z-index: 3;
+}
+
+#screen-home,
+#screen-home .panel,
+#screen-home .hero-glass,
+#screen-home .join-row,
+#screen-home .menu-deck {
   position: relative;
   z-index: 2;
+}
+
+/* Высота главного экрана: во всю высоту, с учётом топбара, если нужно */
+main.hero,
+#screen-home {
+  min-height: 100vh;
+}
+
+/* (Важно) Убрать старые стили, относящиеся к .hero-frog, .frog, .stump */
+.hero-frog,
+.hero .frog,
+.hero .stump {
+  display: none !important;
 }
 
 /* Состояния пузыря */


### PR DESCRIPTION
## Summary
- strip frog/stump art from landing screen and move background bubbles inside `<main>`
- layer UI above fixed bubble backdrop and prevent layout scroll
- reset bubble container before each spawn cycle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2693956d483328b30c874d24fa681