### PR TITLE
Implement delegated navigation and relative asset paths

### DIFF
--- a/FroggyHub/index.html
+++ b/FroggyHub/index.html
@@ -12,7 +12,7 @@
   <style>
     .fh-bg {
       position: fixed; inset: 0; z-index: 0;
-      background: #0b241b url("/assets/background.jpg") center 45% / cover no-repeat;
+      background: #0b241b url("./assets/background.jpg") center 45% / cover no-repeat;
     }
     @media (min-width: 640px) {
       .fh-bg { background-position: center; }
@@ -23,18 +23,20 @@
   </style>
 </head>
 <body class="scene-intro">
-  <div class="fh-bg" aria-hidden="true"></div>
+  <div class="fh-bg background-layer" aria-hidden="true"></div>
   <main id="hero" class="hero" role="main" aria-label="Главные действия">
   <div class="fh-content">
   <!-- Шапка -->
   <nav class="topbar">
-    <div class="topbar-left">
-      <a href="#" id="logo" class="logo" data-link="home">FroggyHub</a>
-    </div>
-    <div class="topbar-right">
-      <button id="nav-menu" class="btn btn-sm btn-ghost" data-link="home" hidden>Меню</button>
-      <button id="nav-profile" class="btn btn-sm btn-ghost" data-link="profile">Профиль</button>
-      <button id="nav-settings" class="btn btn-sm btn-ghost" data-link="settings" data-role="settings">Настройки</button>
+    <div class="inner">
+      <div class="topbar-left">
+        <a href="#" id="logo" class="logo" data-link="home">FroggyHub</a>
+      </div>
+      <div class="topbar-right">
+        <button id="nav-menu" class="btn btn-sm btn-ghost" data-link="home" hidden>Меню</button>
+        <button id="nav-profile" class="btn btn-sm btn-ghost" data-link="profile">Профиль</button>
+        <button id="nav-settings" class="btn btn-sm btn-ghost" data-link="settings" data-role="settings">Настройки</button>
+      </div>
     </div>
   </nav>
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
@@ -42,7 +44,7 @@
     <div class="card auth-card auth-panel" id="authPanel" style="max-width:620px;margin:40px auto">
       <div class="auth-head">
         <div class="auth-avatar">
-          <img src="/assets/frog_idle.png" alt="Froggy" />
+          <img src="./assets/frog_idle.png" alt="Froggy" />
         </div>
 
         <div class="auth-title">
@@ -435,7 +437,7 @@
       <div class="panel profile-card">
         <div class="profile-head">
           <div>
-            <img id="avatar-img" class="avatar" src="/assets/frog_avatar_placeholder.png" alt="">
+            <img id="avatar-img" class="avatar" src="./assets/frog_idle.png" alt="">
             <input id="avatar-file" type="file" accept="image/*" hidden>
             <button id="avatar-upload" class="btn btn-sm">Загрузить аватар</button>
           </div>
@@ -495,7 +497,7 @@
     </div>
   </div>
 </div>
-  <div class="fh-bubbles" aria-hidden="true"></div>
+  <div class="fh-bubbles bg-bubbles" aria-hidden="true"></div>
   </main>
 <script type="module" src="./js/app.js"></script>
 </body>

--- a/event-analytics.html
+++ b/event-analytics.html
@@ -73,6 +73,6 @@
     </div>
   </div>
   <div id="toast" class="toast" role="status" aria-live="polite" hidden></div>
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/event-edit.html
+++ b/event-edit.html
@@ -39,7 +39,7 @@
     </form>
     <p id="editError" class="error" role="status" aria-live="polite"></p>
   </main>
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="./js/app.js"></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/hub.html
+++ b/hub.html
@@ -11,7 +11,7 @@
 <body>
   <div id="mini-profile" style="position:absolute;top:10px;right:10px;text-align:right;">
     Ник: <span id="mp-nick"></span>, Создан: <span id="mp-created"></span>
-    <button id="hub-logout" data-logout class="btn btn--ghost btn--sm">Выйти</button>
+    <button id="hub-logout" data-logout data-action="logout" class="btn btn--ghost btn--sm">Выйти</button>
   </div>
   <main class="container" role="main">
     <div class="card" style="max-width:760px;margin:40px auto">
@@ -34,7 +34,7 @@
       </section>
     </div>
   </main>
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="./js/app.js"></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/index.html
+++ b/index.html
@@ -11,13 +11,15 @@
 </head>
 <body class="scene-intro">
   <main class="fh-content">
-  <div class="fh-bubbles" aria-hidden="true"></div>
+  <div class="fh-bubbles bg-bubbles" aria-hidden="true"></div>
   <!-- Шапка -->
   <nav class="topbar">
+    <div class="inner">
       <a href="#" id="logo" class="logo" data-link="home">FroggyHub</a>
       <button id="nav-menu" class="btn btn-sm btn-ghost" data-link="home" hidden type="button">Меню</button>
       <button id="nav-profile" class="btn btn-sm btn-ghost" data-link="profile" type="button">Профиль</button>
       <button id="nav-settings" class="btn btn-sm btn-ghost" data-link="settings" data-role="settings" type="button">Настройки</button>
+    </div>
   </nav>
   <!-- ЭКРАН 1: ВХОД / РЕГИСТРАЦИЯ -->
   <section id="screen-auth" class="screen container" role="main">
@@ -415,7 +417,7 @@
       <div class="panel profile-card">
         <div class="profile-head">
           <div>
-            <img id="avatar-img" class="avatar" alt=""><!-- src removed: frog_avatar_placeholder.png missing -->
+            <img id="avatar-img" class="avatar" src="./assets/frog_idle.png" alt="">
             <input id="avatar-file" type="file" accept="image/*" hidden>
             <button id="avatar-upload" class="btn btn-sm" type="button">Загрузить аватар</button>
           </div>
@@ -475,6 +477,6 @@
     </div>
   </div>
 </main>
-<script type="module" src="/js/app.js"></script>
+<script type="module" src="./js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -237,77 +237,359 @@ else {
     try { s ? localStorage.setItem(LS_KEY, JSON.stringify(s)) : localStorage.removeItem(LS_KEY); } catch {}
   };
 
-  // --- Экраны
-  const $auth = document.querySelector('#screen-auth');
-  const $home = document.querySelector('#screen-home');
+  // --- Роутинг и навигация
+  const screenNodes = Array.from(document.querySelectorAll('[id^="screen-"]'));
+  const screenMap = new Map();
+  for (const node of screenNodes) {
+    if (!(node instanceof HTMLElement)) continue;
+    const id = node.id || '';
+    if (!id.startsWith('screen-')) continue;
+    const key = id.slice(7).toLowerCase();
+    if (!screenMap.has(key)) screenMap.set(key, node);
+  }
+  let currentRoute = '';
 
-  const show = ($el) => { [$auth,$home].forEach(x=>x&&x.classList.remove('visible')); $el && $el.classList.add('visible'); };
+  const ACTION_FUNCTIONS = {
+    logout: ['logout'],
+    create: ['create', 'createEvent', 'startCreateFlow'],
+    join: ['join', 'joinEvent', 'joinByCode'],
+    save: ['save', 'saveEvent', 'saveChanges'],
+    refresh: ['refresh', 'refreshData', 'reload'],
+    back: ['back', 'goBack', 'navigateBack'],
+  };
 
-  // --- Простенький роутер
-  async function route() {
-    const hash = (location.hash || '#auth').toLowerCase();
-    const supa = getSupabase();
+  const normalizeRoute = (value) => {
+    if (typeof value !== 'string') return '';
+    return value.trim().replace(/^#/, '').toLowerCase();
+  };
+
+  const getHashRoute = () => normalizeRoute(location.hash.slice(1));
+
+  const getRouteCandidate = (el) => {
+    if (!el || !(el instanceof HTMLElement)) return '';
+    const { dataset } = el;
+    if (dataset?.route) return dataset.route;
+    if (dataset?.nav) return dataset.nav;
+    if (dataset?.link) return dataset.link;
+    if (dataset?.go) return dataset.go;
+    const href = el.getAttribute('href');
+    if (href && href.startsWith('#')) return href.slice(1);
+    return '';
+  };
+
+  const getElementLabel = (el) => {
+    if (!el) return '';
+    const aria = el.getAttribute?.('aria-label');
+    if (aria) return aria.trim();
+    const text = (el.textContent || '').replace(/\s+/g, ' ').trim();
+    if (text) return text;
+    const title = el.getAttribute?.('title');
+    return title ? title.trim() : '';
+  };
+
+  function updateActiveNav(route) {
+    const interactive = document.querySelectorAll('a, button, [role="button"]');
+    interactive.forEach((el) => {
+      if (!(el instanceof HTMLElement)) return;
+      const candidate = normalizeRoute(getRouteCandidate(el));
+      const isActive = candidate && candidate === route;
+      el.classList.toggle('active', isActive);
+      if (isActive) el.setAttribute('aria-current', 'page');
+      else el.removeAttribute('aria-current');
+    });
+  }
+
+  function navigateTo(route) {
+    const desired = normalizeRoute(route);
+    let nextRoute = desired;
+    let target = desired ? screenMap.get(desired) : null;
+
+    if (!target) {
+      if (screenMap.has('home')) {
+        nextRoute = 'home';
+        target = screenMap.get('home');
+      } else if (screenMap.has('auth')) {
+        nextRoute = 'auth';
+        target = screenMap.get('auth');
+      } else {
+        const first = screenMap.entries().next().value;
+        if (first) {
+          nextRoute = first[0];
+          target = first[1];
+        } else {
+          nextRoute = '';
+        }
+      }
+    }
+
+    screenMap.forEach((node) => {
+      if (!(node instanceof HTMLElement)) return;
+      node.hidden = true;
+      node.classList.remove('visible');
+    });
+
+    if (target instanceof HTMLElement) {
+      target.hidden = false;
+      if (target.classList.contains('screen')) target.classList.add('visible');
+      else target.classList.remove('hidden');
+    }
+
+    currentRoute = nextRoute;
+    updateActiveNav(currentRoute);
+
+    const baseUrl = `${location.pathname}${location.search}`;
+    const hashUrl = currentRoute ? `${baseUrl}#${currentRoute}` : baseUrl;
+    history.replaceState(null, '', hashUrl);
+    window.onRouteChange?.(currentRoute);
+    return currentRoute;
+  }
+
+  function ensureBackgroundGuards() {
+    document.querySelectorAll('.background-layer, .bg-bubbles').forEach((el) => {
+      if (!(el instanceof HTMLElement)) return;
+      if (!el.style.pointerEvents) el.style.pointerEvents = 'none';
+      if (!el.style.zIndex) el.style.zIndex = '0';
+    });
+  }
+
+  function autoAttachDataAttributes() {
+    const interactive = document.querySelectorAll('a, button, [role="button"]');
+    interactive.forEach((el) => {
+      if (!(el instanceof HTMLElement)) return;
+      const label = getElementLabel(el).toLowerCase();
+      if (!el.dataset.route && !el.dataset.nav) {
+        if (label === 'профиль') el.dataset.route = 'profile';
+        else if (label === 'настройки') el.dataset.route = 'settings';
+        else if (label === 'меню' || label === 'froggyhub' || el.classList.contains('logo')) el.dataset.route = 'home';
+      }
+      if (!el.dataset.action) {
+        if (label === 'создать событие') el.dataset.action = 'create';
+        else if (label === 'присоединиться') el.dataset.action = 'join';
+        else if (label === 'выйти') el.dataset.action = 'logout';
+      }
+    });
+  }
+
+  function logInteractiveElements() {
+    const rows = [];
+    const interactive = document.querySelectorAll('a, button, [role="button"]');
+    interactive.forEach((el) => {
+      if (!(el instanceof HTMLElement)) return;
+      const label = getElementLabel(el);
+      const route = normalizeRoute(getRouteCandidate(el));
+      const action = el.dataset.action || '';
+      const href = el.dataset.href || el.getAttribute('href') || '';
+      const tag = el.tagName.toLowerCase() + (el.id ? `#${el.id}` : '');
+      if (route || action || href) {
+        rows.push({ element: tag, label, route, action, href });
+      } else {
+        const isButton = el.tagName === 'BUTTON';
+        const btnType = isButton ? (el.getAttribute('type') || 'submit').toLowerCase() : '';
+        if (!isButton || (btnType !== 'submit' && btnType !== 'reset')) {
+          console.warn('Interactive element without route/action', el);
+        }
+      }
+    });
+    if (rows.length) {
+      console.info('Interactive elements summary:');
+      console.table(rows);
+    }
+  }
+
+  function invokeGlobalAction(action, el) {
+    const candidates = ACTION_FUNCTIONS[action];
+    if (!candidates) return false;
+    for (const name of candidates) {
+      const fn = window[name];
+      if (typeof fn === 'function') {
+        fn.call(window, el);
+        return true;
+      }
+    }
+    console.warn(`No handler for action "${action}"`, el);
+    return false;
+  }
+
+  function handleAction(action, el) {
+    if (!action || !el) return false;
+    const normalized = action.toLowerCase();
+    const targetSelector = el.dataset.target;
+    const target = targetSelector ? document.querySelector(targetSelector) : null;
+
+    switch (normalized) {
+      case 'open-modal': {
+        const modal = target || el.closest('dialog');
+        if (modal instanceof HTMLDialogElement) {
+          modal.showModal();
+        } else if (modal instanceof HTMLElement) {
+          modal.hidden = false;
+          modal.classList.remove('hidden');
+        } else {
+          console.warn('Target not found for open-modal', el);
+        }
+        return true;
+      }
+      case 'close-modal': {
+        const modal = target || el.closest('dialog');
+        if (modal instanceof HTMLDialogElement) {
+          modal.close();
+        } else if (modal instanceof HTMLElement) {
+          modal.hidden = true;
+          modal.classList.remove('visible');
+          modal.classList.remove('active');
+        } else {
+          console.warn('Target not found for close-modal', el);
+        }
+        return true;
+      }
+      case 'toggle': {
+        if (target instanceof HTMLElement) {
+          target.hidden = !target.hidden;
+        } else {
+          el.classList.toggle('active');
+        }
+        return true;
+      }
+      case 'copy': {
+        const sourceText = el.dataset.copy
+          || (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement ? target.value : target?.textContent)
+          || (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement ? el.value : el.textContent);
+        const text = (sourceText || '').toString().trim();
+        if (!text) {
+          console.warn('Nothing to copy', el);
+          return true;
+        }
+        if (navigator.clipboard?.writeText) {
+          navigator.clipboard.writeText(text).catch((err) => console.warn('Copy failed', err));
+        } else {
+          const ta = document.createElement('textarea');
+          ta.value = text;
+          ta.setAttribute('readonly', '');
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.select();
+          try { document.execCommand('copy'); }
+          catch (err) { console.warn('Copy failed', err); }
+          document.body.removeChild(ta);
+        }
+        return true;
+      }
+      case 'logout':
+      case 'create':
+      case 'join':
+      case 'save':
+      case 'refresh':
+      case 'back':
+        return invokeGlobalAction(normalized, el);
+      default:
+        console.warn('Unknown action', action, el);
+        return false;
+    }
+  }
+
+  function handleDocumentClick(event) {
+    if (event.defaultPrevented || event.button !== 0) return;
+    const el = event.target.closest('a, button, [role="button"]');
+    if (!el || !(el instanceof HTMLElement)) return;
+    if (el.matches('[disabled], [aria-disabled="true"]')) return;
+
+    const action = el.dataset.action;
+    if (action) {
+      const handled = handleAction(action, el);
+      if (handled) {
+        event.preventDefault();
+        return;
+      }
+    }
+
+    const dataHref = el.dataset.href;
+    if (dataHref) {
+      event.preventDefault();
+      if (dataHref.startsWith('#')) navigateTo(dataHref.slice(1));
+      else window.location.assign(dataHref);
+      return;
+    }
+
+    const routeCandidate = getRouteCandidate(el);
+    if (routeCandidate) {
+      if (screenMap.size > 0) {
+        navigateTo(routeCandidate);
+        event.preventDefault();
+      }
+      return;
+    }
+
+    const href = el.getAttribute('href');
+    if (href && href.startsWith('#')) {
+      if (screenMap.size > 0) {
+        event.preventDefault();
+        navigateTo(href.slice(1));
+      }
+    }
+  }
+
+  function handleKeydown(event) {
+    if (event.defaultPrevented) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const el = event.target;
+    if (!(el instanceof HTMLElement)) return;
+    if (el.getAttribute('role') !== 'button') return;
+    if (el.matches('[disabled], [aria-disabled="true"]')) return;
+    event.preventDefault();
+    el.click();
+  }
+
+  async function route(preferredRoute) {
+    const supaClient = getSupabase();
     let session = getSavedSession();
+    let routeHint = normalizeRoute(preferredRoute);
 
-    // быстрая проверка
-    if (!session && supa?.auth) {
+    if (!session && supaClient?.auth) {
       const ctrl = new AbortController();
-      const t = setTimeout(()=>ctrl.abort(), 1500);
+      const timer = setTimeout(() => ctrl.abort(), 1500);
       try {
-        const { data } = await supa.auth.getSession({ signal: ctrl.signal });
+        const { data } = await supaClient.auth.getSession({ signal: ctrl.signal });
         session = data?.session || null;
-      } catch { /* таймаут/ошибка – игнор */ }
-      clearTimeout(t);
+      } catch { /* ignore */ }
+      clearTimeout(timer);
       if (session) setSavedSession({ user: session.user, access_token: session.access_token });
     }
 
     const authed = !!session;
+    window.FH.session = session || null;
 
     if (!authed) {
-      show($auth);
-      location.hash = '#auth';
+      setSavedSession(null);
+      const fallback = routeHint && routeHint !== 'home' ? routeHint : 'auth';
+      navigateTo(fallback);
       return;
     }
 
-    // авторизованы
-    show($home);
-    if (hash !== '#home') location.hash = '#home';
+    let targetRoute = routeHint;
+    if (!targetRoute || targetRoute === 'auth') targetRoute = 'home';
+    if (targetRoute && !screenMap.has(targetRoute)) {
+      targetRoute = screenMap.has('home') ? 'home' : targetRoute;
+    }
+    navigateTo(targetRoute);
   }
 
-  // --- Навигация и действия (делегирование)
-  document.addEventListener('click', (e) => {
-    const linkBtn = e.target.closest('[data-link]');
-    if (linkBtn) {
-      const to = linkBtn.getAttribute('data-link');
-      if (to === 'home') location.hash = '#home';
-      else if (to === 'profile') location.hash = '#profile';
-      else if (to === 'settings') location.hash = '#settings';
-      return;
-    }
+  document.addEventListener('click', handleDocumentClick);
+  document.addEventListener('keydown', handleKeydown, true);
 
-    const goBtn = e.target.closest('[data-go]');
-    if (goBtn) {
-      const to = goBtn.getAttribute('data-go');
-      const target = document.querySelector(`#screen-${to}`);
-      if (!target) return;
-      document.querySelectorAll('.screen').forEach(s => {
-        s.classList.remove('visible');
-        s.hidden = true;
-      });
-      target.hidden = false;
-      target.classList.add('visible');
-      return;
-    }
+  const onDomReady = () => {
+    ensureBackgroundGuards();
+    autoAttachDataAttributes();
+    logInteractiveElements();
+    const initialRoute = getHashRoute();
+    route(initialRoute);
+  };
 
-    const actionBtn = e.target.closest('[data-action]');
-    if (actionBtn) {
-      const act = actionBtn.getAttribute('data-action');
-      if (act === 'create' && typeof startCreateFlow === 'function') {
-        startCreateFlow();
-      } else if (act === 'join' && typeof joinByCode === 'function') {
-        joinByCode();
-      }
-    }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', onDomReady);
+  else onDomReady();
+
+  window.addEventListener('hashchange', () => {
+    route(getHashRoute());
   });
 
   // --- Обработчики форм логина/регистрации
@@ -324,25 +606,24 @@ else {
         if (!nickname || !password) return;
 
         try {
-          const supa = getSupabase();
+          const supaClient = getSupabase();
           let ok = false, session = null;
 
           if (kind === 'login') {
-            const { data, error } = await supa.auth.signInWithPassword({ email: `${nickname}@local`, password });
+            const { data, error } = await supaClient.auth.signInWithPassword({ email: `${nickname}@local`, password });
             if (!error) { ok = true; session = data.session; }
           } else {
-            const { data, error } = await supa.auth.signUp({ email: `${nickname}@local`, password });
+            const { data, error } = await supaClient.auth.signUp({ email: `${nickname}@local`, password });
             if (!error) {
-              // повторный вход для единообразия
-              const r = await supa.auth.signInWithPassword({ email: `${nickname}@local`, password });
+              const r = await supaClient.auth.signInWithPassword({ email: `${nickname}@local`, password });
               session = r.data.session; ok = !r.error;
             }
           }
 
           if (ok && session) {
             setSavedSession({ user: session.user, access_token: session.access_token });
-            location.hash = '#home'; // триггерит route()
-            await route();
+            navigateTo('home');
+            await route('home');
           }
         } catch (err) { /* можно показать тост */ }
       });
@@ -365,9 +646,5 @@ else {
       spawnBubbles(box, desiredBubbleCount());
     }, 200));
   })();
-
-  // --- Старт
-  document.addEventListener('DOMContentLoaded', route);
-  window.addEventListener('hashchange', route);
 }
 

--- a/lobby.html
+++ b/lobby.html
@@ -4,13 +4,13 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Лобби — FroggyHub</title>
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="./style.css" />
   <link rel="icon"
         href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Ctext y='.9em' font-size='96'%3E🐸%3C/text%3E%3C/svg%3E">
   <style>
     .fh-bg {
       position: fixed; inset: 0; z-index: 0;
-      background: #0b241b url("/assets/background.jpg") center 45% / cover no-repeat;
+      background: #0b241b url("./assets/background.jpg") center 45% / cover no-repeat;
     }
     @media (min-width: 640px) {
       .fh-bg { background-position: center; }
@@ -22,15 +22,17 @@
   </style>
 </head>
 <body data-page="lobby">
-  <div class="fh-bg" aria-hidden="true"></div>
-  <div id="fh-message-clouds" aria-hidden="true"></div>
+  <div class="fh-bg background-layer" aria-hidden="true"></div>
+  <div id="fh-message-clouds" class="bg-bubbles" aria-hidden="true"></div>
   <div class="fh-content">
     <header class="fh-header">
       <nav class="topbar">
-        <a href="/" class="logo">FroggyHub</a>
-        <a href="/" class="btn btn--ghost btn--sm">Меню</a>
-        <a href="/profile.html" class="btn btn--ghost btn--sm">Профиль</a>
-        <button id="logoutBtn" data-logout class="btn btn--ghost btn--sm">Выйти</button>
+        <div class="inner">
+          <a href="/" class="logo">FroggyHub</a>
+          <a href="/" class="btn btn--ghost btn--sm">Меню</a>
+          <a href="/profile.html" class="btn btn--ghost btn--sm">Профиль</a>
+          <button id="logoutBtn" data-logout data-action="logout" class="btn btn--ghost btn--sm">Выйти</button>
+        </div>
       </nav>
     </header>
 
@@ -80,7 +82,7 @@
     </section>
   </main>
 
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="./js/app.js"></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   # Сборка не нужна — это статический фронт
   command = ""
-  publish = "FroggyHub"
+  publish = "."
   functions = "netlify/functions"
 
 # Если у тебя есть SPA-роутинг, раскомментируй блок ниже

--- a/profile.html
+++ b/profile.html
@@ -15,10 +15,10 @@
       <h1>Профиль</h1>
       <p>Никнейм: <strong id="profile-nickname"></strong></p>
       <p>Создан: <span id="profile-created"></span></p>
-      <button type="button" class="btn btn--ghost" id="btn-logout" data-logout>Выйти</button>
+      <button type="button" class="btn btn--ghost" id="btn-logout" data-logout data-action="logout">Выйти</button>
     </div>
   </main>
-  <script type="module" src="js/app.js"></script>
+  <script type="module" src="./js/app.js"></script>
   <div id="cookieCard" class="card" style="display:none">
     <svg id="cookieSvg" viewBox="0 0 24 24" aria-hidden="true">
       <g><path d="M12 2a5 5 0 0 0 5 5 5 5 0 0 0 5 5 10 10 0 1 1-10-10z"/></g>

--- a/style.css
+++ b/style.css
@@ -45,6 +45,11 @@ body{
   font:16px/1.5 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial;
 }
 
+main, .screen, .topbar {
+  position: relative;
+  z-index: 1;
+}
+
 main.hero{min-height:100vh;}
 
 /* Контейнер для фона с пузырями */
@@ -54,6 +59,12 @@ main.hero{min-height:100vh;}
   z-index: 0;
   pointer-events: none;
   overflow: hidden;
+}
+
+.background-layer,
+.bg-bubbles {
+  pointer-events: none;
+  z-index: 0;
 }
 
 #screen-auth,
@@ -69,19 +80,37 @@ main.hero{min-height:100vh;}
 }
 
 .topbar {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 0;
-  right: 0;
   width: 100%;
+  z-index: 1000;
+  box-sizing: border-box;
+  pointer-events: auto;
+  background: rgba(0,0,0,.15);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(255,255,255,.06);
+}
+.topbar .inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 12px 24px;
   display: flex;
   align-items: center;
-  padding: 12px 1rem;
-  z-index: 30;
-  pointer-events: auto;
+  justify-content: space-between;
+  gap: 12px;
+  box-sizing: border-box;
 }
-.topbar > * { flex: 1; text-align: center; }
-.topbar .logo { text-align: left; }
+.topbar .inner > * {
+  flex: 1;
+  text-align: center;
+}
+.topbar .logo {
+  text-align: left;
+  font-weight: 800;
+  letter-spacing: .3px;
+  color: #cdeed9;
+  text-decoration: none;
+}
 
 /* Состояния пузыря */
 .fh-bubble {
@@ -771,12 +800,15 @@ body.scene-intro .speech{display:block}
 .wl-taken { background:#ffe3e3; color:#7a1c1c; }
 
 /* Top bar */
-.topbar{
-  position: sticky; top: 0; z-index: 50;
-  display:flex; align-items:center; justify-content:space-between;
-  padding:10px 16px;
-  background:rgba(0,0,0,.15); backdrop-filter:blur(6px);
-  border-bottom:1px solid rgba(255,255,255,.06);
+.topbar {
+  background: rgba(0,0,0,.15);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(255,255,255,.06);
+}
+.topbar .inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 .topbar .logo{ font-weight:800; letter-spacing:.3px; color:#cdeed9; text-decoration:none; }
 .topbar-right{ display:flex; gap:8px; }


### PR DESCRIPTION
## Summary
- point Netlify to deploy the repository root instead of the legacy FroggyHub folder
- adjust HTML pages to use relative asset/script paths, add top bar inner containers, and default to the frog idle avatar where needed
- update shared styles so the sticky top bar and background layers stack correctly
- rework js/app.js to delegate navigation/actions, auto-tag obvious buttons, and keep location/hash state in sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8dd76a2b08332a771510c5b0121b9